### PR TITLE
MS-233 GitHub Actions jobs execution time capped at vars.JOB_TIMEOUT_MINUTES

### DIFF
--- a/.github/workflows/deploy-to-firebase-distribution.yml
+++ b/.github/workflows/deploy-to-firebase-distribution.yml
@@ -11,6 +11,7 @@ on:
 jobs:
     deploy-to-firebase:
         runs-on: ubuntu-latest
+        timeout-minutes: ${{ fromJSON(vars.JOB_TIMEOUT_MINUTES) }}
 
         concurrency:
             group: firebase-${{ inputs.buildType }}-workflow #only one instance of this workflow can run at a time

--- a/.github/workflows/deploy-to-internal.yml
+++ b/.github/workflows/deploy-to-internal.yml
@@ -15,6 +15,7 @@ jobs:
     deploy-to-internal:
 
         runs-on: ubuntu-latest
+        timeout-minutes: ${{ fromJSON(vars.JOB_TIMEOUT_MINUTES) }}
 
         concurrency:
             group: release-internal-workflow #only one instance of this workflow can run at a time

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -14,6 +14,7 @@ jobs:
     sync:
         name: Sync Items
         runs-on: ubuntu-latest
+        timeout-minutes: ${{ fromJSON(vars.JOB_TIMEOUT_MINUTES) }}
         steps:
             -   name: Sync
                 uses: mheap/github-action-issue-to-jira@v1

--- a/.github/workflows/promote-artifact.yml
+++ b/.github/workflows/promote-artifact.yml
@@ -19,6 +19,7 @@ on:
 jobs:
     promote-artifact:
         runs-on: ubuntu-latest
+        timeout-minutes: ${{ fromJSON(vars.JOB_TIMEOUT_MINUTES) }}
 
         environment: ${{inputs.deployment-track}}   # Dynamically set the job environment based on the input
 

--- a/.github/workflows/refresh-gradle-cache.yml
+++ b/.github/workflows/refresh-gradle-cache.yml
@@ -9,6 +9,7 @@ on:
 jobs:
     refresh-caches:
         runs-on: ubuntu-latest
+        timeout-minutes: ${{ fromJSON(vars.JOB_TIMEOUT_MINUTES) }}
 
         env:
             GOOGLE_SERVICES_FILE: ${{ secrets.GOOGLE_SERVICES_FILE}}

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -18,6 +18,7 @@ jobs:
 
     test-modules:
         runs-on: ubuntu-latest
+        timeout-minutes: ${{ fromJSON(vars.JOB_TIMEOUT_MINUTES) }}
 
         env:
             GOOGLE_SERVICES_FILE: ${{ secrets.GOOGLE_SERVICES_FILE}}

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -10,6 +10,7 @@ jobs:
             GOOGLE_SERVICES_FILE: ${{ secrets.GOOGLE_SERVICES_FILE}}
 
         runs-on: ubuntu-latest
+        timeout-minutes: ${{ fromJSON(vars.JOB_TIMEOUT_MINUTES) }}
         steps:
             -   name: Checkout
                 uses: actions/checkout@v4


### PR DESCRIPTION
In case of issues with GitHub actions/jobs, they may get stuck and take all possible execution time, which is limited to 6 hours by default. A safer 30 minute limit String value is set in vars.JOB_TIMEOUT_MINUTES instead, and is converted to Int in the job configurations.