### PR TITLE
MS-201 Save userId on login or intent

### DIFF
--- a/feature/login-check/src/main/java/com/simprints/feature/logincheck/LoginCheckViewModel.kt
+++ b/feature/login-check/src/main/java/com/simprints/feature/logincheck/LoginCheckViewModel.kt
@@ -9,6 +9,7 @@ import com.simprints.core.livedata.LiveDataEventWithContent
 import com.simprints.core.livedata.send
 import com.simprints.feature.login.LoginError
 import com.simprints.feature.login.LoginResult
+import com.simprints.feature.logincheck.usecases.*
 import com.simprints.feature.logincheck.usecases.AddAuthorizationEventUseCase
 import com.simprints.feature.logincheck.usecases.CancelBackgroundSyncUseCase
 import com.simprints.feature.logincheck.usecases.ExtractCrashKeysUseCase
@@ -19,8 +20,8 @@ import com.simprints.feature.logincheck.usecases.IsUserSignedInUseCase.SignedInS
 import com.simprints.feature.logincheck.usecases.IsUserSignedInUseCase.SignedInState.SIGNED_IN
 import com.simprints.feature.logincheck.usecases.ReportActionRequestEventsUseCase
 import com.simprints.feature.logincheck.usecases.StartBackgroundSyncUseCase
-import com.simprints.feature.logincheck.usecases.UpdateSessionScopePayloadUseCase
 import com.simprints.feature.logincheck.usecases.UpdateProjectInCurrentSessionUseCase
+import com.simprints.feature.logincheck.usecases.UpdateSessionScopePayloadUseCase
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.ProjectState
 import com.simprints.infra.logging.Simber
@@ -47,6 +48,7 @@ class LoginCheckViewModel @Inject internal constructor(
     private val cancelBackgroundSync: CancelBackgroundSyncUseCase,
     private val updateDatabaseCountsInCurrentSession: UpdateSessionScopePayloadUseCase,
     private val updateProjectInCurrentSession: UpdateProjectInCurrentSessionUseCase,
+    private val updateStoredUserId: UpdateStoredUserIdUseCase,
 ) : ViewModel() {
 
     private var cachedRequest: ActionRequest? = null
@@ -59,7 +61,6 @@ class LoginCheckViewModel @Inject internal constructor(
     val showLoginFlow: LiveData<LiveDataEventWithContent<ActionRequest>>
         get() = _showLoginFlow
     private val _showLoginFlow = MutableLiveData<LiveDataEventWithContent<ActionRequest>>()
-
 
     val proceedWithAction: LiveData<LiveDataEventWithContent<ActionRequest>>
         get() = _proceedWithAction
@@ -140,6 +141,7 @@ class LoginCheckViewModel @Inject internal constructor(
 
     private suspend fun proceedWithAction(actionRequest: ActionRequest) = viewModelScope.launch {
         updateProjectInCurrentSession()
+        updateStoredUserId(actionRequest.userId)
         awaitAll(
             async { updateDatabaseCountsInCurrentSession() },
             async { addAuthorizationEvent(actionRequest, true) },

--- a/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/UpdateStoredUserIdUseCase.kt
+++ b/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/UpdateStoredUserIdUseCase.kt
@@ -1,0 +1,18 @@
+package com.simprints.feature.logincheck.usecases
+
+import com.simprints.core.domain.tokenization.TokenizableString
+import com.simprints.infra.authstore.AuthStore
+import javax.inject.Inject
+
+class UpdateStoredUserIdUseCase @Inject constructor(
+    private val authStore: AuthStore,
+) {
+
+    operator fun invoke(userId: TokenizableString) {
+        // This is a hack to make sure that there is a stored user ID if user logged in before 2024.1.0.
+        // It could be removed after all we drop support for older versions.
+        if (authStore.signedInUserId == null) {
+            authStore.signedInUserId = userId
+        }
+    }
+}

--- a/feature/login-check/src/test/java/com/simprints/feature/logincheck/LoginCheckViewModelTest.kt
+++ b/feature/login-check/src/test/java/com/simprints/feature/logincheck/LoginCheckViewModelTest.kt
@@ -63,6 +63,9 @@ internal class LoginCheckViewModelTest {
     @MockK
     lateinit var updateProjectStateUseCase: UpdateProjectInCurrentSessionUseCase
 
+    @MockK
+    lateinit var updateStoredUserIdUseCase: UpdateStoredUserIdUseCase
+
     private lateinit var viewModel: LoginCheckViewModel
 
 
@@ -82,6 +85,7 @@ internal class LoginCheckViewModelTest {
             cancelBackgroundSync,
             updateSessionScopePayloadUseCase,
             updateProjectStateUseCase,
+            updateStoredUserIdUseCase,
         )
     }
 
@@ -279,6 +283,7 @@ internal class LoginCheckViewModelTest {
 
         coVerify {
             updateProjectStateUseCase.invoke()
+            updateStoredUserIdUseCase.invoke(any())
             updateSessionScopePayloadUseCase.invoke()
             addAuthorizationEventUseCase.invoke(any(), eq(true))
             extractCrashKeysUseCase.invoke(any())

--- a/feature/login-check/src/test/java/com/simprints/feature/logincheck/usecases/UpdateStoredUserIdUseCaseTest.kt
+++ b/feature/login-check/src/test/java/com/simprints/feature/logincheck/usecases/UpdateStoredUserIdUseCaseTest.kt
@@ -1,0 +1,45 @@
+package com.simprints.feature.logincheck.usecases
+
+import com.simprints.core.domain.tokenization.TokenizableString
+import com.simprints.core.domain.tokenization.asTokenizableRaw
+import com.simprints.infra.authstore.AuthStore
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class UpdateStoredUserIdUseCaseTest {
+
+    @MockK
+    private lateinit var authStore: AuthStore
+
+    private lateinit var useCase: UpdateStoredUserIdUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        useCase = UpdateStoredUserIdUseCase(authStore)
+    }
+
+    @Test
+    fun `Does not update userId when already present in store`() {
+        every { authStore.signedInUserId } returns "userId".asTokenizableRaw()
+
+        useCase("userId".asTokenizableRaw())
+
+        verify(exactly = 0) { authStore.setProperty("signedInUserId").value(any<TokenizableString.Raw>()) }
+    }
+
+    @Test
+    fun `Does updates userId when not present in store`() {
+        every { authStore.signedInUserId } returns null
+
+        useCase("userId".asTokenizableRaw())
+
+        verify { authStore.setProperty("signedInUserId").value(any<TokenizableString.Raw>()) }
+    }
+
+}

--- a/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/Authenticator.kt
+++ b/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/Authenticator.kt
@@ -34,7 +34,7 @@ internal class Authenticator @Inject constructor(
         userId: TokenizableString.Raw,
         projectId: String,
         projectSecret: String,
-        deviceId: String
+        deviceId: String,
     ): AuthenticateDataResult {
         val result = try {
             logMessageForCrashReportWithNetworkTrigger("Making authentication request")
@@ -45,6 +45,8 @@ internal class Authenticator @Inject constructor(
             projectAuthenticator.authenticate(nonceScope, projectSecret)
 
             logMessageForCrashReportWithNetworkTrigger("Sign in success")
+            authStore.signedInUserId = userId
+
             AuthenticateDataResult.Authenticated
         } catch (t: Throwable) {
             when (t) {

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/AuthStore.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/AuthStore.kt
@@ -1,6 +1,7 @@
 package com.simprints.infra.authstore
 
 import com.google.firebase.FirebaseApp
+import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.infra.authstore.domain.models.Token
 import com.simprints.infra.network.SimNetwork
 import com.simprints.infra.network.SimRemoteInterface
@@ -8,6 +9,7 @@ import kotlin.reflect.KClass
 
 interface AuthStore {
 
+    var signedInUserId: TokenizableString?
     var signedInProjectId: String
 
     fun isProjectIdSignedIn(possibleProjectId: String): Boolean

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/AuthStoreImpl.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/AuthStoreImpl.kt
@@ -1,6 +1,7 @@
 package com.simprints.infra.authstore
 
 import com.google.firebase.FirebaseApp
+import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.infra.authstore.db.FirebaseAuthManager
 import com.simprints.infra.authstore.domain.LoginInfoStore
 import com.simprints.infra.authstore.domain.models.Token
@@ -16,6 +17,12 @@ internal class AuthStoreImpl @Inject constructor(
     private val firebaseAuthManager: FirebaseAuthManager,
     private val simApiClientFactory: SimApiClientFactory,
 ) : AuthStore {
+
+    override var signedInUserId: TokenizableString?
+        get() = loginInfoStore.signedInUserId
+        set(value) {
+            loginInfoStore.signedInUserId = value
+        }
 
     override var signedInProjectId: String
         get() = loginInfoStore.signedInProjectId

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
@@ -2,7 +2,10 @@ package com.simprints.infra.authstore.domain
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.simprints.core.domain.tokenization.TokenizableString
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.lang.reflect.Array.setBoolean
 import javax.inject.Inject
 
 internal class LoginInfoStore @Inject constructor(
@@ -10,9 +13,12 @@ internal class LoginInfoStore @Inject constructor(
 ) {
 
     companion object {
+
         private const val PREF_FILE_NAME = "b3f0cf9b-4f3f-4c5b-bf85-7b1f44eddd7a"
         private const val PREF_MODE = Context.MODE_PRIVATE
         private const val ENCRYPTED_PROJECT_SECRET: String = "ENCRYPTED_PROJECT_SECRET"
+        private const val USER_ID_VALUE: String = "USER_ID_VALUE"
+        private const val USER_ID_TOKENIZED: String = "USER_ID_TOKENIZED"
         private const val PROJECT_ID: String = "PROJECT_ID"
         private const val PROJECT_ID_CLAIM: String = "PROJECT_ID_CLAIM"
         private const val CORE_FIREBASE_PROJECT_ID = "CORE_FIREBASE_PROJECT_ID"
@@ -22,6 +28,26 @@ internal class LoginInfoStore @Inject constructor(
 
     // TODO Move data to an encrypted version - CORE-2590
     private val prefs: SharedPreferences = ctx.getSharedPreferences(PREF_FILE_NAME, PREF_MODE)
+
+    var signedInUserId: TokenizableString? = null
+        get() {
+            val value = prefs.getString(USER_ID_VALUE, null)
+            return when {
+                value == null -> null
+                prefs.getBoolean(USER_ID_TOKENIZED, false) -> TokenizableString.Tokenized(value)
+                else -> TokenizableString.Raw(value)
+            }
+        }
+        set(value) = prefs.edit {
+            if (value == null) {
+                remove(USER_ID_VALUE)
+                remove(USER_ID_TOKENIZED)
+            } else {
+                putBoolean(USER_ID_TOKENIZED, value is TokenizableString.Tokenized)
+                putString(USER_ID_VALUE, value.value)
+            }
+            field = value
+        }
 
     var signedInProjectId: String = ""
         get() = prefs.getString(PROJECT_ID, "").orEmpty()
@@ -65,6 +91,7 @@ internal class LoginInfoStore @Inject constructor(
         signedInProjectId.isNotEmpty() && signedInProjectId == possibleProjectId
 
     fun cleanCredentials() {
+        signedInUserId = null
         signedInProjectId = ""
         prefs.edit().putString(ENCRYPTED_PROJECT_SECRET, "").apply()
 

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
@@ -17,7 +17,7 @@ internal class LoginInfoStore @Inject constructor(
         private const val PREF_FILE_NAME = "b3f0cf9b-4f3f-4c5b-bf85-7b1f44eddd7a"
         private const val PREF_MODE = Context.MODE_PRIVATE
         private const val ENCRYPTED_PROJECT_SECRET: String = "ENCRYPTED_PROJECT_SECRET"
-        private const val USER_ID_VALUE: String = "USER_ID_VALUE"
+        private const val USER_ID_VALUE: String = "USER_ID"
         private const val USER_ID_TOKENIZED: String = "USER_ID_TOKENIZED"
         private const val PROJECT_ID: String = "PROJECT_ID"
         private const val PROJECT_ID_CLAIM: String = "PROJECT_ID_CLAIM"

--- a/infra/auth-store/src/test/java/com/simprints/infra/authstore/AuthStoreImplTest.kt
+++ b/infra/auth-store/src/test/java/com/simprints/infra/authstore/AuthStoreImplTest.kt
@@ -3,6 +3,7 @@ package com.simprints.infra.authstore
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
+import com.simprints.core.domain.tokenization.asTokenizableRaw
 import com.simprints.infra.authstore.db.FirebaseAuthManager
 import com.simprints.infra.authstore.domain.LoginInfoStore
 import com.simprints.infra.authstore.domain.models.Token
@@ -27,6 +28,22 @@ class AuthStoreImplTest {
         firebaseAuthManager,
         simApiClientFactory
     )
+
+    @Test
+    fun `get signedUserId should call the correct method`() {
+        every { loginInfoStore.signedInUserId } returns USER_ID
+        val receivedUserId = loginManagerManagerImpl.signedInUserId
+
+        assertThat(receivedUserId).isEqualTo(USER_ID)
+    }
+
+    @Test
+    fun `set signedUserId should call the correct method`() {
+        every { loginInfoStore.signedInUserId } returns USER_ID
+        loginManagerManagerImpl.signedInUserId = USER_ID
+
+        verify { loginInfoStore.setProperty("signedInUserId").value(USER_ID) }
+    }
 
     @Test
     fun `get signedInProjectId should call the correct method`() {
@@ -122,6 +139,7 @@ class AuthStoreImplTest {
 
     companion object {
         private const val PROJECT_ID = "projectId"
+        private val USER_ID = "userId".asTokenizableRaw()
         private val TOKEN = Token("token", "projectId", "apiKey", "application")
         private val FIREBASE_APP = mockk<FirebaseApp>()
         private val SIM_API_CLIENT = mockk<SimNetwork.SimApiClient<SimRemoteInterface>>()

--- a/infra/auth-store/src/test/java/com/simprints/infra/authstore/domain/LoginInfoStoreTest.kt
+++ b/infra/auth-store/src/test/java/com/simprints/infra/authstore/domain/LoginInfoStoreTest.kt
@@ -39,7 +39,7 @@ class LoginInfoStoreTest {
     fun `setting the raw signed in user id should set in the shared preferences`() {
         loginInfoStoreImpl.signedInUserId = "user".asTokenizableRaw()
 
-        verify(exactly = 1) { editor.putString("USER_ID_VALUE", "user") }
+        verify(exactly = 1) { editor.putString("USER_ID", "user") }
         verify(exactly = 1) { editor.putBoolean("USER_ID_TOKENIZED", false) }
     }
 
@@ -47,7 +47,7 @@ class LoginInfoStoreTest {
     fun `setting the tokenized signed in user id should set in the shared preferences`() {
         loginInfoStoreImpl.signedInUserId = "user".asTokenizableEncrypted()
 
-        verify(exactly = 1) { editor.putString("USER_ID_VALUE", "user") }
+        verify(exactly = 1) { editor.putString("USER_ID", "user") }
         verify(exactly = 1) { editor.putBoolean("USER_ID_TOKENIZED", true) }
     }
 
@@ -188,7 +188,7 @@ class LoginInfoStoreTest {
     fun `cleanCredentials should reset all the credentials`() {
         loginInfoStoreImpl.cleanCredentials()
 
-        verify(exactly = 1) { editor.remove("USER_ID_VALUE") }
+        verify(exactly = 1) { editor.remove("USER_ID") }
         verify(exactly = 1) { editor.remove("USER_ID_TOKENIZED") }
         verify(exactly = 1) { editor.putString("PROJECT_ID", "") }
         verify(exactly = 1) { editor.putString("ENCRYPTED_PROJECT_SECRET", "") }

--- a/infra/auth-store/src/test/java/com/simprints/infra/authstore/domain/LoginInfoStoreTest.kt
+++ b/infra/auth-store/src/test/java/com/simprints/infra/authstore/domain/LoginInfoStoreTest.kt
@@ -3,6 +3,8 @@ package com.simprints.infra.authstore.domain
 import android.content.Context
 import android.content.SharedPreferences
 import com.google.common.truth.Truth.assertThat
+import com.simprints.core.domain.tokenization.asTokenizableEncrypted
+import com.simprints.core.domain.tokenization.asTokenizableRaw
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -23,6 +25,30 @@ class LoginInfoStoreTest {
         every { sharedPreferences.edit() } returns editor
         every { editor.putString(any(), any()) } returns editor
         loginInfoStoreImpl = LoginInfoStore(ctx)
+    }
+
+    @Test
+    fun `getting the signed in user id should returns it`() {
+        every { sharedPreferences.getString(any(), any()) } returns "user"
+        every { sharedPreferences.getBoolean(any(), any()) } returns true
+
+        assertThat(loginInfoStoreImpl.signedInUserId).isEqualTo("user".asTokenizableRaw())
+    }
+
+    @Test
+    fun `setting the raw signed in user id should set in the shared preferences`() {
+        loginInfoStoreImpl.signedInUserId = "user".asTokenizableRaw()
+
+        verify(exactly = 1) { editor.putString("USER_ID_VALUE", "user") }
+        verify(exactly = 1) { editor.putBoolean("USER_ID_TOKENIZED", false) }
+    }
+
+    @Test
+    fun `setting the tokenized signed in user id should set in the shared preferences`() {
+        loginInfoStoreImpl.signedInUserId = "user".asTokenizableEncrypted()
+
+        verify(exactly = 1) { editor.putString("USER_ID_VALUE", "user") }
+        verify(exactly = 1) { editor.putBoolean("USER_ID_TOKENIZED", true) }
     }
 
     @Test
@@ -162,13 +188,15 @@ class LoginInfoStoreTest {
     fun `cleanCredentials should reset all the credentials`() {
         loginInfoStoreImpl.cleanCredentials()
 
+        verify(exactly = 1) { editor.remove("USER_ID_VALUE") }
+        verify(exactly = 1) { editor.remove("USER_ID_TOKENIZED") }
         verify(exactly = 1) { editor.putString("PROJECT_ID", "") }
         verify(exactly = 1) { editor.putString("ENCRYPTED_PROJECT_SECRET", "") }
         verify(exactly = 1) { editor.putString("PROJECT_ID_CLAIM", "") }
         verify(exactly = 1) { editor.putString("CORE_FIREBASE_PROJECT_ID", "") }
         verify(exactly = 1) { editor.putString("CORE_FIREBASE_APPLICATION_ID", "") }
         verify(exactly = 1) { editor.putString("CORE_FIREBASE_API_KEY", "") }
-        verify(exactly = 6) { editor.apply() }
+        verify(exactly = 7) { editor.apply() }
     }
 
     @Test

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/status/down/EventDownSyncScopeRepository.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/status/down/EventDownSyncScopeRepository.kt
@@ -48,7 +48,7 @@ internal class EventDownSyncScopeRepository @Inject constructor(
     }
 
     private suspend fun getUserId(): String {
-        // After we are certain that all users have user IDs cached (introduced in 2024.1.0), the fallback can be removed
+        // After we are certain that all users have user IDs cached (no-one uses 2023.3 for a while), the fallback can be removed
         val possibleUserId: String = authStore.signedInUserId?.value
             ?: recentUserActivityManager.getRecentUserActivity().lastUserUsed.value
 

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/status/down/EventDownSyncScopeRepositoryTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/status/down/EventDownSyncScopeRepositoryTest.kt
@@ -43,6 +43,7 @@ import org.junit.Test
 internal class EventDownSyncScopeRepositoryTest {
 
     companion object {
+
         private val LAST_EVENT_ID = GUID1
         private val LAST_SYNC_TIME = TIME1
         private val LAST_STATE = DownSyncState.COMPLETE
@@ -80,126 +81,125 @@ internal class EventDownSyncScopeRepositoryTest {
     }
 
     @Test
-    fun buildProjectDownSyncScope() {
-        runTest(UnconfinedTestDispatcher()) {
-            val syncScope = eventDownSyncScopeRepository.getDownSyncScope(
+    fun buildProjectDownSyncScope() = runTest(UnconfinedTestDispatcher()) {
+        val syncScope = eventDownSyncScopeRepository.getDownSyncScope(
+            listOf(Modes.FINGERPRINT),
+            DEFAULT_MODULES.toList(),
+            Partitioning.GLOBAL
+        )
+
+        assertProjectSyncScope(syncScope)
+    }
+
+    @Test
+    fun buildUserDownSyncScope() = runTest(UnconfinedTestDispatcher()) {
+        every { authStore.signedInUserId } returns DEFAULT_USER_ID
+
+        val syncScope = eventDownSyncScopeRepository.getDownSyncScope(
+            listOf(Modes.FINGERPRINT),
+            DEFAULT_MODULES.toList(),
+            Partitioning.USER
+        )
+
+        assertUserSyncScope(syncScope)
+    }
+
+    @Test
+    fun buildUserDownSyncScopeWhenNoSaved() = runTest(UnconfinedTestDispatcher()) {
+        every { authStore.signedInUserId } returns null
+
+        val syncScope = eventDownSyncScopeRepository.getDownSyncScope(
+            listOf(Modes.FINGERPRINT),
+            DEFAULT_MODULES.toList(),
+            Partitioning.USER
+        )
+
+        assertUserSyncScope(syncScope)
+    }
+
+    @Test
+    fun buildModuleDownSyncScope() = runTest(UnconfinedTestDispatcher()) {
+        val syncScope = eventDownSyncScopeRepository.getDownSyncScope(
+            listOf(Modes.FINGERPRINT),
+            DEFAULT_MODULES.toList(),
+            Partitioning.MODULE
+        )
+
+        assertModuleSyncScope(syncScope)
+    }
+
+    @Test
+    fun throwWhenProjectIsMissing() = runTest(UnconfinedTestDispatcher()) {
+        every { authStore.signedInProjectId } returns ""
+
+        assertThrows<MissingArgumentForDownSyncScopeException> {
+            eventDownSyncScopeRepository.getDownSyncScope(
                 listOf(Modes.FINGERPRINT),
                 DEFAULT_MODULES.toList(),
                 Partitioning.GLOBAL
             )
-
-            assertProjectSyncScope(syncScope)
         }
+
     }
 
     @Test
-    fun buildUserDownSyncScope() {
-        runTest(UnconfinedTestDispatcher()) {
+    fun throwWhenUserIsMissing() = runTest(UnconfinedTestDispatcher()) {
+        coEvery { authStore.signedInUserId } returns null
+        coEvery { recentUserActivityManager.getRecentUserActivity() } returns mockk {
+            every { lastUserUsed } returns "".asTokenizableEncrypted()
+        }
 
-            val syncScope = eventDownSyncScopeRepository.getDownSyncScope(
+        assertThrows<MissingArgumentForDownSyncScopeException> {
+            eventDownSyncScopeRepository.getDownSyncScope(
                 listOf(Modes.FINGERPRINT),
                 DEFAULT_MODULES.toList(),
                 Partitioning.USER
             )
-
-            assertUserSyncScope(syncScope)
         }
     }
 
     @Test
-    fun buildModuleDownSyncScope() {
-        runTest(UnconfinedTestDispatcher()) {
-            val syncScope = eventDownSyncScopeRepository.getDownSyncScope(
-                listOf(Modes.FINGERPRINT),
-                DEFAULT_MODULES.toList(),
-                Partitioning.MODULE
-            )
+    fun downSyncOp_refresh_shouldReturnARefreshedOp() = runTest(UnconfinedTestDispatcher()) {
+        val refreshedSyncOp =
+            eventDownSyncScopeRepository.refreshState(projectDownSyncScope.operations.first())
 
-            assertModuleSyncScope(syncScope)
-        }
+        assertThat(refreshedSyncOp).isNotNull()
+        refreshedSyncOp.assertProjectSyncOpIsRefreshed()
     }
 
     @Test
-    fun throwWhenProjectIsMissing() {
-        runTest(UnconfinedTestDispatcher()) {
-            every { authStore.signedInProjectId } returns ""
+    fun insertOrUpdate_shouldInsertIntoTheDb() = runTest {
+        eventDownSyncScopeRepository.insertOrUpdate(projectDownSyncScope.operations.first())
 
-            assertThrows<MissingArgumentForDownSyncScopeException> {
-                eventDownSyncScopeRepository.getDownSyncScope(
-                    listOf(Modes.FINGERPRINT),
-                    DEFAULT_MODULES.toList(),
-                    Partitioning.GLOBAL
-                )
-            }
-        }
+        coVerify { downSyncOperationOperationDao.insertOrUpdate(any()) }
     }
 
     @Test
-    fun throwWhenUserIsMissing() {
-        runTest(UnconfinedTestDispatcher()) {
-            coEvery { recentUserActivityManager.getRecentUserActivity() } returns mockk {
-                every { lastUserUsed } returns "".asTokenizableEncrypted()
-            }
+    fun deleteOperations_shouldDeleteOpsFromDb() = runTest {
+        eventDownSyncScopeRepository.deleteOperations(
+            DEFAULT_MODULES.toList(),
+            listOf(Modes.FINGERPRINT)
+        )
 
-            assertThrows<MissingArgumentForDownSyncScopeException> {
-                eventDownSyncScopeRepository.getDownSyncScope(
-                    listOf(Modes.FINGERPRINT),
-                    DEFAULT_MODULES.toList(),
-                    Partitioning.GLOBAL
-                )
-            }
-        }
-    }
-
-    @Test
-    fun downSyncOp_refresh_shouldReturnARefreshedOp() {
-        runTest(UnconfinedTestDispatcher()) {
-
-            val refreshedSyncOp =
-                eventDownSyncScopeRepository.refreshState(projectDownSyncScope.operations.first())
-
-            assertThat(refreshedSyncOp).isNotNull()
-            refreshedSyncOp.assertProjectSyncOpIsRefreshed()
-        }
-    }
-
-    @Test
-    fun insertOrUpdate_shouldInsertIntoTheDb() {
-        runTest {
-            eventDownSyncScopeRepository.insertOrUpdate(projectDownSyncScope.operations.first())
-
-            coVerify { downSyncOperationOperationDao.insertOrUpdate(any()) }
-        }
-    }
-
-    @Test
-    fun deleteOperations_shouldDeleteOpsFromDb() {
-        runTest {
-
-            eventDownSyncScopeRepository.deleteOperations(
-                DEFAULT_MODULES.toList(),
+        DEFAULT_MODULES.forEach { moduleId ->
+            val scope = SubjectModuleScope(
+                DEFAULT_PROJECT_ID,
+                listOf(moduleId),
                 listOf(Modes.FINGERPRINT)
             )
-
-            DEFAULT_MODULES.forEach { moduleId ->
-                val scope = SubjectModuleScope(
-                    DEFAULT_PROJECT_ID,
-                    listOf(moduleId),
-                    listOf(Modes.FINGERPRINT)
+            coVerify(exactly = 1) {
+                downSyncOperationOperationDao.delete(
+                    scope.operations.first().getUniqueKey()
                 )
-                coVerify(exactly = 1) { downSyncOperationOperationDao.delete(scope.operations.first().getUniqueKey()) }
             }
         }
     }
 
     @Test
-    fun deleteAll_shouldDeleteAllOpsFromDb() {
-        runTest {
+    fun deleteAll_shouldDeleteAllOpsFromDb() = runTest {
+        eventDownSyncScopeRepository.deleteAll()
 
-            eventDownSyncScopeRepository.deleteAll()
-
-            coVerify { downSyncOperationOperationDao.deleteAll() }
-        }
+        coVerify { downSyncOperationOperationDao.deleteAll() }
     }
 
     private fun getSyncOperationsWithLastResult() =
@@ -250,7 +250,10 @@ internal class EventDownSyncScopeRepositoryTest {
         assertThat(syncScope).isInstanceOf(SubjectModuleScope::class.java)
         with((syncScope as SubjectModuleScope)) {
             assertThat(projectId).isEqualTo(DEFAULT_PROJECT_ID)
-            assertThat(moduleIds).containsExactly(DEFAULT_MODULE_ID.value, DEFAULT_MODULE_ID_2.value)
+            assertThat(moduleIds).containsExactly(
+                DEFAULT_MODULE_ID.value,
+                DEFAULT_MODULE_ID_2.value
+            )
             assertThat(modes).isEqualTo(listOf(Modes.FINGERPRINT))
         }
     }


### PR DESCRIPTION
Main changes:
* Saving user ID on login
* If already logged in, save userID on successful login check when handling flow


This accidentally includes our fix in a separate PR from the hotfix.


Note on data "migration": 
* Until the user ID was deleted, it has been stored in the same shared prefs, so if a user updates from before the issue was introduced, the store will just reuse the old value as `TokenisableString.Raw`