### PR TITLE
[CORE-3149] Buttons on the contest screen are filling the entire width of the screen

### DIFF
--- a/feature/consent/src/main/res/layout/fragment_consent.xml
+++ b/feature/consent/src/main/res/layout/fragment_consent.xml
@@ -62,34 +62,33 @@
         android:orientation="horizontal"
         app:layout_constraintGuide_percent="0.75" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/consentDeclineButton"
-        style="@style/Widget.Simprints.Button.Red"
+    <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="72dp"
-        android:layout_marginTop="24dp"
-        android:layout_marginEnd="16dp"
-        android:text="@string/consent_decline_button"
+        android:orientation="horizontal"
+        android:gravity="center"
+        android:layout_marginHorizontal="16dp"
         app:layout_constraintBottom_toTopOf="@+id/consentPrivacyNotice"
-        app:layout_constraintEnd_toStartOf="@+id/consentAcceptButton"
-        app:layout_constraintHorizontal_chainStyle="packed"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/guideline"
-        app:layout_constraintWidth_max="200dp" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/consentAcceptButton"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="72dp"
-        android:text="@string/consent_accept_button"
-        app:layout_constraintBottom_toBottomOf="@+id/consentDeclineButton"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/consentDeclineButton"
-        app:layout_constraintTop_toTopOf="@+id/consentDeclineButton"
-        app:layout_constraintWidth_max="200dp" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/guideline">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/consentDeclineButton"
+            style="@style/Widget.Simprints.Button.Red"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_marginEnd="8dp"
+            android:text="@string/consent_decline_button"/>
+        <com.google.android.material.button.MaterialButton
+            android:layout_marginStart="8dp"
+            android:id="@+id/consentAcceptButton"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="@string/consent_accept_button"/>
+    </LinearLayout>
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/consentPrivacyNotice"
@@ -101,6 +100,6 @@
         android:textAllCaps="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/consentDeclineButton" />
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Buttons also will have the same height.
![image](https://github.com/Simprints/Android-Simprints-ID/assets/129499142/0258a2e2-33c1-430a-b7b1-e821f9fd692a)
![image](https://github.com/Simprints/Android-Simprints-ID/assets/129499142/355e4827-0dd6-48ac-a01e-be7696363b7e)
