### PR TITLE
MS-42 Out-of-session event scope upload

### DIFF
--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/ApiUploadEventsBody.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/ApiUploadEventsBody.kt
@@ -5,5 +5,7 @@ import com.simprints.infra.eventsync.event.remote.models.session.ApiEventScope
 
 @Keep
 internal data class ApiUploadEventsBody(
-    val sessions: List<ApiEventScope>,
+    val sessions: List<ApiEventScope> = emptyList(),
+    val eventUpSyncs: List<ApiEventScope> = emptyList(),
+    val eventDownSyncs: List<ApiEventScope> = emptyList(),
 )

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/EventRemoteDataSource.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/EventRemoteDataSource.kt
@@ -8,12 +8,9 @@ import com.fasterxml.jackson.core.JsonToken.START_OBJECT
 import com.simprints.core.tools.json.JsonHelper
 import com.simprints.infra.authstore.AuthStore
 import com.simprints.infra.events.event.domain.EventCount
-import com.simprints.infra.events.event.domain.models.Event
-import com.simprints.infra.events.event.domain.models.scope.EventScope
 import com.simprints.infra.events.event.domain.models.subject.EnrolmentRecordEvent
 import com.simprints.infra.eventsync.event.remote.exceptions.TooManyRequestsException
 import com.simprints.infra.eventsync.event.remote.models.fromApiToDomain
-import com.simprints.infra.eventsync.event.remote.models.session.ApiEventScope
 import com.simprints.infra.eventsync.event.remote.models.subject.ApiEnrolmentRecordEvent
 import com.simprints.infra.eventsync.event.remote.models.subject.fromApiToDomain
 import com.simprints.infra.eventsync.status.down.domain.EventDownSyncResult
@@ -124,13 +121,10 @@ internal class EventRemoteDataSource @Inject constructor(
 
     suspend fun post(
         projectId: String,
-        eventScopes: Map<EventScope, List<Event>>,
+        body: ApiUploadEventsBody,
         acceptInvalidEvents: Boolean = true,
     ): EventUpSyncResult {
         val response = executeCall { remoteInterface ->
-            val body = ApiUploadEventsBody(
-                eventScopes.map { (scope, events) -> ApiEventScope.fromDomain(scope, events) }
-            )
             remoteInterface.uploadEvents(projectId, acceptInvalidEvents, body)
         }
 

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/EventDownSyncTask.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/EventDownSyncTask.kt
@@ -106,27 +106,30 @@ internal class EventDownSyncTask @Inject constructor(
             emitProgress(lastOperation, count, count)
         }
 
-        eventRepository.addOrUpdateEvent(
-            eventScope,
-            EventDownSyncRequestEvent(
-                createdAt = requestStartTime,
-                endedAt = timeHelper.now(),
-                requestId = result?.requestId.orEmpty(),
-                query = operation.queryEvent.let { query ->
-                    EventDownSyncRequestEvent.QueryParameters(
-                        query.moduleId,
-                        query.attendantId,
-                        query.subjectId,
-                        query.modes.map { it.name },
-                        query.lastEventId
-                    )
-                },
-                msToFirstResponseByte = firstEventTimestamp?.let { it.ms - requestStartTime.ms },
-                eventRead = count,
-                errorType = errorType,
-                responseStatus = result?.status,
+        if (count > 0 || errorType != null) {
+            // Track only events that have any useful data
+            eventRepository.addOrUpdateEvent(
+                eventScope,
+                EventDownSyncRequestEvent(
+                    createdAt = requestStartTime,
+                    endedAt = timeHelper.now(),
+                    requestId = result?.requestId.orEmpty(),
+                    query = operation.queryEvent.let { query ->
+                        EventDownSyncRequestEvent.QueryParameters(
+                            query.moduleId,
+                            query.attendantId,
+                            query.subjectId,
+                            query.modes.map { it.name },
+                            query.lastEventId
+                        )
+                    },
+                    msToFirstResponseByte = firstEventTimestamp?.let { it.ms - requestStartTime.ms },
+                    eventRead = count,
+                    errorType = errorType,
+                    responseStatus = result?.status,
+                )
             )
-        )
+        }
     }
 
     private suspend fun FlowCollector<EventDownSyncProgress>.emitProgress(

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
@@ -126,12 +126,17 @@ internal class EventUpSyncTask @Inject constructor(
                 .mapValues { (_, events) ->
                     events?.let { filterEventsToUpSync(events, config) }.orEmpty()
                 }
+                .map { (scope, events) -> ApiEventScope.fromDomain(scope, events) }
+
             if (scopesToUpload.isNotEmpty()) {
-                result = eventRemoteDataSource.post(projectId, scopesToUpload)
+                result = eventRemoteDataSource.post(
+                    projectId,
+                    ApiUploadEventsBody(sessions = scopesToUpload)
+                )
             }
 
             Simber.d("[EVENT_REPO] Deleting ${scopesToUpload.size} session scopes")
-            scopesToUpload.keys.forEach { eventRepository.deleteEventScope(it.id) }
+            scopesToUpload.forEach { eventRepository.deleteEventScope(it.id) }
 
             addRequestEvent(
                 eventScope = eventScope,

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
@@ -229,7 +229,10 @@ internal class EventUpSyncTask @Inject constructor(
         uploadedUpSyncScopes: Int = 0,
         uploadedDownSyncScopes: Int = 0,
     ) {
-        if (uploadedSessionScopes > 0 || uploadedUpSyncScopes > 0 || uploadedDownSyncScopes > 0) {
+        if (uploadedSessionScopes > 0 || uploadedDownSyncScopes > 0) {
+            // Not tracking cases when only up sync scopes are uploaded as it is likely
+            // to cause a feedback loop of up-syncing the previous up-sync event.
+
             eventRepository.addOrUpdateEvent(
                 eventScope,
                 EventUpSyncRequestEvent(

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
@@ -69,16 +69,19 @@ internal class EventUpSyncTask @Inject constructor(
 
             uploadSessionEvents(projectId = operation.projectId, config, eventScope).collect {
                 count = it
-                lastOperation = lastOperation.copy(lastState = RUNNING, lastSyncTime = timeHelper.now().ms)
+                lastOperation =
+                    lastOperation.copy(lastState = RUNNING, lastSyncTime = timeHelper.now().ms)
                 emitProgress(lastOperation, count)
             }
             uploadOutOfSessionEvents(operation.projectId, eventScope).collect {
                 count = it
-                lastOperation = lastOperation.copy(lastState = RUNNING, lastSyncTime = timeHelper.now().ms)
+                lastOperation =
+                    lastOperation.copy(lastState = RUNNING, lastSyncTime = timeHelper.now().ms)
                 emitProgress(lastOperation, count)
             }
 
-            lastOperation = lastOperation.copy(lastState = COMPLETE, lastSyncTime = timeHelper.now().ms)
+            lastOperation =
+                lastOperation.copy(lastState = COMPLETE, lastSyncTime = timeHelper.now().ms)
             emitProgress(lastOperation, count)
         } catch (t: Throwable) {
             Simber.e(t)
@@ -226,18 +229,20 @@ internal class EventUpSyncTask @Inject constructor(
         uploadedUpSyncScopes: Int = 0,
         uploadedDownSyncScopes: Int = 0,
     ) {
-        eventRepository.addOrUpdateEvent(
-            eventScope,
-            EventUpSyncRequestEvent(
-                createdAt = startTime,
-                endedAt = timeHelper.now(),
-                requestId = result.requestId,
-                sessionCount = uploadedSessionScopes,
-                eventUpSyncCount = uploadedUpSyncScopes,
-                eventDownSyncCount = uploadedDownSyncScopes,
-                responseStatus = result.status,
+        if (uploadedSessionScopes > 0 || uploadedUpSyncScopes > 0 || uploadedDownSyncScopes > 0) {
+            eventRepository.addOrUpdateEvent(
+                eventScope,
+                EventUpSyncRequestEvent(
+                    createdAt = startTime,
+                    endedAt = timeHelper.now(),
+                    requestId = result.requestId,
+                    sessionCount = uploadedSessionScopes,
+                    eventUpSyncCount = uploadedUpSyncScopes,
+                    eventDownSyncCount = uploadedDownSyncScopes,
+                    responseStatus = result.status,
+                )
             )
-        )
+        }
     }
 
     private suspend fun handleFailedRequest(

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/EventRemoteDataSourceTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/EventRemoteDataSourceTest.kt
@@ -5,6 +5,7 @@ import com.simprints.core.tools.json.JsonHelper
 import com.simprints.infra.authstore.AuthStore
 import com.simprints.infra.events.event.domain.EventCount
 import com.simprints.infra.events.event.domain.models.Event
+import com.simprints.infra.events.event.domain.models.scope.EventScopeType
 import com.simprints.infra.events.event.domain.models.subject.EnrolmentRecordEvent
 import com.simprints.infra.events.event.domain.models.subject.EnrolmentRecordEventType
 import com.simprints.infra.events.sampledata.SampleDefaults.DEFAULT_MODULE_ID
@@ -323,7 +324,12 @@ class EventRemoteDataSourceTest {
 
         val events = listOf(createAlertScreenEvent())
         val scope = createSessionScope()
-        eventRemoteDataSource.post(DEFAULT_PROJECT_ID, mapOf(scope to events))
+        eventRemoteDataSource.post(
+            DEFAULT_PROJECT_ID,
+            ApiUploadEventsBody(
+                sessions = listOf(ApiEventScope.fromDomain(scope, events))
+            )
+        )
 
         coVerify(exactly = 1) {
             eventRemoteInterface.uploadEvents(
@@ -353,7 +359,7 @@ class EventRemoteDataSourceTest {
             assertThrows<Throwable> {
                 eventRemoteDataSource.post(
                     DEFAULT_PROJECT_ID,
-                    mapOf(createSessionScope() to listOf(createAlertScreenEvent()))
+                    ApiUploadEventsBody()
                 )
             }
         }

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/down/tasks/EventDownSyncTaskTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/down/tasks/EventDownSyncTaskTest.kt
@@ -170,6 +170,17 @@ class EventDownSyncTaskTest {
     }
 
     @Test
+    fun downSync_shouldNotAddEventToProvidedScopeIfNoEvents() = runTest {
+        mockProgressEmission(emptyList())
+
+        eventDownSyncTask.downSync(this, projectOp, eventScope).toList()
+
+        coVerify(exactly = 0) {
+            eventRepository.addOrUpdateEvent(any(), any())
+        }
+    }
+
+    @Test
     fun downSync_shouldEmitAFailureIfDownloadFails() = runTest {
         coEvery { eventRemoteDataSource.getEvents(any(), any()) } throws Throwable("IO Exception")
 

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTaskTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTaskTest.kt
@@ -99,7 +99,7 @@ internal class EventUpSyncTaskTest {
 
     @Test
     fun `upload fetches events for all provided closed sessions`() = runTest {
-        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.NONE)
+        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.ALL)
 
         coEvery { eventRepo.getClosedEventScopes(any()) } returns emptyList()
         coEvery { eventRepo.getClosedEventScopes(EventScopeType.SESSION) } returns listOf(
@@ -240,7 +240,7 @@ internal class EventUpSyncTaskTest {
 
     @Test
     fun `upload in progress should emit progress`() = runTest {
-        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.NONE)
+        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.ALL)
 
         coEvery { eventRepo.getClosedEventScopes(any()) } returns emptyList()
         coEvery { eventRepo.getClosedEventScopes(EventScopeType.SESSION) } returns listOf(
@@ -264,7 +264,7 @@ internal class EventUpSyncTaskTest {
 
     @Test
     fun `when upload fails due to generic error should not delete session events`() = runTest {
-        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.NONE)
+        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.ALL)
 
         coEvery { eventRepo.getClosedEventScopes(any()) } returns listOf(createSessionScope(GUID1))
         coEvery {
@@ -280,7 +280,7 @@ internal class EventUpSyncTaskTest {
 
     @Test
     fun `when upload fails due to network issue should not delete session events`() = runTest {
-        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.NONE)
+        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.ALL)
 
         coEvery { eventRepo.getClosedEventScopes(any()) } returns emptyList()
         coEvery { eventRepo.getClosedEventScopes(EventScopeType.SESSION) } returns listOf(
@@ -396,7 +396,7 @@ internal class EventUpSyncTaskTest {
 
     @Test
     fun `upload should save request event for each upload request`() = runTest {
-        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.NONE)
+        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.ALL)
 
         coEvery { eventRepo.getClosedEventScopes(any()) } returns listOf(
             createSessionScope(GUID1),
@@ -420,7 +420,7 @@ internal class EventUpSyncTaskTest {
 
     @Test
     fun `upload fetches events for all non-session scopes`() = runTest {
-        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.NONE)
+        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.ALL)
 
         coEvery { eventRepo.getClosedEventScopes(EventScopeType.SESSION) } returns emptyList()
         coEvery { eventRepo.getClosedEventScopes(EventScopeType.UP_SYNC) } returns listOf(
@@ -444,7 +444,7 @@ internal class EventUpSyncTaskTest {
 
     @Test
     fun `upload reports separate events for session and out-of-session scopes`() = runTest {
-        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.NONE)
+        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.ALL)
 
         coEvery { eventRepo.getClosedEventScopes(EventScopeType.SESSION) } returns listOf(
             createSessionScope(GUID1),
@@ -471,6 +471,16 @@ internal class EventUpSyncTaskTest {
                     it.payload.content == EventUpSyncRequestEvent.UpSyncContent(0, 1, 1)
             })
         }
+    }
+
+    @Test
+    fun `upload does not reports events if no scopes to upload`() = runTest {
+        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.ALL)
+        coEvery { eventRepo.getClosedEventScopes(any()) } returns emptyList()
+
+        eventUpSyncTask.upSync(operation, eventScope).toList()
+
+        coVerify(exactly = 0) { eventRepo.addOrUpdateEvent(any(), any()) }
     }
 
     private fun setUpSyncKind(kind: UpSynchronizationConfiguration.UpSynchronizationKind) {

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTaskTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTaskTest.kt
@@ -129,9 +129,8 @@ internal class EventUpSyncTaskTest {
             eventRemoteDataSource.post(
                 any(),
                 withArg {
-                    val (scope, events) = it.entries.first()
-                    assertThat(scope.id).isEqualTo(GUID1)
-                    assertThat(events).hasSize(2)
+                    assertThat(it.sessions.first().id).isEqualTo(GUID1)
+                    assertThat(it.sessions.first().events).hasSize(2)
                 },
                 any()
             )
@@ -159,9 +158,8 @@ internal class EventUpSyncTaskTest {
             eventRemoteDataSource.post(
                 any(),
                 withArg {
-                    val (scope, events) = it.entries.first()
-                    assertThat(scope.id).isEqualTo(GUID1)
-                    assertThat(events).hasSize(4)
+                    assertThat(it.sessions.first().id).isEqualTo(GUID1)
+                    assertThat(it.sessions.first().events).hasSize(4)
                 },
                 any()
             )
@@ -188,9 +186,8 @@ internal class EventUpSyncTaskTest {
             eventRemoteDataSource.post(
                 any(),
                 withArg {
-                    val (scope, events) = it.entries.first()
-                    assertThat(scope.id).isEqualTo(GUID1)
-                    assertThat(events).hasSize(3)
+                    assertThat(it.sessions.first().id).isEqualTo(GUID1)
+                    assertThat(it.sessions.first().events).hasSize(3)
                 },
                 any()
             )

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTaskTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTaskTest.kt
@@ -477,6 +477,22 @@ internal class EventUpSyncTaskTest {
     fun `upload does not reports events if no scopes to upload`() = runTest {
         setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.ALL)
         coEvery { eventRepo.getClosedEventScopes(any()) } returns emptyList()
+        coEvery { eventRepo.getClosedEventScopes(EventScopeType.UP_SYNC) } returns listOf(
+            createSessionScope(GUID2),
+        )
+        coEvery {
+            eventRepo.getEventsFromScope(any())
+        } returns listOf(createEventWithSessionId(GUID1, GUID1))
+
+        eventUpSyncTask.upSync(operation, eventScope).toList()
+
+        coVerify(exactly = 0) { eventRepo.addOrUpdateEvent(any(), any()) }
+    }
+
+    @Test
+    fun `upload does not reports events if only up-sync scopes are present to upload`() = runTest {
+        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.ALL)
+        coEvery { eventRepo.getClosedEventScopes(any()) } returns emptyList()
 
         eventUpSyncTask.upSync(operation, eventScope).toList()
 

--- a/infra/events/src/debug/java/com/simprints/infra/events/sampledata/SampleDefaults.kt
+++ b/infra/events/src/debug/java/com/simprints/infra/events/sampledata/SampleDefaults.kt
@@ -20,6 +20,7 @@ object SampleDefaults {
 
     val GUID1 = UUID.randomUUID().toString()
     val GUID2 = UUID.randomUUID().toString()
+    val GUID3 = UUID.randomUUID().toString()
 
     val TIME1 = System.currentTimeMillis()
 

--- a/infra/events/src/main/java/com/simprints/infra/events/EventRepository.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/EventRepository.kt
@@ -21,6 +21,7 @@ interface EventRepository {
     suspend fun getOpenEventScopes(type: EventScopeType): List<EventScope>
     suspend fun getClosedEventScopes(type: EventScopeType): List<EventScope>
     suspend fun deleteEventScope(scopeId: String)
+    suspend fun deleteEventScopes(scopeIds: List<String>)
 
     suspend fun getEventsFromScope(scopeId: String): List<Event>
     suspend fun getEventsJsonFromScope(scopeId: String): List<String>

--- a/infra/events/src/main/java/com/simprints/infra/events/EventRepositoryImpl.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/EventRepositoryImpl.kt
@@ -81,6 +81,7 @@ internal open class EventRepositoryImpl @Inject constructor(
         eventLocalDataSource.saveEventScope(eventScope)
         return eventScope
     }
+
     override suspend fun getEventScope(downSyncEventScopeId: String): EventScope? =
         eventLocalDataSource.loadEventScope(downSyncEventScopeId)
 
@@ -123,6 +124,11 @@ internal open class EventRepositoryImpl @Inject constructor(
     override suspend fun deleteEventScope(scopeId: String) = reportException {
         eventLocalDataSource.deleteEventScope(scopeId = scopeId)
         eventLocalDataSource.deleteEventsInScope(scopeId = scopeId)
+    }
+
+    override suspend fun deleteEventScopes(scopeIds: List<String>) = reportException {
+        eventLocalDataSource.deleteEventScopes(scopeIds = scopeIds)
+        eventLocalDataSource.deleteEventsInScopes(scopeIds = scopeIds)
     }
 
     override suspend fun getEventsFromScope(scopeId: String): List<Event> =

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/EventLocalDataSource.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/EventLocalDataSource.kt
@@ -118,6 +118,12 @@ internal open class EventLocalDataSource @Inject constructor(
         scopeDao.delete(listOf(scopeId))
     }
 
+    suspend fun deleteEventScopes(scopeIds: List<String>) = useRoom(writingContext) {
+        scopeIds.chunked(SQLITE_VARIABLE_LIMIT).forEach { chunk ->
+            scopeDao.delete(chunk)
+        }
+    }
+
     suspend fun saveEvent(event: Event) = useRoom(writingContext) {
         eventDao.insertOrUpdate(event.fromDomainToDb())
     }
@@ -146,8 +152,20 @@ internal open class EventLocalDataSource @Inject constructor(
         eventDao.deleteAllFromScope(scopeId = scopeId)
     }
 
+    suspend fun deleteEventsInScopes(scopeIds: List<String>) = useRoom(writingContext) {
+        scopeIds.chunked(SQLITE_VARIABLE_LIMIT).forEach { chunk ->
+            eventDao.deleteAllFromScopes(scopeIds = chunk)
+        }
+    }
+
     suspend fun deleteAll() = useRoom(writingContext) {
         scopeDao.deleteAll()
         eventDao.deleteAll()
+    }
+
+    companion object {
+
+        // Actual limit is 999, but it is better to leave some wiggle room
+        private const val SQLITE_VARIABLE_LIMIT = 900
     }
 }

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/EventRoomDao.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/EventRoomDao.kt
@@ -29,6 +29,9 @@ internal interface EventRoomDao {
     @Query("delete from DbEvent where scopeId = :scopeId")
     suspend fun deleteAllFromScope(scopeId: String)
 
+    @Query("delete from DbEvent where scopeId in (:scopeIds)")
+    suspend fun deleteAllFromScopes(scopeIds: List<String>)
+
     @Query("delete from DbEvent")
     suspend fun deleteAll()
 

--- a/infra/events/src/test/java/com/simprints/infra/events/EventRepositoryImplTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/EventRepositoryImplTest.kt
@@ -221,6 +221,16 @@ internal class EventRepositoryImplTest {
     }
 
     @Test
+    fun `deleting scope should delete events in scopes`() = runTest {
+        eventRepo.deleteEventScopes(listOf("scopeId"))
+
+        coVerify {
+            eventLocalDataSource.deleteEventScopes(listOf("scopeId"))
+            eventLocalDataSource.deleteEventsInScopes(listOf("scopeId"))
+        }
+    }
+
+    @Test
     fun `should delegate event fetch`() = runTest {
         eventRepo.getEventsFromScope("scopeId")
 


### PR DESCRIPTION
Notable changes: 
* Added up-sync and down-sync type event scopes to the event up-sync task as a separate request.
* Changed the session event upload to happen in batches of arbitrary size (for now). This value should be reviewed and adjusted once we get more information.
* Added checks to only create request events with helpful information (e.g. skip down-sync attempts when there is nothing to sync). 
* Also, delete empty scopes on closing to even further reduce the amount of useless information to upload.