### PR TITLE
MA-11 Use secure shared prefs in login info store

### DIFF
--- a/feature/matcher/src/main/java/com/simprints/matcher/usecases/MatchResultSet.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/usecases/MatchResultSet.kt
@@ -40,7 +40,6 @@ internal class MatchResultSet<T : MatchResultItem>(
 
     companion object {
 
-        // TODO add as parameters
         /**
          * Default max size of the result set.
          */

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
@@ -134,7 +134,6 @@ internal class OrchestratorViewModel @Inject constructor(
             if (matchingStep != null) {
                 val faceSamples = result.results.mapNotNull { it.sample }
                     .map { MatchParams.FaceSample(it.faceId, it.template) }
-                //TODO: check
                 val newPayload = matchingStep.payload
                     .getParcelable<MatchStepStubPayload>(MatchStepStubPayload.STUB_KEY)
                     ?.toFaceStepArgs(faceSamples)
@@ -150,7 +149,6 @@ internal class OrchestratorViewModel @Inject constructor(
             if (matchingStep != null) {
                 val fingerprintSamples = result.results.mapNotNull { it.sample }
                     .map { MatchParams.FingerprintSample(it.fingerIdentifier, it.format, it.template) }
-                //TODO: check
                 val newPayload = matchingStep.payload
                     .getParcelable<MatchStepStubPayload>(MatchStepStubPayload.STUB_KEY)
                     ?.toFingerprintStepArgs(fingerprintSamples)

--- a/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/SignerManager.kt
+++ b/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/SignerManager.kt
@@ -39,7 +39,7 @@ internal class SignerManager @Inject constructor(
             // Only store credentials if all other calls succeeded. This avoids the undefined state
             // where credentials are store (i.e. user is considered logged in) but project configuration
             // is missing
-            authStore.storeCredentials(projectId)
+            authStore.signedInProjectId = projectId
         } catch (e: Exception) {
             authStore.clearFirebaseToken()
             configRepository.clearData()

--- a/infra/auth-logic/src/test/java/com/simprints/infra/authlogic/authenticator/SignerManagerTest.kt
+++ b/infra/auth-logic/src/test/java/com/simprints/infra/authlogic/authenticator/SignerManagerTest.kt
@@ -104,13 +104,13 @@ internal class SignerManagerTest {
 
         signIn()
 
-        verify { mockAuthStore.storeCredentials(DEFAULT_PROJECT_ID) }
+        verify { mockAuthStore.signedInProjectId = DEFAULT_PROJECT_ID }
     }
 
     @Test
     fun storeCredentialsFails_signInShouldFail() = runTest(UnconfinedTestDispatcher()) {
         mockRemoteSignedIn()
-        mockStoreCredentialsLocally(true)
+        every { mockAuthStore.signedInProjectId = any() } throws Throwable("Failed to store credentials")
 
         assertThrows<Throwable> { signIn() }
     }
@@ -197,14 +197,8 @@ internal class SignerManagerTest {
 
     private suspend fun signIn() = signerManager.signIn(DEFAULT_PROJECT_ID, token)
 
-    private fun mockStoreCredentialsLocally(error: Boolean = false) =
-        every { mockAuthStore.storeCredentials(DEFAULT_PROJECT_ID) }.apply {
-            if (!error) {
-                this.returns(Unit)
-            } else {
-                this.throws(Throwable("Failed to store credentials"))
-            }
-        }
+    private fun mockStoreCredentialsLocally() =
+        every { mockAuthStore.signedInProjectId } returns (DEFAULT_PROJECT_ID)
 
     private fun mockRemoteSignedIn(error: Boolean = false) =
         coEvery { mockAuthStore.storeFirebaseToken(token) }.apply {

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/AuthStore.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/AuthStore.kt
@@ -14,7 +14,6 @@ interface AuthStore {
 
     fun isProjectIdSignedIn(possibleProjectId: String): Boolean
     fun cleanCredentials()
-    fun storeCredentials(projectId: String)
 
     suspend fun storeFirebaseToken(token: Token)
     fun clearFirebaseToken()

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/AuthStoreImpl.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/AuthStoreImpl.kt
@@ -37,10 +37,6 @@ internal class AuthStoreImpl @Inject constructor(
         loginInfoStore.cleanCredentials()
     }
 
-    override fun storeCredentials(projectId: String) {
-        loginInfoStore.storeCredentials(projectId)
-    }
-
     override suspend fun storeFirebaseToken(token: Token) {
         firebaseAuthManager.signIn(token)
     }

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
@@ -129,8 +129,4 @@ internal class LoginInfoStore @Inject constructor(
             remove(CORE_FIREBASE_API_KEY)
         }
     }
-
-    fun storeCredentials(projectId: String) {
-        signedInProjectId = projectId
-    }
 }

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
@@ -4,19 +4,21 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.simprints.core.domain.tokenization.TokenizableString
+import com.simprints.core.domain.tokenization.isTokenized
+import com.simprints.infra.security.SecurityManager
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.lang.reflect.Array.setBoolean
 import javax.inject.Inject
 
 internal class LoginInfoStore @Inject constructor(
     @ApplicationContext ctx: Context,
+    securityManager: SecurityManager,
 ) {
 
     companion object {
 
-        private const val PREF_FILE_NAME = "b3f0cf9b-4f3f-4c5b-bf85-7b1f44eddd7a"
-        private const val PREF_MODE = Context.MODE_PRIVATE
-        private const val ENCRYPTED_PROJECT_SECRET: String = "ENCRYPTED_PROJECT_SECRET"
+        private const val LEGACY_PREF_FILE_NAME = "b3f0cf9b-4f3f-4c5b-bf85-7b1f44eddd7a"
+        private const val SECURE_PREF_FILE_NAME = "99caf5cd-7b1c-4127-912d-77d4c35c51f3"
+
         private const val USER_ID_VALUE: String = "USER_ID"
         private const val USER_ID_TOKENIZED: String = "USER_ID_TOKENIZED"
         private const val PROJECT_ID: String = "PROJECT_ID"
@@ -26,83 +28,106 @@ internal class LoginInfoStore @Inject constructor(
         private const val CORE_FIREBASE_API_KEY = "CORE_FIREBASE_API_KEY"
     }
 
-    // TODO Move data to an encrypted version - CORE-2590
-    private val prefs: SharedPreferences = ctx.getSharedPreferences(PREF_FILE_NAME, PREF_MODE)
+    @Deprecated("Data has been migrated to secure prefs. Delete after there are no users below 2024.1.0")
+    private val prefs: SharedPreferences =
+        ctx.getSharedPreferences(LEGACY_PREF_FILE_NAME, Context.MODE_PRIVATE)
+
+    private val securePrefs = securityManager.buildEncryptedSharedPreferences(SECURE_PREF_FILE_NAME)
+
+    /**
+     * Ensures that data has been migrated to secure prefs before accessing it.
+     */
+    private fun getSecurePrefs(): SharedPreferences {
+        if (prefs.contains(PROJECT_ID)) {
+            securePrefs.edit(commit = true) {
+                putString(USER_ID_VALUE, prefs.getString(USER_ID_VALUE, ""))
+                putBoolean(USER_ID_TOKENIZED, prefs.getBoolean(USER_ID_TOKENIZED, false))
+                putString(PROJECT_ID, prefs.getString(PROJECT_ID, ""))
+                putString(PROJECT_ID_CLAIM, prefs.getString(PROJECT_ID_CLAIM, ""))
+                putString(CORE_FIREBASE_PROJECT_ID, prefs.getString(CORE_FIREBASE_PROJECT_ID, ""))
+                putString(CORE_FIREBASE_APPLICATION_ID, prefs.getString(CORE_FIREBASE_APPLICATION_ID, ""))
+                putString(CORE_FIREBASE_API_KEY, prefs.getString(CORE_FIREBASE_API_KEY, ""))
+            }
+            prefs.edit(commit = true) { clear() }
+        }
+        return securePrefs
+    }
 
     var signedInUserId: TokenizableString? = null
-        get() {
-            val value = prefs.getString(USER_ID_VALUE, null)
-            return when {
+        get() = getSecurePrefs().let {
+            val value = it.getString(USER_ID_VALUE, null)
+            when {
                 value == null -> null
-                prefs.getBoolean(USER_ID_TOKENIZED, false) -> TokenizableString.Tokenized(value)
+                it.getBoolean(USER_ID_TOKENIZED, false) -> TokenizableString.Tokenized(value)
                 else -> TokenizableString.Raw(value)
             }
         }
-        set(value) = prefs.edit {
-            if (value == null) {
-                remove(USER_ID_VALUE)
-                remove(USER_ID_TOKENIZED)
-            } else {
-                putBoolean(USER_ID_TOKENIZED, value is TokenizableString.Tokenized)
-                putString(USER_ID_VALUE, value.value)
-            }
+        set(value) {
             field = value
+            getSecurePrefs().edit {
+                if (value == null) {
+                    remove(USER_ID_VALUE)
+                    remove(USER_ID_TOKENIZED)
+                } else {
+                    putBoolean(USER_ID_TOKENIZED, value.isTokenized())
+                    putString(USER_ID_VALUE, value.value)
+                }
+            }
         }
 
     var signedInProjectId: String = ""
-        get() = prefs.getString(PROJECT_ID, "").orEmpty()
+        get() = getSecurePrefs().getString(PROJECT_ID, "").orEmpty()
         set(value) {
             field = value
-            prefs.edit().putString(PROJECT_ID, field).apply()
+            getSecurePrefs().edit { putString(PROJECT_ID, field) }
         }
 
     // Core Firebase Project details. We store them to initialize the core Firebase project.
     var coreFirebaseProjectId: String = ""
-        get() = prefs.getString(CORE_FIREBASE_PROJECT_ID, "").orEmpty()
+        get() = securePrefs.getString(CORE_FIREBASE_PROJECT_ID, "").orEmpty()
         set(value) {
             field = value
-            prefs.edit().putString(CORE_FIREBASE_PROJECT_ID, field).apply()
+            getSecurePrefs().edit { putString(CORE_FIREBASE_PROJECT_ID, field) }
         }
 
     var coreFirebaseApplicationId: String = ""
-        get() = prefs.getString(CORE_FIREBASE_APPLICATION_ID, "").orEmpty()
+        get() = securePrefs.getString(CORE_FIREBASE_APPLICATION_ID, "").orEmpty()
         set(value) {
             field = value
-            prefs.edit().putString(CORE_FIREBASE_APPLICATION_ID, field).apply()
+            getSecurePrefs().edit { putString(CORE_FIREBASE_APPLICATION_ID, field) }
         }
 
     var coreFirebaseApiKey: String = ""
-        get() = prefs.getString(CORE_FIREBASE_API_KEY, "").orEmpty()
+        get() = securePrefs.getString(CORE_FIREBASE_API_KEY, "").orEmpty()
         set(value) {
             field = value
-            prefs.edit().putString(CORE_FIREBASE_API_KEY, field).apply()
+            getSecurePrefs().edit { putString(CORE_FIREBASE_API_KEY, field) }
         }
 
     // Cached claims in the auth token. We used them to check whether the user is signed or not
     // in without reading the token from Firebase (async operation)
     var projectIdTokenClaim: String? = ""
-        get() = prefs.getString(PROJECT_ID_CLAIM, "")
+        get() = securePrefs.getString(PROJECT_ID_CLAIM, "")
         set(value) {
             field = value
-            prefs.edit().putString(PROJECT_ID_CLAIM, field ?: "").apply()
+            getSecurePrefs().edit { putString(PROJECT_ID_CLAIM, field ?: "") }
         }
 
     fun isProjectIdSignedIn(possibleProjectId: String): Boolean =
         signedInProjectId.isNotEmpty() && signedInProjectId == possibleProjectId
 
     fun cleanCredentials() {
-        signedInUserId = null
-        signedInProjectId = ""
-        prefs.edit().putString(ENCRYPTED_PROJECT_SECRET, "").apply()
-
-        clearCachedTokenClaims()
+        securePrefs.edit { clear() }
+        prefs.edit { clear() }
     }
 
     fun clearCachedTokenClaims() {
-        projectIdTokenClaim = ""
-        coreFirebaseProjectId = ""
-        coreFirebaseApplicationId = ""
-        coreFirebaseApiKey = ""
+        getSecurePrefs().edit {
+            remove(PROJECT_ID_CLAIM)
+            remove(CORE_FIREBASE_PROJECT_ID)
+            remove(CORE_FIREBASE_APPLICATION_ID)
+            remove(CORE_FIREBASE_API_KEY)
+        }
     }
 
     fun storeCredentials(projectId: String) {

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
@@ -8,7 +8,9 @@ import com.simprints.core.domain.tokenization.isTokenized
 import com.simprints.infra.security.SecurityManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 internal class LoginInfoStore @Inject constructor(
     @ApplicationContext ctx: Context,
     securityManager: SecurityManager,

--- a/infra/auth-store/src/test/java/com/simprints/infra/authstore/AuthStoreImplTest.kt
+++ b/infra/auth-store/src/test/java/com/simprints/infra/authstore/AuthStoreImplTest.kt
@@ -85,13 +85,6 @@ class AuthStoreImplTest {
     }
 
     @Test
-    fun `storeCredentials should call the correct method`() {
-        loginManagerManagerImpl.storeCredentials(PROJECT_ID)
-
-        verify(exactly = 1) { loginInfoStore.storeCredentials(PROJECT_ID) }
-    }
-
-    @Test
     fun `signIn should call the correct method`() = runTest(UnconfinedTestDispatcher()) {
         loginManagerManagerImpl.storeFirebaseToken(TOKEN)
 

--- a/infra/auth-store/src/test/java/com/simprints/infra/authstore/domain/LoginInfoStoreTest.kt
+++ b/infra/auth-store/src/test/java/com/simprints/infra/authstore/domain/LoginInfoStoreTest.kt
@@ -5,32 +5,86 @@ import android.content.SharedPreferences
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.tokenization.asTokenizableEncrypted
 import com.simprints.core.domain.tokenization.asTokenizableRaw
+import com.simprints.infra.security.SecurityManager
+import io.mockk.MockKAnnotations
 import io.mockk.every
-import io.mockk.mockk
+import io.mockk.impl.annotations.MockK
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
 
 class LoginInfoStoreTest {
 
-    private val ctx = mockk<Context>()
-    private val sharedPreferences = mockk<SharedPreferences>()
-    private val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+    @MockK
+    private lateinit var ctx: Context
+
+    @MockK
+    private lateinit var securityManager: SecurityManager
+
+    @MockK
+    private lateinit var legacySharedPreferences: SharedPreferences
+
+    @MockK
+    private lateinit var legacyEditor: SharedPreferences.Editor
+
+    @MockK
+    private lateinit var secureSharedPreferences: SharedPreferences
+
+    @MockK
+    private lateinit var secureEditor: SharedPreferences.Editor
 
     private lateinit var loginInfoStoreImpl: LoginInfoStore
 
     @Before
     fun setup() {
-        every { ctx.getSharedPreferences(any(), any()) } returns sharedPreferences
-        every { sharedPreferences.edit() } returns editor
-        every { editor.putString(any(), any()) } returns editor
-        loginInfoStoreImpl = LoginInfoStore(ctx)
+        MockKAnnotations.init(this, relaxed = true)
+
+        every { ctx.getSharedPreferences(any(), any()) } returns legacySharedPreferences
+        every { legacySharedPreferences.edit() } returns legacyEditor
+
+        every { securityManager.buildEncryptedSharedPreferences(any()) } returns secureSharedPreferences
+        every { secureSharedPreferences.edit() } returns secureEditor
+
+        every { secureEditor.putString(any(), any()) } returns secureEditor
+        every { secureEditor.putBoolean(any(), any()) } returns secureEditor
+
+        loginInfoStoreImpl = LoginInfoStore(ctx, securityManager)
     }
 
     @Test
-    fun `getting the signed in user id should returns it`() {
-        every { sharedPreferences.getString(any(), any()) } returns "user"
-        every { sharedPreferences.getBoolean(any(), any()) } returns true
+    fun `should migrate data from legacy prefs to secure prefs`() {
+        every { legacySharedPreferences.contains(any()) } returns true
+        every { legacySharedPreferences.getString(any(), any()) } returns "old-value"
+        every { legacySharedPreferences.getBoolean(any(), any()) } returns true
+        every { secureSharedPreferences.getString(any(), any()) } returns "new-value"
+
+        val result = loginInfoStoreImpl.signedInProjectId
+
+        verify {
+            // check any amount of save data
+            secureEditor.putString(any(), any())
+            secureEditor.putBoolean(any(), any())
+        }
+        verify(exactly = 1) {
+            secureEditor.commit()
+            // Check that legacy prefs cleared
+            legacyEditor.clear()
+            legacyEditor.commit()
+        }
+    }
+
+    @Test
+    fun `getting the signed in encrypted user id should returns it`() {
+        every { secureSharedPreferences.getString(any(), any()) } returns "user"
+        every { secureSharedPreferences.getBoolean(any(), any()) } returns true
+
+        assertThat(loginInfoStoreImpl.signedInUserId).isEqualTo("user".asTokenizableEncrypted())
+    }
+
+    @Test
+    fun `getting the signed in raw user id should return it`() {
+        every { secureSharedPreferences.getString(any(), any()) } returns "user"
+        every { secureSharedPreferences.getBoolean(any(), any()) } returns false
 
         assertThat(loginInfoStoreImpl.signedInUserId).isEqualTo("user".asTokenizableRaw())
     }
@@ -39,21 +93,32 @@ class LoginInfoStoreTest {
     fun `setting the raw signed in user id should set in the shared preferences`() {
         loginInfoStoreImpl.signedInUserId = "user".asTokenizableRaw()
 
-        verify(exactly = 1) { editor.putString("USER_ID", "user") }
-        verify(exactly = 1) { editor.putBoolean("USER_ID_TOKENIZED", false) }
+        verify(exactly = 1) {
+            secureEditor.putString("USER_ID", "user")
+            secureEditor.putBoolean("USER_ID_TOKENIZED", false)
+        }
     }
 
     @Test
     fun `setting the tokenized signed in user id should set in the shared preferences`() {
         loginInfoStoreImpl.signedInUserId = "user".asTokenizableEncrypted()
 
-        verify(exactly = 1) { editor.putString("USER_ID", "user") }
-        verify(exactly = 1) { editor.putBoolean("USER_ID_TOKENIZED", true) }
+        verify(exactly = 1) {
+            secureEditor.putString("USER_ID", "user")
+            secureEditor.putBoolean("USER_ID_TOKENIZED", true)
+        }
+    }
+
+    @Test
+    fun `setting the null to user id should clear it from the shared preferences`() {
+        loginInfoStoreImpl.signedInUserId = null
+
+        verify { secureEditor.remove(any()) }
     }
 
     @Test
     fun `getting the signed in project id should returns it`() {
-        every { sharedPreferences.getString(any(), any()) } returns "projectId"
+        every { secureSharedPreferences.getString(any(), any()) } returns "projectId"
 
         assertThat(loginInfoStoreImpl.signedInProjectId).isEqualTo("projectId")
     }
@@ -62,66 +127,70 @@ class LoginInfoStoreTest {
     fun `setting the signed in project id should set in the shared preferences`() {
         loginInfoStoreImpl.signedInProjectId = "projectId"
 
-        verify(exactly = 1) { editor.putString("PROJECT_ID", "projectId") }
-        verify(exactly = 1) { editor.apply() }
+        verify(exactly = 1) {
+            secureEditor.putString("PROJECT_ID", "projectId")
+            secureEditor.apply()
+        }
     }
 
     @Test
     fun `getting the core firebase project id should returns it`() {
-        every { sharedPreferences.getString(any(), any()) } returns "firebase"
+        every { secureSharedPreferences.getString(any(), any()) } returns "firebase"
 
         assertThat(loginInfoStoreImpl.coreFirebaseProjectId).isEqualTo("firebase")
     }
 
     @Test
     fun `getting the core firebase project id should returns an empty string if null`() {
-        every { sharedPreferences.getString(any(), any()) } returns null
+        every { secureSharedPreferences.getString(any(), any()) } returns null
 
         assertThat(loginInfoStoreImpl.coreFirebaseProjectId).isEqualTo("")
     }
-
 
     @Test
     fun `setting the core firebase project id should set in the shared preferences`() {
         loginInfoStoreImpl.coreFirebaseProjectId = "firebase"
 
-        verify(exactly = 1) { editor.putString("CORE_FIREBASE_PROJECT_ID", "firebase") }
-        verify(exactly = 1) { editor.apply() }
+        verify(exactly = 1) {
+            secureEditor.putString("CORE_FIREBASE_PROJECT_ID", "firebase")
+            secureEditor.apply()
+        }
     }
 
     @Test
     fun `getting the core firebase application id should returns it`() {
-        every { sharedPreferences.getString(any(), any()) } returns "firebase"
+        every { secureSharedPreferences.getString(any(), any()) } returns "firebase"
 
         assertThat(loginInfoStoreImpl.coreFirebaseApplicationId).isEqualTo("firebase")
     }
 
     @Test
     fun `getting the core firebase application id should returns an empty string if null`() {
-        every { sharedPreferences.getString(any(), any()) } returns null
+        every { secureSharedPreferences.getString(any(), any()) } returns null
 
         assertThat(loginInfoStoreImpl.coreFirebaseApplicationId).isEqualTo("")
     }
-
 
     @Test
     fun `setting the core firebase application id should set in the shared preferences`() {
         loginInfoStoreImpl.coreFirebaseApplicationId = "firebase"
 
-        verify(exactly = 1) { editor.putString("CORE_FIREBASE_APPLICATION_ID", "firebase") }
-        verify(exactly = 1) { editor.apply() }
+        verify(exactly = 1) {
+            secureEditor.putString("CORE_FIREBASE_APPLICATION_ID", "firebase")
+            secureEditor.apply()
+        }
     }
 
     @Test
     fun `getting the core firebase api key should returns it`() {
-        every { sharedPreferences.getString(any(), any()) } returns "firebase"
+        every { secureSharedPreferences.getString(any(), any()) } returns "firebase"
 
         assertThat(loginInfoStoreImpl.coreFirebaseApiKey).isEqualTo("firebase")
     }
 
     @Test
     fun `getting the core firebase api key should returns an empty string if null`() {
-        every { sharedPreferences.getString(any(), any()) } returns null
+        every { secureSharedPreferences.getString(any(), any()) } returns null
 
         assertThat(loginInfoStoreImpl.coreFirebaseApiKey).isEqualTo("")
     }
@@ -130,27 +199,29 @@ class LoginInfoStoreTest {
     fun `setting the core firebase api key should set in the shared preferences`() {
         loginInfoStoreImpl.coreFirebaseApiKey = "firebase"
 
-        verify(exactly = 1) { editor.putString("CORE_FIREBASE_API_KEY", "firebase") }
-        verify(exactly = 1) { editor.apply() }
+        verify(exactly = 1) {
+            secureEditor.putString("CORE_FIREBASE_API_KEY", "firebase")
+            secureEditor.apply()
+        }
     }
 
     @Test
     fun `getSignedInProjectIdOrEmpty should return an empty string if null`() {
-        every { sharedPreferences.getString(any(), any()) } returns null
+        every { secureSharedPreferences.getString(any(), any()) } returns null
 
         assertThat(loginInfoStoreImpl.signedInProjectId).isEqualTo("")
     }
 
     @Test
     fun `getSignedInProjectIdOrEmpty should return the signed in project id`() {
-        every { sharedPreferences.getString(any(), any()) } returns "project"
+        every { secureSharedPreferences.getString(any(), any()) } returns "project"
 
         assertThat(loginInfoStoreImpl.signedInProjectId).isEqualTo("project")
     }
 
     @Test
     fun `getting the project id claim should returns the string`() {
-        every { sharedPreferences.getString(any(), any()) } returns "project"
+        every { secureSharedPreferences.getString(any(), any()) } returns "project"
 
         assertThat(loginInfoStoreImpl.projectIdTokenClaim).isEqualTo("project")
     }
@@ -159,27 +230,29 @@ class LoginInfoStoreTest {
     fun `setting the project id claim should set in the shared preferences`() {
         loginInfoStoreImpl.projectIdTokenClaim = "project"
 
-        verify(exactly = 1) { editor.putString("PROJECT_ID_CLAIM", "project") }
-        verify(exactly = 1) { editor.apply() }
+        verify(exactly = 1) {
+            secureEditor.putString("PROJECT_ID_CLAIM", "project")
+            secureEditor.apply()
+        }
     }
 
     @Test
     fun `isProjectIdSignedIn should return false if the signed in project id is empty`() {
-        every { sharedPreferences.getString(any(), any()) } returns ""
+        every { secureSharedPreferences.getString(any(), any()) } returns ""
 
         assertThat(loginInfoStoreImpl.isProjectIdSignedIn("project")).isFalse()
     }
 
     @Test
     fun `isProjectIdSignedIn should return false if the signed in project id is different`() {
-        every { sharedPreferences.getString(any(), any()) } returns "another project"
+        every { secureSharedPreferences.getString(any(), any()) } returns "another project"
 
         assertThat(loginInfoStoreImpl.isProjectIdSignedIn("project")).isFalse()
     }
 
     @Test
     fun `isProjectIdSignedIn should return false if the signed in project id is the same`() {
-        every { sharedPreferences.getString(any(), any()) } returns "project"
+        every { secureSharedPreferences.getString(any(), any()) } returns "project"
 
         assertThat(loginInfoStoreImpl.isProjectIdSignedIn("project")).isTrue()
     }
@@ -188,22 +261,26 @@ class LoginInfoStoreTest {
     fun `cleanCredentials should reset all the credentials`() {
         loginInfoStoreImpl.cleanCredentials()
 
-        verify(exactly = 1) { editor.remove("USER_ID") }
-        verify(exactly = 1) { editor.remove("USER_ID_TOKENIZED") }
-        verify(exactly = 1) { editor.putString("PROJECT_ID", "") }
-        verify(exactly = 1) { editor.putString("ENCRYPTED_PROJECT_SECRET", "") }
-        verify(exactly = 1) { editor.putString("PROJECT_ID_CLAIM", "") }
-        verify(exactly = 1) { editor.putString("CORE_FIREBASE_PROJECT_ID", "") }
-        verify(exactly = 1) { editor.putString("CORE_FIREBASE_APPLICATION_ID", "") }
-        verify(exactly = 1) { editor.putString("CORE_FIREBASE_API_KEY", "") }
-        verify(exactly = 7) { editor.apply() }
+        verify(exactly = 1) {
+            secureEditor.clear()
+            secureEditor.apply()
+        }
+    }
+
+    @Test
+    fun `clearCachedTokenClaims should reset firebase claims`() {
+        loginInfoStoreImpl.clearCachedTokenClaims()
+
+        verify(exactly = 4) { secureEditor.remove(any()) }
     }
 
     @Test
     fun `storeCredentials should set the credentials`() {
         loginInfoStoreImpl.storeCredentials("project")
 
-        verify(exactly = 1) { editor.putString("PROJECT_ID", "project") }
-        verify(exactly = 1) { editor.apply() }
+        verify(exactly = 1) {
+            secureEditor.putString("PROJECT_ID", "project")
+            secureEditor.apply()
+        }
     }
 }

--- a/infra/auth-store/src/test/java/com/simprints/infra/authstore/domain/LoginInfoStoreTest.kt
+++ b/infra/auth-store/src/test/java/com/simprints/infra/authstore/domain/LoginInfoStoreTest.kt
@@ -273,14 +273,4 @@ class LoginInfoStoreTest {
 
         verify(exactly = 4) { secureEditor.remove(any()) }
     }
-
-    @Test
-    fun `storeCredentials should set the credentials`() {
-        loginInfoStoreImpl.storeCredentials("project")
-
-        verify(exactly = 1) {
-            secureEditor.putString("PROJECT_ID", "project")
-            secureEditor.apply()
-        }
-    }
 }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/common/EventSyncCache.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/common/EventSyncCache.kt
@@ -10,8 +10,10 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import java.util.*
 import javax.inject.Inject
+import javax.inject.Singleton
 
 @SuppressLint("ApplySharedPref")
+@Singleton
 internal class EventSyncCache @Inject constructor(
     securityManager: SecurityManager,
     @DispatcherIO private val dispatcher: CoroutineDispatcher,

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/common/EventSyncCacheTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/common/EventSyncCacheTest.kt
@@ -160,6 +160,4 @@ class EventSyncCacheTest {
         }
     }
 
-    // TODO: Add more tests
-
 }

--- a/infra/orchestrator-data/src/main/java/com/simprints/infra/orchestration/data/results/AppResult.kt
+++ b/infra/orchestrator-data/src/main/java/com/simprints/infra/orchestration/data/results/AppResult.kt
@@ -3,7 +3,6 @@ package com.simprints.infra.orchestration.data.results
 import android.os.Bundle
 import java.io.Serializable
 
-//TODO: Keep?
 data class AppResult(
     val resultCode: Int,
     val extras: Bundle,


### PR DESCRIPTION
* Switch LoginInfoStore to use encrypted shared prefs with data migration on the first data access.
* Some minor related cleanup - deleted redundant method in AuthStore/LoginInfoStore and deleted useless TODOs.

Note that this change adds a bit of startup time - on my Sony F8331 with Android 8 cold app start from launcher to dashboard changes from around 6-7s to 8-9s. 