### PR TITLE
Rename signing_properties.gradle so that it can be add the git ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,9 @@ GITHUB_TOKEN=<the-token-you-just-created>
 
 
 For security reasons the debug.keystore and the google-services.json are not included in the repository.
-To build the app you need to add them to the project and update the signing_properties.gradle.kts file with the correct passwords.
+To build the app you need to add them to the project and update the signing_info.gradle.kts file with the correct passwords.
 
 
-To avoid accidentally committing changes to signing properties run
-```
-Run `git update-index --skip-worktree build-logic/signing_properties.gradle.kts
-```
 
 
 ## Full CI Workflow

--- a/build-logic/.gitignore
+++ b/build-logic/.gitignore
@@ -1,2 +1,2 @@
 # Ignoring changes in this file to avoid accidentally committing debug keys
-signing_properties.gradle.kts
+signing_info.gradle.kts

--- a/build-logic/convention/src/main/kotlin/PipelineDeployConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PipelineDeployConventionPlugin.kt
@@ -11,7 +11,7 @@ class PipelineDeployConventionPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         with(target) {
-            apply(from = "${rootDir}/build-logic/signing_properties.gradle.kts")
+            apply(from = "${rootDir}/build-logic/signing_info.gradle.kts")
             val props = extra.properties
 
             with(pluginManager) {

--- a/build-logic/signing_properties.gradle.kts
+++ b/build-logic/signing_properties.gradle.kts
@@ -1,6 +1,0 @@
-extra.apply {
-    set("store_file", "$rootDir/debug.keystore")
-    set("store_password", "****")
-    set("key_alias", "****")
-    set("key_password", "****")
-}

--- a/ci/deployment/signing_properties_setup
+++ b/ci/deployment/signing_properties_setup
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 echo "$SIGNING_JKS_FILE" | base64 -di >android-signing-keystore.jks
-
-cat << EOF >> build-logic/signing_properties.gradle.kts
+# create the signing_info.gradle.kts file and add the signing info
+touch build-logic/signing_info.gradle.kts
+cat << EOF >> build-logic/signing_info.gradle.kts
 extra.apply {
     set("store_file", "\$rootDir/android-signing-keystore.jks")
     set("store_password", "${SIGNING_KEYSTORE_PASSWORD}")

--- a/ci/pipeline/setup
+++ b/ci/pipeline/setup
@@ -4,3 +4,11 @@ echo "org.gradle.caching=true" >>gradle.properties
 echo "org.gradle.jvmargs=-Xmx7g"
 touch local.properties
 touch build-logic/signing_info.gradle.kts
+# Add dummy signing info to build-logic/signing_info.gradle.kts
+cat << EOF >> build-logic/signing_info.gradle.kts
+extra.apply {
+    set("store_file", "dummy")
+    set("store_password", "dummy")
+    set("key_alias", "dummy")
+    set("key_password", "dummy")
+}

--- a/ci/pipeline/setup
+++ b/ci/pipeline/setup
@@ -3,3 +3,4 @@ chmod +x gradlew
 echo "org.gradle.caching=true" >>gradle.properties
 echo "org.gradle.jvmargs=-Xmx7g"
 touch local.properties
+touch build-logic/signing_info.gradle.kts


### PR DESCRIPTION
I renamed the signing_properties.gradle.kts so that Git ignores the new name and stops annoying us.
after merging this PR you should completely delete `signing_properties.gradle.kts  `and create a new file named `signing_info.gradle.kts` 
I will also open the same PR in the main branch to simplify your life. 