### PR TITLE
[MS-19] use root detection while syncing data

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/MainFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/MainFragment.kt
@@ -6,10 +6,10 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.simprints.infra.uibase.viewbinding.viewBinding
 import com.simprints.feature.dashboard.BuildConfig
 import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentMainBinding
+import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -28,6 +28,9 @@ internal class MainFragment : Fragment(R.layout.fragment_main) {
         }
         viewModel.consentRequired.observe(viewLifecycleOwner) {
             binding.dashboardToolbar.menu.findItem(R.id.menuPrivacyNotice).isVisible = it
+        }
+        viewModel.rootedDeviceDetected.observe(viewLifecycleOwner) {
+            binding.rootedDeviceError.visibility = View.VISIBLE
         }
     }
 

--- a/feature/dashboard/src/main/res/layout/fragment_main.xml
+++ b/feature/dashboard/src/main/res/layout/fragment_main.xml
@@ -60,4 +60,44 @@
 
         </LinearLayout>
     </ScrollView>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/rootedDeviceError"
+        android:visibility="gone"
+        android:background="@color/simprints_red">
+        <TextView
+            android:id="@+id/alertTitle"
+            style="@style/Text.Headline5.White.Bold"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginBottom="24dp"
+            android:gravity="center"
+            android:maxLines="2"
+            app:layout_constraintBottom_toTopOf="@id/alertImage"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintVertical_chainStyle="packed"
+            app:layout_constraintWidth_percent="0.8"
+            android:text="@string/orchestrator_rooted_device_error_title" />
+
+        <ImageView
+            android:id="@+id/alertImage"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginVertical="16dp"
+            android:padding="16dp"
+            android:scaleType="fitCenter"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHeight_percent="0.33"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.3"
+            app:layout_constraintWidth_percent="0.5"
+            android:src="@drawable/ic_alert_default"
+            tools:ignore="ContentDescription" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/main/MainViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/main/MainViewModelTest.kt
@@ -3,6 +3,8 @@ package com.simprints.feature.dashboard.main
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import com.simprints.infra.config.store.ConfigRepository
+import com.simprints.infra.security.SecurityManager
+import com.simprints.infra.security.exceptions.RootedDeviceException
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import io.mockk.coEvery
 import io.mockk.every
@@ -25,11 +27,20 @@ class MainViewModelTest {
             }
         }
     }
+    private val securityManager = mockk<SecurityManager>(relaxed = true)
+
 
     @Test
     fun `should initialize the live data correctly`() {
-        val viewModel = MainViewModel(configRepository)
+        val viewModel = MainViewModel(configRepository, securityManager)
 
         assertThat(viewModel.consentRequired.value).isEqualTo(true)
+    }
+    @Test
+    fun `should show rooted device detected if device is rooted`() {
+        coEvery { securityManager.checkIfDeviceIsRooted() } throws RootedDeviceException()
+        val viewModel = MainViewModel(configRepository, securityManager)
+
+        assertThat(viewModel.rootedDeviceDetected.value).isNotNull()
     }
 }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorker.kt
@@ -16,6 +16,7 @@ import com.simprints.infra.eventsync.sync.common.*
 import com.simprints.infra.eventsync.sync.down.EventDownSyncWorkersBuilder
 import com.simprints.infra.eventsync.sync.up.EventUpSyncWorkersBuilder
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.security.SecurityManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineDispatcher
@@ -33,6 +34,7 @@ internal class EventSyncMasterWorker @AssistedInject constructor(
     private val eventSyncSubMasterWorkersBuilder: EventSyncSubMasterWorkersBuilder,
     private val timeHelper: TimeHelper,
     @DispatcherBG private val dispatcher: CoroutineDispatcher,
+    private val securityManager: SecurityManager,
 ) : SimCoroutineWorker(appContext, params) {
 
     companion object {
@@ -58,6 +60,8 @@ internal class EventSyncMasterWorker @AssistedInject constructor(
     override suspend fun doWork(): Result =
         withContext(dispatcher) {
             try {
+                // check if device is rooted before starting the sync
+                securityManager.checkIfDeviceIsRooted()
                 crashlyticsLog("Start")
                 showProgressNotification()
                 val configuration = configRepository.getProjectConfiguration()


### PR DESCRIPTION
If the user roots his device after login, he could downsync biometric records from the backend.
I added a root detection check before doing any sync operations. also displayed a big alert screen in one dashboard screen to let the user knows that SID doesn't work in rooted devices.