### PR TITLE
CORE-3190 ETags and other request caches

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -159,7 +159,6 @@ realm_base = { module = "io.realm.kotlin:library-base", version.ref = "realm_ver
 
 #Retrofit
 retrofit-core = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit_version" }
-retrofit-adapter = { module = "com.squareup.retrofit2:adapter-rxjava2", version.ref = "retrofit_version" }
 retrofit-jackson = { module = "com.squareup.retrofit2:converter-jackson", version.ref = "retrofit_version" }
 retrofit-converterScalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit_version" }
 retrofit-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okttp_version" }

--- a/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/remote/UnauthenticatedClientFactory.kt
+++ b/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/remote/UnauthenticatedClientFactory.kt
@@ -1,26 +1,21 @@
 package com.simprints.infra.authlogic.authenticator.remote
 
-import android.content.Context
 import com.simprints.core.DeviceID
 import com.simprints.core.PackageVersionName
 import com.simprints.infra.network.SimNetwork
 import com.simprints.infra.network.SimRemoteInterface
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.reflect.KClass
 
 internal class UnauthenticatedClientFactory @Inject constructor(
     private val simNetwork: SimNetwork,
     @DeviceID private val deviceId: String,
-    @ApplicationContext private val ctx: Context,
     @PackageVersionName private val versionName: String,
 ) {
 
     fun <T : SimRemoteInterface> build(remoteInterface: KClass<T>): SimNetwork.SimApiClient<T> =
         simNetwork.getSimApiClient(
             remoteInterface,
-            ctx,
-            simNetwork.getApiBaseUrl(),
             deviceId,
             versionName,
             null,

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/network/SimApiClientFactory.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/network/SimApiClientFactory.kt
@@ -1,19 +1,16 @@
 package com.simprints.infra.authstore.network
 
-import android.content.Context
 import com.simprints.core.DeviceID
 import com.simprints.core.PackageVersionName
 import com.simprints.infra.authstore.db.FirebaseAuthManager
 import com.simprints.infra.network.SimNetwork
 import com.simprints.infra.network.SimRemoteInterface
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.reflect.KClass
 
 internal class SimApiClientFactory @Inject constructor(
     private val simNetwork: SimNetwork,
     @DeviceID private val deviceId: String,
-    @ApplicationContext private val ctx: Context,
     @PackageVersionName private val versionName: String,
     private val firebaseAuthManager: FirebaseAuthManager,
 ) {
@@ -24,8 +21,6 @@ internal class SimApiClientFactory @Inject constructor(
     suspend fun <T : SimRemoteInterface> buildClient(remoteInterface: KClass<T>): SimNetwork.SimApiClient<T> {
         return simNetwork.getSimApiClient(
             remoteInterface,
-            ctx,
-            simNetwork.getApiBaseUrl(),
             deviceId,
             versionName,
             firebaseAuthManager.getCurrentToken(),

--- a/infra/network/build.gradle.kts
+++ b/infra/network/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
 
     runtimeOnly(libs.kotlin.coroutinesAndroid)
 
-    implementation(libs.retrofit.adapter)
     implementation(libs.retrofit.converterScalars)
     implementation(libs.retrofit.core)
     implementation(libs.retrofit.jackson)

--- a/infra/network/src/main/java/com/simprints/infra/network/NetworkModule.kt
+++ b/infra/network/src/main/java/com/simprints/infra/network/NetworkModule.kt
@@ -1,16 +1,21 @@
 package com.simprints.infra.network
 
+import android.content.Context
 import com.simprints.infra.network.connectivity.ConnectivityTrackerImpl
 import com.simprints.infra.network.url.BaseUrlProvider
 import com.simprints.infra.network.url.BaseUrlProviderImpl
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import okhttp3.Cache
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class NetworkModule {
+abstract class NetworkBindingsModule {
 
     @Binds
     internal abstract fun provideSimNetwork(impl: SimNetworkImpl): SimNetwork
@@ -20,5 +25,19 @@ abstract class NetworkModule {
 
     @Binds
     internal abstract fun provideConnectivityTracker(impl: ConnectivityTrackerImpl): ConnectivityTracker
+
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    private const val NETWORK_CACHE_SIZE = 10 * 1024 * 1024L // 10mb
+
+    @Provides
+    @Singleton
+    fun provideNetworkCache(
+        @ApplicationContext context: Context,
+    ): Cache = Cache(context.cacheDir, NETWORK_CACHE_SIZE)
 
 }

--- a/infra/network/src/main/java/com/simprints/infra/network/SimNetwork.kt
+++ b/infra/network/src/main/java/com/simprints/infra/network/SimNetwork.kt
@@ -1,6 +1,5 @@
 package com.simprints.infra.network
 
-import android.content.Context
 import com.simprints.infra.network.exceptions.BackendMaintenanceException
 import com.simprints.infra.network.exceptions.SyncCloudIntegrationException
 import kotlin.reflect.KClass
@@ -21,8 +20,6 @@ interface SimNetwork {
 
     fun <T : SimRemoteInterface> getSimApiClient(
         remoteInterface: KClass<T>,
-        ctx: Context,
-        url: String,
         deviceId: String,
         versionName: String,
         authToken: String?

--- a/infra/network/src/main/java/com/simprints/infra/network/SimNetworkImpl.kt
+++ b/infra/network/src/main/java/com/simprints/infra/network/SimNetworkImpl.kt
@@ -1,31 +1,29 @@
 package com.simprints.infra.network
 
-import android.content.Context
 import com.simprints.infra.network.apiclient.SimApiClientImpl
+import com.simprints.infra.network.httpclient.DefaultOkHttpClientBuilder
 import com.simprints.infra.network.url.BaseUrlProvider
 import javax.inject.Inject
 import kotlin.reflect.KClass
 
-internal class SimNetworkImpl @Inject constructor(private val baseUrlProvider: BaseUrlProvider) :
-    SimNetwork {
+internal class SimNetworkImpl @Inject constructor(
+    private val baseUrlProvider: BaseUrlProvider,
+    private val okHttpClientBuilder: DefaultOkHttpClientBuilder,
+) : SimNetwork {
 
     override fun <T : SimRemoteInterface> getSimApiClient(
         remoteInterface: KClass<T>,
-        ctx: Context,
-        url: String,
         deviceId: String,
         versionName: String,
-        authToken: String?
-    ): SimNetwork.SimApiClient<T> {
-        return SimApiClientImpl(
-            remoteInterface,
-            ctx,
-            url,
-            deviceId,
-            versionName,
-            authToken
-        )
-    }
+        authToken: String?,
+    ): SimNetwork.SimApiClient<T> = SimApiClientImpl(
+        remoteInterface,
+        okHttpClientBuilder,
+        getApiBaseUrl(),
+        deviceId,
+        versionName,
+        authToken
+    )
 
     override fun getApiBaseUrl(): String {
         return baseUrlProvider.getApiBaseUrl()

--- a/infra/network/src/main/java/com/simprints/infra/network/apiclient/SimApiClientImpl.kt
+++ b/infra/network/src/main/java/com/simprints/infra/network/apiclient/SimApiClientImpl.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import retrofit2.HttpException
 import retrofit2.Retrofit
-import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.jackson.JacksonConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import kotlin.reflect.KClass
@@ -47,7 +46,6 @@ class SimApiClientImpl<T : SimRemoteInterface>(
 
     private val retrofit: Retrofit by lazy {
         Retrofit.Builder()
-            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
             .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(JacksonConverterFactory.create(JsonHelper.jackson))
             .baseUrl(url)

--- a/infra/network/src/main/java/com/simprints/infra/network/httpclient/DefaultOkHttpClientBuilder.kt
+++ b/infra/network/src/main/java/com/simprints/infra/network/httpclient/DefaultOkHttpClientBuilder.kt
@@ -3,6 +3,7 @@ package com.simprints.infra.network.httpclient
 import android.content.Context
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.simprints.infra.network.BuildConfig
+import dagger.hilt.android.qualifiers.ApplicationContext
 import okhttp3.Interceptor
 import okhttp3.MediaType
 import okhttp3.OkHttpClient
@@ -14,9 +15,12 @@ import okio.GzipSink
 import okio.buffer
 import java.io.IOException
 import java.util.concurrent.TimeUnit
+import javax.inject.Inject
 
 
-internal class DefaultOkHttpClientBuilder {
+internal class DefaultOkHttpClientBuilder @Inject constructor(
+    @ApplicationContext private val ctx: Context,
+) {
 
     companion object {
 
@@ -35,7 +39,6 @@ internal class DefaultOkHttpClientBuilder {
     }
 
     fun get(
-        ctx: Context,
         authToken: String? = null,
         deviceId: String,
         versionName: String,

--- a/infra/network/src/main/java/com/simprints/infra/network/httpclient/DefaultOkHttpClientBuilder.kt
+++ b/infra/network/src/main/java/com/simprints/infra/network/httpclient/DefaultOkHttpClientBuilder.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.simprints.infra.network.BuildConfig
 import dagger.hilt.android.qualifiers.ApplicationContext
+import okhttp3.Cache
 import okhttp3.Interceptor
 import okhttp3.MediaType
 import okhttp3.OkHttpClient
@@ -20,6 +21,7 @@ import javax.inject.Inject
 
 internal class DefaultOkHttpClientBuilder @Inject constructor(
     @ApplicationContext private val ctx: Context,
+    private val networkCache: Cache,
 ) {
 
     companion object {
@@ -44,6 +46,7 @@ internal class DefaultOkHttpClientBuilder @Inject constructor(
         versionName: String,
     ): OkHttpClient.Builder =
         OkHttpClient.Builder()
+            .cache(networkCache)
             .followRedirects(false)
             .followSslRedirects(false)
             .readTimeout(60, TimeUnit.SECONDS)

--- a/infra/network/src/test/java/com/simprints/infra/network/SimNetworkImplTest.kt
+++ b/infra/network/src/test/java/com/simprints/infra/network/SimNetworkImplTest.kt
@@ -1,18 +1,31 @@
 package com.simprints.infra.network
 
 import com.simprints.infra.network.apiclient.SimApiClientImpl
+import com.simprints.infra.network.httpclient.DefaultOkHttpClientBuilder
 import com.simprints.infra.network.url.BaseUrlProvider
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
-import io.mockk.spyk
 import io.mockk.verify
+import org.junit.Before
 import org.junit.Test
 
 class SimNetworkImplTest {
 
+    @MockK
+    private lateinit var baseUrlProvider: BaseUrlProvider
+
+    @MockK
+    private lateinit var okHttpClientBuilder: DefaultOkHttpClientBuilder
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+    }
+
     @Test
     fun `calling get base url should call the url provider`() {
-        val baseUrlProvider: BaseUrlProvider = spyk()
-        val network = SimNetworkImpl(baseUrlProvider)
+        val network = SimNetworkImpl(baseUrlProvider, okHttpClientBuilder)
 
         network.getApiBaseUrl()
 
@@ -21,8 +34,7 @@ class SimNetworkImplTest {
 
     @Test
     fun `calling reset base url should call the url provider`() {
-        val baseUrlProvider: BaseUrlProvider = spyk()
-        val network = SimNetworkImpl(baseUrlProvider)
+        val network = SimNetworkImpl(baseUrlProvider, okHttpClientBuilder)
 
         network.resetApiBaseUrl()
 
@@ -31,8 +43,7 @@ class SimNetworkImplTest {
 
     @Test
     fun `calling set base url should call the url provider`() {
-        val baseUrlProvider: BaseUrlProvider = spyk()
-        val network = SimNetworkImpl(baseUrlProvider)
+        val network = SimNetworkImpl(baseUrlProvider, okHttpClientBuilder)
 
         val baseUrl = "FAKE_BASE_URL"
 
@@ -43,13 +54,10 @@ class SimNetworkImplTest {
 
     @Test
     fun `calling get api client should return the api client`() {
-        val baseUrlProvider: BaseUrlProvider = spyk()
-        val network = SimNetworkImpl(baseUrlProvider)
+        val network = SimNetworkImpl(baseUrlProvider, okHttpClientBuilder)
 
         val clientApi = network.getSimApiClient<SimRemoteInterface>(
             mockk(),
-            mockk(),
-            "testUrl",
             "testDeviceID",
             "testVersion",
             "testAuthToken"
@@ -60,18 +68,15 @@ class SimNetworkImplTest {
 
     @Test
     fun `calling get api client with no token should return the api client`() {
-        val baseUrlProvider: BaseUrlProvider = spyk()
-        val network = SimNetworkImpl(baseUrlProvider)
+        val network = SimNetworkImpl(baseUrlProvider, okHttpClientBuilder)
 
         val clientApi = network.getSimApiClient<SimRemoteInterface>(
             mockk(),
-            mockk(),
-            "testUrl",
             "testDeviceID",
             "testVersion",
             null
         )
-        
+
         assert(clientApi is SimApiClientImpl<SimRemoteInterface>)
     }
 

--- a/infra/network/src/test/java/com/simprints/infra/network/apiclient/SimApiClientImplTest.kt
+++ b/infra/network/src/test/java/com/simprints/infra/network/apiclient/SimApiClientImplTest.kt
@@ -40,7 +40,7 @@ class SimApiClientImplTest {
     fun setup() {
         mockWebServer = MockWebServer()
         mockWebServer.start()
-        httpClientBuilder = DefaultOkHttpClientBuilder(mockk())
+        httpClientBuilder = DefaultOkHttpClientBuilder(mockk(), mockk(relaxed = true))
 
         simApiClientImpl = SimApiClientImpl(
             FakeRetrofitInterface::class,

--- a/infra/network/src/test/java/com/simprints/infra/network/httpclient/DefaultOkHttpClientBuilderTest.kt
+++ b/infra/network/src/test/java/com/simprints/infra/network/httpclient/DefaultOkHttpClientBuilderTest.kt
@@ -23,11 +23,15 @@ class DefaultOkHttpClientBuilderTest {
     @RelaxedMockK
     lateinit var ctx: Context
 
+    private lateinit var okHttpBuilder: DefaultOkHttpClientBuilder
+
     @Before
     fun setup() {
         MockKAnnotations.init(this)
         mockWebServer = MockWebServer()
         mockWebServer.start()
+
+        okHttpBuilder = DefaultOkHttpClientBuilder(ctx)
     }
 
     @After
@@ -42,9 +46,8 @@ class DefaultOkHttpClientBuilderTest {
         val versionName = "cxxlvxzn.12.2049"
 
         // create okHttp client using default builder
-        val okHttpBuilder = DefaultOkHttpClientBuilder()
         okHttpClient = okHttpBuilder
-            .get(ctx, "", "", versionName)
+            .get("", "", versionName)
             .build()
 
         val mockHttpRequest = Request.Builder()
@@ -66,9 +69,8 @@ class DefaultOkHttpClientBuilderTest {
 
         val deviceId = "symeAwxomedyvexeid"
 
-        val okHttpBuilder = DefaultOkHttpClientBuilder()
         okHttpClient = okHttpBuilder
-            .get(ctx, "", deviceId, "")
+            .get("", deviceId, "")
             .build()
 
         val mockHttpRequest = Request.Builder()
@@ -88,10 +90,8 @@ class DefaultOkHttpClientBuilderTest {
     fun `should not include auth token in request headers, when auth token is null`() {
         mockWebServer.enqueue(MockResponse())
 
-        val okHttpBuilder = DefaultOkHttpClientBuilder()
-
         okHttpClient = okHttpBuilder
-            .get(ctx, null, "", "")
+            .get(null, "", "")
             .build()
 
         val mockHttpRequest = Request.Builder()
@@ -113,9 +113,8 @@ class DefaultOkHttpClientBuilderTest {
 
         val authToken = "eyxSomeAwesomeAuth.TokenThatIsUsed.ForUnitTesting"
 
-        val okHttpBuilder = DefaultOkHttpClientBuilder()
         okHttpClient = okHttpBuilder
-            .get(ctx, authToken, "", "")
+            .get(authToken, "", "")
             .build()
 
         val mockHttpRequest = Request.Builder()
@@ -136,9 +135,8 @@ class DefaultOkHttpClientBuilderTest {
     fun `should not compress request body if gzip header not provided`() {
         mockWebServer.enqueue(MockResponse())
 
-        val okHttpBuilder = DefaultOkHttpClientBuilder()
         okHttpClient = okHttpBuilder
-            .get(ctx, null, "", "")
+            .get(null, "", "")
             .build()
 
         val mockHttpRequest = Request.Builder()
@@ -158,9 +156,8 @@ class DefaultOkHttpClientBuilderTest {
     fun `should compress request body if gzip header provided`() {
         mockWebServer.enqueue(MockResponse())
 
-        val okHttpBuilder = DefaultOkHttpClientBuilder()
         okHttpClient = okHttpBuilder
-            .get(ctx, null, "", "")
+            .get(null, "", "")
             .build()
 
         val mockHttpRequest = Request.Builder()

--- a/infra/network/src/test/java/com/simprints/infra/network/httpclient/DefaultOkHttpClientBuilderTest.kt
+++ b/infra/network/src/test/java/com/simprints/infra/network/httpclient/DefaultOkHttpClientBuilderTest.kt
@@ -23,6 +23,9 @@ class DefaultOkHttpClientBuilderTest {
     @RelaxedMockK
     lateinit var ctx: Context
 
+    @RelaxedMockK
+    lateinit var networkCache: okhttp3.Cache
+
     private lateinit var okHttpBuilder: DefaultOkHttpClientBuilder
 
     @Before
@@ -31,7 +34,7 @@ class DefaultOkHttpClientBuilderTest {
         mockWebServer = MockWebServer()
         mockWebServer.start()
 
-        okHttpBuilder = DefaultOkHttpClientBuilder(ctx)
+        okHttpBuilder = DefaultOkHttpClientBuilder(ctx, networkCache)
     }
 
     @After


### PR DESCRIPTION
 * ETag and related headers are working out of the box if the response cache is enabled in OkHttp
 * Also slightly simplified network client creation with DI