### PR TITLE
[CORE-3164] Fix for biometric data remaining on device after logout

### DIFF
--- a/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/SignerManager.kt
+++ b/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/SignerManager.kt
@@ -5,7 +5,10 @@ import com.simprints.infra.authlogic.worker.SecurityStateScheduler
 import com.simprints.infra.authstore.AuthStore
 import com.simprints.infra.authstore.domain.models.Token
 import com.simprints.infra.config.sync.ConfigManager
+import com.simprints.infra.enrolment.records.store.EnrolmentRecordRepository
+import com.simprints.infra.events.EventRepository
 import com.simprints.infra.eventsync.EventSyncManager
+import com.simprints.infra.images.ImageRepository
 import com.simprints.infra.images.ImageUpSyncScheduler
 import com.simprints.infra.logging.LoggingConstants
 import com.simprints.infra.logging.Simber
@@ -23,6 +26,9 @@ internal class SignerManager @Inject constructor(
     private val recentUserActivityManager: RecentUserActivityManager,
     private val imageUpSyncScheduler: ImageUpSyncScheduler,
     private val simNetwork: SimNetwork,
+    private val imageRepository: ImageRepository,
+    private val eventRepository: EventRepository,
+    private val enrolmentRecordRepository: EnrolmentRecordRepository,
     @DispatcherIO private val dispatcher: CoroutineDispatcher,
 ) {
 
@@ -63,7 +69,15 @@ internal class SignerManager @Inject constructor(
         configManager.clearData()
         recentUserActivityManager.clearRecentActivity()
 
+        deleteLocalData()
+
         Simber.tag(LoggingConstants.CrashReportTag.LOGOUT.name).i("Signed out")
+    }
+
+    private suspend fun deleteLocalData() {
+        imageRepository.deleteStoredImages()
+        eventRepository.deleteAll()
+        enrolmentRecordRepository.deleteAll()
     }
 
 }

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImpl.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImpl.kt
@@ -79,7 +79,9 @@ internal class EnrolmentRecordLocalDataSourceImpl @Inject constructor(
     }
 
     override suspend fun deleteAll() {
-        delete(listOf(SubjectQuery()))
+        realmWrapper.writeRealm { realm ->
+            realm.deleteAll()
+        }
     }
 
     override suspend fun count(query: SubjectQuery): Int = realmWrapper.readRealm { realm ->

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImplTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImplTest.kt
@@ -54,6 +54,7 @@ class EnrolmentRecordLocalDataSourceImplTest {
 
         val insertedSubject = slot<DbSubject>()
         every { mutableRealm.delete(any()) } answers { localSubjects.clear() }
+        every { mutableRealm.deleteAll() } answers { localSubjects.clear() }
         every { mutableRealm.copyToRealm(capture(insertedSubject), any()) } answers {
             localSubjects.add(insertedSubject.captured.fromDbToDomain())
             insertedSubject.captured


### PR DESCRIPTION
After using SID and then logging out, enrollment records remain in a database and captured images were remaining in app's internal folder (`/data/data/...`) in encrypted form.

Steps to reproduce:
1. Prepare SID for debugging to intercept the enrollment record DB key: at `com.simprints.infra.security.keyprovider.SecureLocalDbKeyProviderImpl` function `readRealmKeyFromSharedPrefs` result.
2. Build & install the debug variant of SID.
3. Clear app data.
4. Prepare a test project.
5. Sign in to the test project with the app.
6. Obtain the enrollment record DB key from step 1.
7. Convert the base64-formatted enrollment record DB key to hex.
8. Enroll a person with SID, using a calling app.
9. Open SID and sign out.
10. Pull `/data/data/com.simprints.id/files/images` folder from device.
11. Pull `/data/data/com.simprints.id/files/<projectID>.realm` file from device, where `<projectID>` is the ID of the project configured at step 4. Open the DB with Realm Studio, use the hex key from step 7.

Expected:
* Subfolders of `/data/data/com.simprints.id/files/images` from step 10 contain no image files.
* The Realm DB from step 11 contains no entries.

Actual:
* Subfolders of `/data/data/com.simprints.id/files/images` from step 10 contain image files (encrypted) of faces associated to beneficiaries enrolled before SID logging out.
* The Realm DB from step 11 contains enrollment records of `DbSubject` and `DbFaceSample` classes associated to beneficiaries enrolled before SID logging out.