### PR TITLE
[CORE-3159] Fix realm migration

### DIFF
--- a/infra/realm/src/main/java/com/simprints/infra/realm/config/RealmConfig.kt
+++ b/infra/realm/src/main/java/com/simprints/infra/realm/config/RealmConfig.kt
@@ -31,7 +31,10 @@ class RealmConfig @Inject constructor() {
         )
         .name("$databaseName.realm")
         .schemaVersion(REALM_SCHEMA_VERSION)
-        .migration(RealmMigrations())
+        .migration(
+            migration = RealmMigrations(),
+            resolveEmbeddedObjectConstraints = true // Delete embedded objects if they are not in the schema anymore
+        )
         .let { if (BuildConfig.DB_ENCRYPTION) it.encryptionKey(key) else it }
         .build()
 


### PR DESCRIPTION
- A crash occurred during the migration from 2022.2.8 to 2023.4.0 due to `Java. lang.IllegalStateException - [RLM_ERR_WRONG_TRANSACTION_STATE]: Must be in a write transaction. `There is no way to get a writable realm db during the migration.
-  Enable resolveEmbeddedObjectConstraints to delete orphan records because we can't delete them during the migration
-  I will test this change after merging this PR by migrating from 2022.2.8 to 2023.4.0. because it is tough to build old versions of SID using the new Android studio and JDk
