### PR TITLE
[CORE-3169] Comply with Firebase limitations for event names and messages length

### DIFF
--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
@@ -371,7 +371,7 @@ internal class FingerprintCaptureViewModel @Inject constructor(
 
     private fun handleCaptureFinished() = with(state) {
         Simber.tag(FINGER_CAPTURE.name)
-            .i("Finger scanned - ${currentFingerState().id} - ${currentFingerState()}")
+            .i("Finger scanned - ${currentFingerState().id}")
         addCaptureAndBiometricEventsInSession()
         saveCurrentImageIfEager()
         if (captureHasSatisfiedTerminalCondition(currentCaptureState())) {

--- a/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/Authenticator.kt
+++ b/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/Authenticator.kt
@@ -53,7 +53,7 @@ internal class Authenticator @Inject constructor(
             }
 
             extractResultFromException(t).also { signInResult ->
-                logMessageForCrashReportWithNetworkTrigger("Sign in reason - $signInResult")
+                logMessageForCrashReportWithNetworkTrigger("Sign in reason - ${signInResult.javaClass.simpleName}")
             }
         }
 

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigSharedPrefsMigration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigSharedPrefsMigration.kt
@@ -43,7 +43,7 @@ internal class ProjectConfigSharedPrefsMigration @Inject constructor(
         } catch (e: Exception) {
             if (e is JacksonException) {
                 // Return default value
-                Simber.i("Invalid old configuration for project ${authStore.signedInProjectId}: $e")
+                Simber.i(e, "Invalid old configuration for project ${authStore.signedInProjectId}")
                 ProtoProjectConfiguration.getDefaultInstance()
             } else {
                 Simber.e(e)

--- a/infra/config-sync/src/main/java/com/simprints/infra/config/sync/worker/ConfigurationWorker.kt
+++ b/infra/config-sync/src/main/java/com/simprints/infra/config/sync/worker/ConfigurationWorker.kt
@@ -18,7 +18,7 @@ internal class ConfigurationWorker @AssistedInject constructor(
     private val configManager: ConfigManager
 ) : CoroutineWorker(context, params) {
 
-    private val tag = ConfigurationWorker::class.java.name
+    private val tag = "ConfigurationWorker"
 
     override suspend fun doWork(): Result = try {
         val projectId = authStore.signedInProjectId

--- a/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
+++ b/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
@@ -20,7 +20,7 @@ abstract class SimCoroutineWorker(
     private var resultSetter = WorkerResultSetter()
 
     protected fun retry(t: Throwable? = null, message: String = t?.message ?: ""): Result {
-        crashlyticsLog("$tag - Retry] $message")
+        crashlyticsLog("[Retry] $message")
 
         logExceptionIfRequired(t)
         return resultSetter.retry()
@@ -32,7 +32,7 @@ abstract class SimCoroutineWorker(
         outputData: Data? = null
     ): Result {
 
-        crashlyticsLog("$tag - Failed] $message")
+        crashlyticsLog("[Failed] $message")
         logExceptionIfRequired(t)
         return resultSetter.failure(outputData)
 
@@ -42,7 +42,7 @@ abstract class SimCoroutineWorker(
         outputData: Data? = null,
         message: String = ""
     ): Result {
-        crashlyticsLog("$tag - Success] $message")
+        crashlyticsLog("[Success] $message")
 
         return resultSetter.success(outputData)
     }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/workers/EventDownSyncCountWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/workers/EventDownSyncCountWorker.kt
@@ -60,13 +60,13 @@ internal class EventDownSyncCountWorker @AssistedInject constructor(
     override suspend fun doWork(): Result = withContext(dispatcher) {
         Simber.tag(SYNC_LOG_TAG).d("[COUNT_DOWN] Started")
         try {
-            crashlyticsLog("Start - Params: $downSyncScope")
+            crashlyticsLog("Start")
 
             val downCount = eventDownSyncCountTask.getCount(downSyncScope)
             val output = jsonHelper.toJson(downCount)
 
             Simber.tag(SYNC_LOG_TAG).d("[COUNT_DOWN] Done $downCount")
-            success(workDataOf(OUTPUT_COUNT_WORKER_DOWN to output), output)
+            success(workDataOf(OUTPUT_COUNT_WORKER_DOWN to output))
 
         } catch (t: Throwable) {
             Simber.tag(SYNC_LOG_TAG).d("[COUNT_DOWN] Failed. ${t.message}")
@@ -76,7 +76,8 @@ internal class EventDownSyncCountWorker @AssistedInject constructor(
                     fail(t, t.message, workDataOf(OUTPUT_FAILED_BECAUSE_CLOUD_INTEGRATION to true))
                 }
                 t is BackendMaintenanceException -> fail(
-                    t, t.message,
+                    t,
+                    t.message,
                     workDataOf(
                         OUTPUT_FAILED_BECAUSE_BACKEND_MAINTENANCE to true,
                         OUTPUT_ESTIMATED_MAINTENANCE_TIME to t.estimatedOutage

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/workers/EventDownSyncDownloaderWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/workers/EventDownSyncDownloaderWorker.kt
@@ -60,7 +60,7 @@ internal class EventDownSyncDownloaderWorker @AssistedInject constructor(
             val workerId = this@EventDownSyncDownloaderWorker.id.toString()
             var count = syncCache.readProgress(workerId)
 
-            crashlyticsLog("Start - Params: $downSyncOperationInput")
+            crashlyticsLog("Start")
 
             downSyncTask.downSync(this, getDownSyncOperation()).collect {
                 count = it.progress
@@ -71,7 +71,7 @@ internal class EventDownSyncDownloaderWorker @AssistedInject constructor(
             Simber.tag(SYNC_LOG_TAG).d("[DOWNLOADER] Done $count")
             success(
                 workDataOf(OUTPUT_DOWN_SYNC to count),
-                "Total downloaded: $0 for $downSyncOperationInput"
+                "Total downloaded: $0"
             )
         } catch (t: Throwable) {
             Simber.tag(SYNC_LOG_TAG).d("[DOWNLOADER] Failed")

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/workers/EventUpSyncCountWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/workers/EventUpSyncCountWorker.kt
@@ -47,7 +47,7 @@ internal class EventUpSyncCountWorker @AssistedInject constructor(
     override suspend fun doWork(): Result = withContext(dispatcher) {
         try {
             Simber.tag(SYNC_LOG_TAG).d("[COUNT_UP] Started")
-            crashlyticsLog("Start - $upSyncScope")
+            crashlyticsLog("Start")
 
             val upCount = getUpCount(upSyncScope)
 

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/up/workers/EventUpSyncUploaderWorkerTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/up/workers/EventUpSyncUploaderWorkerTest.kt
@@ -20,6 +20,7 @@ import com.simprints.infra.eventsync.sync.up.tasks.EventUpSyncTask
 import com.simprints.infra.eventsync.sync.up.EventUpSyncProgress
 import com.simprints.infra.eventsync.sync.up.workers.EventUpSyncUploaderWorker.Companion.INPUT_UP_SYNC
 import com.simprints.infra.authstore.AuthStore
+import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.exceptions.BackendMaintenanceException
 import com.simprints.infra.network.exceptions.SyncCloudIntegrationException
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
@@ -27,9 +28,13 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -52,6 +57,17 @@ class EventUpSyncUploaderWorkerTest {
         every { signedInProjectId } returns PROJECT_ID
     }
     private val upSyncTask = mockk<EventUpSyncTask>()
+
+    @Before
+    fun setUp() {
+        mockkObject(Simber)
+        every { Simber.i(ofType<String>()) } answers {}
+    }
+
+    @After
+    fun cleanUp() {
+        unmockkObject(Simber)
+    }
 
     @Test
     fun worker_shouldExecuteTheTask() = runTest {

--- a/infra/logging/src/main/java/com/simprints/infra/logging/LoggingConstants.kt
+++ b/infra/logging/src/main/java/com/simprints/infra/logging/LoggingConstants.kt
@@ -13,7 +13,7 @@ object LoggingConstants {
         const val PROJECT_ID = "Project_ID"
         const val MODULE_IDS = "Module_IDs"
         const val DEVICE_ID = "Device_ID"
-        const val SUBJECTS_DOWN_SYNC_TRIGGERS = "People_down_sync_triggers"
+        const val SUBJECTS_DOWN_SYNC_TRIGGERS = "Down_sync_triggers"
         const val SESSION_ID = "Session_ID"
     }
 

--- a/infra/logging/src/main/java/com/simprints/infra/logging/LoggingConstants.kt
+++ b/infra/logging/src/main/java/com/simprints/infra/logging/LoggingConstants.kt
@@ -9,12 +9,12 @@ object LoggingConstants {
      * merged into a single set a keys on the next Firebase overhaul.
      */
     object CrashReportingCustomKeys {
-        const val USER_ID = "User ID"
-        const val PROJECT_ID = "Project ID"
-        const val MODULE_IDS = "Module IDs"
-        const val DEVICE_ID = "Device ID"
-        const val SUBJECTS_DOWN_SYNC_TRIGGERS = "People down sync triggers"
-        const val SESSION_ID = "Session ID"
+        const val USER_ID = "User_ID"
+        const val PROJECT_ID = "Project_ID"
+        const val MODULE_IDS = "Module_IDs"
+        const val DEVICE_ID = "Device_ID"
+        const val SUBJECTS_DOWN_SYNC_TRIGGERS = "People_down_sync_triggers"
+        const val SESSION_ID = "Session_ID"
     }
 
     object AnalyticsUserProperties {

--- a/infra/logging/src/main/java/com/simprints/infra/logging/Simber.kt
+++ b/infra/logging/src/main/java/com/simprints/infra/logging/Simber.kt
@@ -119,10 +119,35 @@ object Simber {
      * 1 kB in size."
      */
     fun tag(tag: String, isUserProperty: Boolean = false): Simber {
-        if (isUserProperty)
-            Timber.tag(USER_PROPERTY_TAG + tag)
-        else
-            Timber.tag(tag)
+        var conformingTag = tag
+
+        var maxLength = 24
+        if (isUserProperty) {
+            conformingTag = USER_PROPERTY_TAG + conformingTag
+            maxLength = 40
+        }
+
+        // Ensure length is not greater than allowed by Firebase Analytics
+        if (conformingTag.length > maxLength) {
+            if (BuildConfig.DEBUG) {
+                throw IllegalArgumentException("Tag must be less than 40 characters.")
+            } else {
+            conformingTag = conformingTag.substring(0, maxLength)
+            }
+        }
+
+        // Check that tag complies with Firebase Analytics requirements:
+        // Name must consist of letters, digits or _ (underscores).
+        if (tag.contains(Regex("[^a-zA-Z0-9_]"))) {
+            // Throw an exception in debug but replace invalid characters in other modes
+            if (BuildConfig.DEBUG) {
+                throw IllegalArgumentException("Tag must consist of letters, digits or _ (underscores).")
+            } else {
+                conformingTag = tag.replace(Regex("[^a-zA-Z0-9_]"), "_")
+            }
+        }
+
+        Timber.tag(conformingTag)
         return Simber
     }
 

--- a/infra/logging/src/test/java/com/simprints/infra/logging/SimberTest.kt
+++ b/infra/logging/src/test/java/com/simprints/infra/logging/SimberTest.kt
@@ -1,9 +1,11 @@
 package com.simprints.infra.logging
 
 import com.google.firebase.FirebaseNetworkException
+import com.simprints.infra.logging.Simber.USER_PROPERTY_TAG
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
+import org.junit.Assert.assertEquals
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -23,6 +25,34 @@ class SimberTest {
     @After
     fun cleanUp() {
         unmockkObject(Timber.Forest)
+    }
+
+    @Test
+    fun `tag() sets correctly the user property tag`() {
+        Simber.tag("test", true)
+        verify(exactly = 1) { Timber.tag(USER_PROPERTY_TAG + "test") }
+    }
+
+    @Test
+    fun `tag() sets correctly the non-user property tag`() {
+        Simber.tag("test")
+        verify(exactly = 1) { Timber.tag("test") }
+    }
+
+    @Test
+    fun `in debug mode tag() throws an exception for tags containing invalid characters`() {
+        val exception = kotlin.runCatching { Simber.tag("test:tag") }
+
+        assertEquals(IllegalArgumentException::class.java, exception.exceptionOrNull()?.javaClass)
+        assertEquals("Tag must consist of letters, digits or _ (underscores).", exception.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `in debug mode tag() throws an exception for tags longer than 40 characters`() {
+        val exception = kotlin.runCatching { Simber.tag("01234567890123456789012345678901234567890") }
+
+        assertEquals(IllegalArgumentException::class.java, exception.exceptionOrNull()?.javaClass)
+        assertEquals("Tag must be less than 40 characters.", exception.exceptionOrNull()?.message)
     }
 
     @Test

--- a/infra/logging/src/test/java/com/simprints/infra/logging/SimberTest.kt
+++ b/infra/logging/src/test/java/com/simprints/infra/logging/SimberTest.kt
@@ -49,10 +49,12 @@ class SimberTest {
 
     @Test
     fun `in debug mode tag() throws an exception for tags longer than 40 characters`() {
-        val exception = kotlin.runCatching { Simber.tag("01234567890123456789012345678901234567890") }
+        val exception = kotlin.runCatching {
+            Simber.tag("01234567890123456789012345678901234567890", true)
+        }
 
         assertEquals(IllegalArgumentException::class.java, exception.exceptionOrNull()?.javaClass)
-        assertEquals("Tag must be less than 40 characters.", exception.exceptionOrNull()?.message)
+        assertEquals("String must be less than 40 characters.", exception.exceptionOrNull()?.message)
     }
 
     @Test

--- a/infra/logging/src/test/java/com/simprints/infra/logging/trees/AnalyticsTreeTest.kt
+++ b/infra/logging/src/test/java/com/simprints/infra/logging/trees/AnalyticsTreeTest.kt
@@ -55,10 +55,10 @@ class AnalyticsTreeTest {
         val spyAnalyticsTree = spyk(AnalyticsTree(faMock))
 
         Timber.plant(spyAnalyticsTree)
-        Simber.tag("Test Tag", true).i("Test Message")
+        Simber.tag("Test_Tag", true).i("Test Message")
 
         verify {
-            faMock.setUserProperty("Test Tag", "Test Message")
+            faMock.setUserProperty("Test_Tag", "Test Message")
         }
     }
 

--- a/infra/logging/src/test/java/com/simprints/infra/logging/trees/CrashReportingTreeTest.kt
+++ b/infra/logging/src/test/java/com/simprints/infra/logging/trees/CrashReportingTreeTest.kt
@@ -115,10 +115,10 @@ class CrashReportingTreeTest {
         val spyCrashReportingTree = spyk(CrashReportingTree(crashMock))
 
         Timber.plant(spyCrashReportingTree)
-        Simber.tag("Custom Tag", true).i("Test Message")
+        Simber.tag("Custom_Tag", true).i("Test Message")
 
         verify {
-            crashMock.setCustomKey("Custom Tag", "Test Message")
+            crashMock.setCustomKey("Custom_Tag", "Test Message")
         }
     }
 


### PR DESCRIPTION
This started out with a benign notice of a log from production SID that Configuration worker's tag is incompatible with Firebase Analytics' limitations (see related ticket). Then I kept going into rabbit holes finding more and more instances where our logs didn't make it through to Firebase because they were either too long or contained invalid characters. As a result here are a few different changes:

- ConfigurationWorker's tag was renamed
- Some tags were also renamed (replacing spaces with underscores)
- Some worker logs were stripped of params since they were too long to fit
- Simber was updated to ensure that even if its users don't comply with the rules. In release/staging it makes the tags/messages valid by replacing or trimming the strings. In debug this throws an exception so we can notice and fix the problem rather than keep using a modified tag/message

Open question: how do we make sure this problem doesn't repeat in the future?
We didn't notice it so far because in debug we don't "plant" Firebase Crashlytics/Analytics so we don't get any logs in logcat if we don't comply with their rules. I can think of a few possible solutions:

1. Have a step during release testing where we intentionally connect a release version to AS and monitor logcat. This is relatively simple but doesn't ensure we'll run over all possible logs that can happen.
2. Create and use debug projects of Firebase Crashlytics/Analytics so we have a more realistic debug app but still don't pollute the prod dashboards
3. Anything better?