### PR TITLE
[MS-26] Dependabot does not recognize Maven repositories in dependencyResolutionManagement - fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,20 @@
 version: 2
+registries:
+    google:
+        type: maven-repository
+        url: "https://dl.google.com/dl/android/maven2"
+    maven-central:
+        type: maven-repository
+        url: "https://repo.maven.apache.org/maven2"
+    gradle-plugin-portal:
+        type: maven-repository
+        url: "https://plugins.gradle.org/m2"
+    sonatype:
+        type: maven-repository
+        url: "https://oss.sonatype.org/content/repositories/snapshots"
+    commonsware:
+        type: maven-repository
+        url: "https://s3.amazonaws.com/repo.commonsware.com"
 updates:
     -   package-ecosystem: "gradle"
         directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,16 @@ registries:
     commonsware:
         type: maven-repository
         url: "https://s3.amazonaws.com/repo.commonsware.com"
+    simmatcher:
+        type: maven-repository
+        url: "https://maven.pkg.github.com/simprints/lib-android-simmatcher"
+        username: ${{secrets.GH_PACKAGE_NAME}}
+        password: ${{secrets.GH_PACKAGE_TOKEN}}
+    roc-wrapper:
+        type: maven-repository
+        url: "https://maven.pkg.github.com/simprints/lib-roc-wrapper"
+        username: ${{secrets.GH_PACKAGE_NAME}}
+        password: ${{secrets.GH_PACKAGE_TOKEN}}
 updates:
     -   package-ecosystem: "gradle"
         directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,8 +30,24 @@ updates:
         directory: "/"
         schedule:
             interval: "weekly"
+        registries:
+            - google
+            - maven-central
+            - gradle-plugin-portal
+            - sonatype
+            - commonsware
+            - simmatcher
+            - roc-wrapper
 
     -   package-ecosystem: "github-actions"
         directory: "/"
         schedule:
             interval: "weekly"
+        registries:
+            - google
+            - maven-central
+            - gradle-plugin-portal
+            - sonatype
+            - commonsware
+            - simmatcher
+            - roc-wrapper


### PR DESCRIPTION
Repositories from `settings.gradle.kts` `dependencyResolutionManagement` added as registries (see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#registries) in order to be recognizable by Dependabot.