### PR TITLE
disable automated staging builds

### DIFF
--- a/.github/workflows/deploy-to-firebase-distribution.yml
+++ b/.github/workflows/deploy-to-firebase-distribution.yml
@@ -14,6 +14,7 @@ jobs:
 
         concurrency:
             group: firebase-${{ inputs.buildType }}-workflow #only one instance of this workflow can run at a time
+            cancel-in-progress: true
 
         environment: ${{ inputs.buildType }}   # Dynamically set the job environment based on the input
 

--- a/.github/workflows/deploy-to-internal.yml
+++ b/.github/workflows/deploy-to-internal.yml
@@ -18,6 +18,7 @@ jobs:
 
         concurrency:
             group: release-internal-workflow #only one instance of this workflow can run at a time
+            cancel-in-progress: true
 
         permissions:
             contents: write # A write permission For Auto tagging the releases

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -4,10 +4,7 @@ on:
     workflow_dispatch:
         branches:
             - 'release/*'
-    # Triggered when a push occurs on branches starting with 'release/'
-    push:
-        branches:
-            - 'release/*'
+
 jobs:
     deploy-to-staging:
 


### PR DESCRIPTION
- Cancel in-progress release builds when a new commit is pushed to the release branch
- Only run staging builds manually when needed 