### PR TITLE
MS-205 Image upload halt when event sync starts

### DIFF
--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/tools/di/FakeCoreModule.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/tools/di/FakeCoreModule.kt
@@ -1,5 +1,6 @@
 package com.simprints.feature.dashboard.tools.di
 
+import com.simprints.core.AppScope
 import com.simprints.core.CoreModule
 import com.simprints.core.DeviceID
 import com.simprints.core.DispatcherIO
@@ -52,6 +53,10 @@ object FakeCoreModule {
     @ExternalScope
     @Provides
     fun provideExternalScope(): CoroutineScope = CoroutineScope(Dispatchers.Main + Job())
+
+    @AppScope
+    @Provides
+    fun provideAppScope(): CoroutineScope = CoroutineScope(Dispatchers.Main + Job())
 
     @Provides
     @Singleton

--- a/id/src/main/java/com/simprints/id/Application.kt
+++ b/id/src/main/java/com/simprints/id/Application.kt
@@ -16,6 +16,7 @@ import dagger.hilt.android.HiltAndroidApp
 import io.reactivex.exceptions.UndeliverableException
 import io.reactivex.plugins.RxJavaPlugins
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -42,6 +43,11 @@ open class Application : CoreApplication(), Configuration.Provider {
     override fun onCreate() {
         super.onCreate()
         initApplication()
+    }
+
+    override fun onTerminate() {
+        super.onTerminate()
+        appScope.cancel()
     }
 
     override val workManagerConfiguration: Configuration

--- a/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
+++ b/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
@@ -102,7 +102,7 @@ abstract class SimCoroutineWorker(
     }
 
     protected fun crashlyticsLog(message: String) {
-        Simber.tag(CrashReportTag.SYNC.name).i("$tag - $message")
+        Simber.tag(CrashReportTag.SYNC.name).i("$tag - $message".take(99))
     }
 
     private fun logExceptionIfRequired(t: Throwable?) {

--- a/infra/sync/src/main/java/com/simprints/infra/sync/SyncConstants.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/SyncConstants.kt
@@ -4,7 +4,8 @@ import java.util.concurrent.TimeUnit
 
 internal object SyncConstants {
 
-    val SYNC_REPEAT_UNIT = TimeUnit.MINUTES
+    val SYNC_TIME_UNIT = TimeUnit.MINUTES
+    const val DEFAULT_BACKOFF_INTERVAL_MINUTES = 5L
 
     const val PROJECT_SYNC_WORK_NAME = "project-sync-work-v2"
     const val PROJECT_SYNC_REPEAT_INTERVAL = BuildConfig.PROJECT_DOWN_SYNC_WORKER_INTERVAL_MINUTES

--- a/infra/sync/src/main/java/com/simprints/infra/sync/enrolments/EnrolmentRecordWorker.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/enrolments/EnrolmentRecordWorker.kt
@@ -5,6 +5,7 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.simprints.core.DispatcherIO
+import com.simprints.core.workers.SimCoroutineWorker
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.enrolment.records.store.EnrolmentRecordRepository
 import com.simprints.infra.sync.SyncConstants
@@ -20,9 +21,12 @@ class EnrolmentRecordWorker @AssistedInject constructor(
     private val enrolmentRecordRepository: EnrolmentRecordRepository,
     private val configRepository: ConfigRepository,
     @DispatcherIO private val dispatcher: CoroutineDispatcher,
-) : CoroutineWorker(context, params) {
+) : SimCoroutineWorker(context, params) {
+
+    override val tag: String = "EnrolmentRecordWorker"
 
     override suspend fun doWork(): Result = withContext(dispatcher) {
+        crashlyticsLog("Enrolment record upload start")
         try {
             val instructionId =
                 inputData.getString(SyncConstants.RECORD_UPLOAD_INPUT_ID_NAME)

--- a/infra/sync/src/main/java/com/simprints/infra/sync/extensions/WorkManager.ext.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/extensions/WorkManager.ext.kt
@@ -1,6 +1,7 @@
 package com.simprints.infra.sync.extensions
 
 import androidx.work.*
+import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
 import com.simprints.infra.sync.SyncConstants
 
 
@@ -8,6 +9,7 @@ internal fun defaultWorkerConstraints() = Constraints.Builder()
     .setRequiredNetworkType(NetworkType.CONNECTED)
     .build()
 
+@ExcludedFromGeneratedTestCoverageReports("Basic API wrapper to provide default values for most parameters")
 internal inline fun <reified T : ListenableWorker> WorkManager.schedulePeriodicWorker(
     workName: String,
     repeatInterval: Long,
@@ -29,6 +31,7 @@ internal inline fun <reified T : ListenableWorker> WorkManager.schedulePeriodicW
         .build()
 )
 
+@ExcludedFromGeneratedTestCoverageReports("Basic API wrapper to provide default values for most parameters")
 internal inline fun <reified T : ListenableWorker> WorkManager.startWorker(
     workName: String,
     existingWorkPolicy: ExistingWorkPolicy = ExistingWorkPolicy.KEEP,

--- a/infra/sync/src/main/java/com/simprints/infra/sync/firmware/FirmwareFileUpdateWorker.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/firmware/FirmwareFileUpdateWorker.kt
@@ -2,9 +2,9 @@ package com.simprints.infra.sync.firmware
 
 import android.content.Context
 import androidx.hilt.work.HiltWorker
-import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.simprints.core.DispatcherBG
+import com.simprints.core.workers.SimCoroutineWorker
 import com.simprints.fingerprint.infra.scanner.data.FirmwareRepository
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.exceptions.NetworkConnectionException
@@ -24,16 +24,17 @@ class FirmwareFileUpdateWorker @AssistedInject constructor(
     @Assisted params: WorkerParameters,
     private val firmwareRepository: FirmwareRepository,
     @DispatcherBG private val dispatcher: CoroutineDispatcher,
-) : CoroutineWorker(context, params) {
+) : SimCoroutineWorker(context, params) {
 
+    override val tag: String = "FirmwareFileUpdateWorker"
 
     override suspend fun doWork(): Result = withContext(dispatcher) {
+        crashlyticsLog("FirmwareFileUpdateWorker started")
         try {
-            Simber.d("FirmwareFileUpdateWorker started")
             firmwareRepository.updateStoredFirmwareFilesWithLatest()
             firmwareRepository.cleanUpOldFirmwareFiles()
 
-            Simber.d("FirmwareFileUpdateWorker succeeded")
+            crashlyticsLog("FirmwareFileUpdateWorker succeeded")
             Result.success()
         } catch (e: Throwable) {
             when {

--- a/infra/sync/src/main/java/com/simprints/infra/sync/images/ImageUpSyncWorker.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/images/ImageUpSyncWorker.kt
@@ -25,7 +25,6 @@ internal class ImageUpSyncWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result = withContext(dispatcher) {
         crashlyticsLog("Image upload start")
-        showProgressNotification()
 
         try {
             if (imageRepository.uploadStoredImagesAndDelete(authStore.signedInProjectId)) {

--- a/infra/sync/src/main/java/com/simprints/infra/sync/images/ImageUpSyncWorker.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/images/ImageUpSyncWorker.kt
@@ -21,7 +21,7 @@ internal class ImageUpSyncWorker @AssistedInject constructor(
     @DispatcherBG private val dispatcher: CoroutineDispatcher,
 ) : SimCoroutineWorker(context, params) {
 
-    override val tag: String = ImageUpSyncWorker::class.java.simpleName
+    override val tag: String = "ImageUpSyncWorker"
 
     override suspend fun doWork(): Result = withContext(dispatcher) {
         crashlyticsLog("Image upload start")


### PR DESCRIPTION
Main changes:
* Added a listener for event sync master worker state changes and cancel+reschedule image upload worker.

Things I learned in the process:
* `isStopped` flag in `CoroutineWorker` is completely useless. Cancelling the worker cancels the whole coroutine scope, and the code within the scope does not get a chance to check if it should stop 🤷🏻 
* Having foreground notification in a worker prevents if from being cancelled by the work manager. It also ignores the `isStopped` flag :D 
* Cancelling a periodic worker by ID seems to prevent future workers from being rescheduled, contrary to what the internet says.