### PR TITLE
[MS-216] Missing spaces between sentences in consent text fix - appendSentence extracted

### DIFF
--- a/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/helpers/AppendUtil.kt
+++ b/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/helpers/AppendUtil.kt
@@ -1,0 +1,9 @@
+package com.simprints.feature.consent.screens.consent.helpers
+
+internal fun StringBuilder.appendSentence(text: String): StringBuilder {
+    if (isNotEmpty()) {
+        append(" ")
+    }
+    append(text)
+    return this
+}

--- a/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/helpers/GeneralConsentTextHelper.kt
+++ b/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/helpers/GeneralConsentTextHelper.kt
@@ -115,12 +115,4 @@ internal class GeneralConsentTextHelper @Inject constructor(
         GeneralConfiguration.Modality.FACE -> context.getString(R.string.consent_biometrics_access_face)
         GeneralConfiguration.Modality.FINGERPRINT -> context.getString(R.string.consent_biometrics_access_fingerprint)
     }
-
-    private fun StringBuilder.appendSentence(text: String): StringBuilder {
-        if (isNotEmpty()) {
-            append(" ")
-        }
-        append(text)
-        return this
-    }
 }

--- a/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/helpers/ParentalConsentTextHelper.kt
+++ b/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/helpers/ParentalConsentTextHelper.kt
@@ -117,12 +117,4 @@ internal class ParentalConsentTextHelper @Inject constructor(
         Modality.FINGERPRINT -> context.getString(R.string.consent_biometrics_access_fingerprint)
         else -> ""
     }
-
-    private fun StringBuilder.appendSentence(text: String): StringBuilder {
-        if (isNotEmpty()) {
-            append(" ")
-        }
-        append(text)
-        return this
-    }
 }

--- a/feature/consent/src/test/java/com/simprints/feature/consent/screens/consent/helpers/AppendUtilKtTest.kt
+++ b/feature/consent/src/test/java/com/simprints/feature/consent/screens/consent/helpers/AppendUtilKtTest.kt
@@ -1,0 +1,29 @@
+package com.simprints.feature.consent.screens.consent.helpers
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AppendUtilKtTest {
+
+    @Test
+    fun `should append first sentence without leading space`() {
+        val initialTextStringBuilder = StringBuilder()
+        val actualText = initialTextStringBuilder.appendSentence("Sentence 1.").toString()
+        val expectedText = "Sentence 1."
+
+        assertThat(actualText).isEqualTo(expectedText)
+    }
+
+    @Test
+    fun `should append non-first sentence with leading space`() {
+        val initialTextStringBuilder = StringBuilder("Sentence 1.")
+        val actualText = initialTextStringBuilder.appendSentence("Sentence 2.").toString()
+        val expectedText = "Sentence 1. Sentence 2."
+
+        assertThat(actualText).isEqualTo(expectedText)
+    }
+
+}


### PR DESCRIPTION
`StringBuilder.appendSentence` available for `consent` package only.