### PR TITLE
MS-229 Event upload batch size config

### DIFF
--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/main/sync/SyncViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/main/sync/SyncViewModelTest.kt
@@ -23,6 +23,7 @@ import com.simprints.infra.config.store.models.DeviceConfiguration
 import com.simprints.infra.config.store.models.DownSynchronizationConfiguration
 import com.simprints.infra.config.store.models.ProjectState
 import com.simprints.infra.config.store.models.SynchronizationConfiguration
+import com.simprints.infra.config.store.models.UpSynchronizationConfiguration
 import com.simprints.infra.config.store.models.UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration
 import com.simprints.infra.config.store.models.UpSynchronizationConfiguration.UpSynchronizationKind.ALL
 import com.simprints.infra.eventsync.EventSyncManager
@@ -95,7 +96,7 @@ internal class SyncViewModelTest {
         every { eventSyncManager.getLastSyncState() } returns syncState
         every { connectivityTracker.observeIsConnected() } returns isConnected
         coEvery { configRepository.getProjectConfiguration().synchronization } returns mockk {
-            every { up.simprints } returns SimprintsUpSynchronizationConfiguration(kind = ALL)
+            every { up.simprints } returns SimprintsUpSynchronizationConfiguration(kind = ALL, batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes.default())
             every { frequency } returns SynchronizationConfiguration.Frequency.PERIODICALLY_AND_ON_SESSION_START
             every { down.partitionType } returns DownSynchronizationConfiguration.PartitionType.MODULE
         }

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/main/sync/SyncViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/main/sync/SyncViewModelTest.kt
@@ -96,7 +96,11 @@ internal class SyncViewModelTest {
         every { eventSyncManager.getLastSyncState() } returns syncState
         every { connectivityTracker.observeIsConnected() } returns isConnected
         coEvery { configRepository.getProjectConfiguration().synchronization } returns mockk {
-            every { up.simprints } returns SimprintsUpSynchronizationConfiguration(kind = ALL, batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes.default())
+            every { up.simprints } returns SimprintsUpSynchronizationConfiguration(
+                kind = ALL,
+                batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes.default(),
+                false,
+            )
             every { frequency } returns SynchronizationConfiguration.Frequency.PERIODICALLY_AND_ON_SESSION_START
             every { down.partitionType } returns DownSynchronizationConfiguration.PartitionType.MODULE
         }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/ConfigLocalDataSourceImpl.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/ConfigLocalDataSourceImpl.kt
@@ -181,11 +181,11 @@ internal class ConfigLocalDataSourceImpl @Inject constructor(
                         simprints = UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(
                             kind = UpSynchronizationConfiguration.UpSynchronizationKind.NONE,
                             batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes.default(),
+                            imagesRequireUnmeteredConnection = false,
                         ),
                         coSync = UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration(
                             kind = UpSynchronizationConfiguration.UpSynchronizationKind.NONE
                         ),
-                        imagesRequireUnmeteredConnection = false,
                     ),
                     down = DownSynchronizationConfiguration(
                         partitionType = DownSynchronizationConfiguration.PartitionType.USER,

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/ConfigLocalDataSourceImpl.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/ConfigLocalDataSourceImpl.kt
@@ -179,7 +179,8 @@ internal class ConfigLocalDataSourceImpl @Inject constructor(
                     frequency = SynchronizationConfiguration.Frequency.PERIODICALLY,
                     up = UpSynchronizationConfiguration(
                         simprints = UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(
-                            kind = UpSynchronizationConfiguration.UpSynchronizationKind.NONE
+                            kind = UpSynchronizationConfiguration.UpSynchronizationKind.NONE,
+                            batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes.default(),
                         ),
                         coSync = UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration(
                             kind = UpSynchronizationConfiguration.UpSynchronizationKind.NONE

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/models/OldProjectConfig.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/models/OldProjectConfig.kt
@@ -197,7 +197,12 @@ internal data class OldProjectConfig(
                         UpSynchronizationConfiguration.UpSynchronizationKind.valueOf(
                             simprintsSync
                         )
-                    }
+                    },
+                    batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes(
+                        sessions = 1,
+                        upSyncs = 1,
+                        downSyncs = 1,
+                    ),
                 ),
                 coSync = UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration(
                     kind = if (coSync == null) {

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/models/OldProjectConfig.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/models/OldProjectConfig.kt
@@ -203,6 +203,7 @@ internal data class OldProjectConfig(
                         upSyncs = 1,
                         downSyncs = 1,
                     ),
+                    imagesRequireUnmeteredConnection = false,
                 ),
                 coSync = UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration(
                     kind = if (coSync == null) {
@@ -217,7 +218,6 @@ internal data class OldProjectConfig(
                         )
                     }
                 ),
-                imagesRequireUnmeteredConnection = false,
             ),
             down = DownSynchronizationConfiguration(
                 partitionType = DownSynchronizationConfiguration.PartitionType.valueOf(

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/models/UpSynchronizationConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/models/UpSynchronizationConfiguration.kt
@@ -7,13 +7,13 @@ internal fun UpSynchronizationConfiguration.toProto(): ProtoUpSynchronizationCon
     ProtoUpSynchronizationConfiguration.newBuilder()
         .setSimprints(simprints.toProto())
         .setCoSync(coSync.toProto())
-        .setImagesRequireUnmeteredConnection(imagesRequireUnmeteredConnection)
         .build()
 
 internal fun UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration.toProto(): ProtoUpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration =
     ProtoUpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration.newBuilder()
         .setKind(kind.toProto())
         .setBatchSizes(batchSizes.toProto())
+        .setImagesRequireUnmeteredConnection(imagesRequireUnmeteredConnection)
         .build()
 
 internal fun UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration.toProto(): ProtoUpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration =
@@ -36,10 +36,10 @@ internal fun UpSynchronizationConfiguration.UpSyncBatchSizes.toProto(): ProtoUpS
         .build()
 
 internal fun ProtoUpSynchronizationConfiguration.toDomain(): UpSynchronizationConfiguration =
-    UpSynchronizationConfiguration(simprints.toDomain(), coSync.toDomain(), imagesRequireUnmeteredConnection)
+    UpSynchronizationConfiguration(simprints.toDomain(), coSync.toDomain())
 
 internal fun ProtoUpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration.toDomain(): UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration =
-    UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(kind.toDomain(), batchSizes.toDomain())
+    UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(kind.toDomain(), batchSizes.toDomain(), imagesRequireUnmeteredConnection)
 
 internal fun ProtoUpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration.toDomain(): UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration =
     UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration(kind.toDomain())

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/models/UpSynchronizationConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/models/UpSynchronizationConfiguration.kt
@@ -13,6 +13,7 @@ internal fun UpSynchronizationConfiguration.toProto(): ProtoUpSynchronizationCon
 internal fun UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration.toProto(): ProtoUpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration =
     ProtoUpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration.newBuilder()
         .setKind(kind.toProto())
+        .setBatchSizes(batchSizes.toProto())
         .build()
 
 internal fun UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration.toProto(): ProtoUpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration =
@@ -28,11 +29,17 @@ internal fun UpSynchronizationConfiguration.UpSynchronizationKind.toProto(): Pro
         UpSynchronizationConfiguration.UpSynchronizationKind.ALL -> ProtoUpSynchronizationConfiguration.UpSynchronizationKind.ALL
     }
 
+internal fun UpSynchronizationConfiguration.UpSyncBatchSizes.toProto(): ProtoUpSyncBatchSizes = ProtoUpSyncBatchSizes.newBuilder()
+        .setSessions(sessions)
+        .setUpSyncs(upSyncs)
+        .setDownSyncs(downSyncs)
+        .build()
+
 internal fun ProtoUpSynchronizationConfiguration.toDomain(): UpSynchronizationConfiguration =
     UpSynchronizationConfiguration(simprints.toDomain(), coSync.toDomain(), imagesRequireUnmeteredConnection)
 
 internal fun ProtoUpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration.toDomain(): UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration =
-    UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(kind.toDomain())
+    UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(kind.toDomain(), batchSizes.toDomain())
 
 internal fun ProtoUpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration.toDomain(): UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration =
     UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration(kind.toDomain())
@@ -47,3 +54,6 @@ internal fun ProtoUpSynchronizationConfiguration.UpSynchronizationKind.toDomain(
             "invalid UpSynchronizationKind $name"
         )
     }
+
+internal fun ProtoUpSyncBatchSizes.toDomain(): UpSynchronizationConfiguration.UpSyncBatchSizes =
+    UpSynchronizationConfiguration.UpSyncBatchSizes(sessions, upSyncs, downSyncs)

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ProjectConfiguration.kt
@@ -40,4 +40,4 @@ fun ProjectConfiguration.isEventDownSyncAllowed(): Boolean =
     synchronization.frequency != SynchronizationConfiguration.Frequency.ONLY_PERIODICALLY_UP_SYNC
 
 fun ProjectConfiguration.imagesUploadRequiresUnmeteredConnection(): Boolean =
-    synchronization.up.imagesRequireUnmeteredConnection
+    synchronization.up.simprints.imagesRequireUnmeteredConnection

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/UpSynchronizationConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/UpSynchronizationConfiguration.kt
@@ -6,9 +6,24 @@ data class UpSynchronizationConfiguration(
     val imagesRequireUnmeteredConnection: Boolean,
 ) {
 
-    data class SimprintsUpSynchronizationConfiguration(val kind: UpSynchronizationKind)
+    data class SimprintsUpSynchronizationConfiguration(
+        val kind: UpSynchronizationKind,
+        val batchSizes: UpSyncBatchSizes,
+    )
 
     data class CoSyncUpSynchronizationConfiguration(val kind: UpSynchronizationKind)
+
+    data class UpSyncBatchSizes(
+        val sessions: Int,
+        val upSyncs: Int,
+        val downSyncs: Int,
+    ) {
+
+        companion object {
+
+            fun default() = UpSyncBatchSizes(1, 1, 1)
+        }
+    }
 
     enum class UpSynchronizationKind {
         NONE,

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/UpSynchronizationConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/UpSynchronizationConfiguration.kt
@@ -3,12 +3,12 @@ package com.simprints.infra.config.store.models
 data class UpSynchronizationConfiguration(
     val simprints: SimprintsUpSynchronizationConfiguration,
     val coSync: CoSyncUpSynchronizationConfiguration,
-    val imagesRequireUnmeteredConnection: Boolean,
 ) {
 
     data class SimprintsUpSynchronizationConfiguration(
         val kind: UpSynchronizationKind,
         val batchSizes: UpSyncBatchSizes,
+        val imagesRequireUnmeteredConnection: Boolean,
     )
 
     data class CoSyncUpSynchronizationConfiguration(val kind: UpSynchronizationKind)

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiSynchronizationConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiSynchronizationConfiguration.kt
@@ -22,6 +22,7 @@ internal data class ApiSynchronizationConfiguration(
 
     @Keep
     enum class Frequency {
+
         ONLY_PERIODICALLY_UP_SYNC,
         PERIODICALLY,
         PERIODICALLY_AND_ON_SESSION_START;
@@ -49,19 +50,28 @@ internal data class ApiSynchronizationConfiguration(
             )
 
         @Keep
-        data class ApiSimprintsUpSynchronizationConfiguration(val kind: UpSynchronizationKind) {
+        data class ApiSimprintsUpSynchronizationConfiguration(
+            val kind: UpSynchronizationKind,
+            val batchSizes: ApiUpSyncBatchSizes?,
+        ) {
+
             fun toDomain(): UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration =
-                UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(kind.toDomain())
+                UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(
+                    kind.toDomain(),
+                    batchSizes?.toDomain() ?: UpSynchronizationConfiguration.UpSyncBatchSizes.default()
+                )
         }
 
         @Keep
         data class ApiCoSyncUpSynchronizationConfiguration(val kind: UpSynchronizationKind) {
+
             fun toDomain(): UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration =
                 UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration(kind.toDomain())
         }
 
         @Keep
         enum class UpSynchronizationKind {
+
             NONE,
             ONLY_ANALYTICS,
             ONLY_BIOMETRICS,
@@ -75,13 +85,24 @@ internal data class ApiSynchronizationConfiguration(
                     ALL -> UpSynchronizationConfiguration.UpSynchronizationKind.ALL
                 }
         }
+
+        @Keep
+        data class ApiUpSyncBatchSizes(
+            val sessions: Int,
+            val upSyncs: Int,
+            val downSyncs: Int,
+        ) {
+
+            fun toDomain(): UpSynchronizationConfiguration.UpSyncBatchSizes =
+                UpSynchronizationConfiguration.UpSyncBatchSizes(sessions, upSyncs, downSyncs)
+        }
     }
 
     @Keep
     data class ApiDownSynchronizationConfiguration(
         val partitionType: PartitionType,
         val maxNbOfModules: Int,
-        val moduleOptions: List<String>?
+        val moduleOptions: List<String>?,
     ) {
 
         fun toDomain(): DownSynchronizationConfiguration =
@@ -93,6 +114,7 @@ internal data class ApiSynchronizationConfiguration(
 
         @Keep
         enum class PartitionType {
+
             PROJECT,
             MODULE,
             USER;

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiSynchronizationConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiSynchronizationConfiguration.kt
@@ -39,26 +39,27 @@ internal data class ApiSynchronizationConfiguration(
     data class ApiUpSynchronizationConfiguration(
         val simprints: ApiSimprintsUpSynchronizationConfiguration,
         val coSync: ApiCoSyncUpSynchronizationConfiguration,
-        val imagesRequireUnmeteredConnection: Boolean,
     ) {
 
         fun toDomain(): UpSynchronizationConfiguration =
             UpSynchronizationConfiguration(
                 simprints.toDomain(),
                 coSync.toDomain(),
-                imagesRequireUnmeteredConnection
             )
 
         @Keep
         data class ApiSimprintsUpSynchronizationConfiguration(
             val kind: UpSynchronizationKind,
             val batchSizes: ApiUpSyncBatchSizes?,
+            val imagesRequireUnmeteredConnection: Boolean?,
         ) {
 
             fun toDomain(): UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration =
                 UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(
-                    kind.toDomain(),
-                    batchSizes?.toDomain() ?: UpSynchronizationConfiguration.UpSyncBatchSizes.default()
+                    kind = kind.toDomain(),
+                    batchSizes = batchSizes?.toDomain()
+                        ?: UpSynchronizationConfiguration.UpSyncBatchSizes.default(),
+                    imagesRequireUnmeteredConnection = imagesRequireUnmeteredConnection ?: false,
                 )
         }
 

--- a/infra/config-store/src/main/proto/project_config.proto
+++ b/infra/config-store/src/main/proto/project_config.proto
@@ -175,6 +175,7 @@ message ProtoUpSynchronizationConfiguration {
 
     message SimprintsUpSynchronizationConfiguration {
         UpSynchronizationKind kind = 1;
+        ProtoUpSyncBatchSizes batchSizes = 2;
     }
 
     message CoSyncUpSynchronizationConfiguration {
@@ -189,6 +190,11 @@ message ProtoUpSynchronizationConfiguration {
     }
 }
 
+message ProtoUpSyncBatchSizes {
+    int32 sessions = 1;
+    int32 upSyncs = 2;
+    int32 downSyncs = 3;
+}
 
 message ProtoDecisionPolicy {
     int32 low = 1;

--- a/infra/config-store/src/main/proto/project_config.proto
+++ b/infra/config-store/src/main/proto/project_config.proto
@@ -171,11 +171,11 @@ message ProtoDownSynchronizationConfiguration {
 message ProtoUpSynchronizationConfiguration {
     SimprintsUpSynchronizationConfiguration simprints = 1;
     CoSyncUpSynchronizationConfiguration co_sync = 2;
-    bool imagesRequireUnmeteredConnection = 3;
 
     message SimprintsUpSynchronizationConfiguration {
         UpSynchronizationKind kind = 1;
         ProtoUpSyncBatchSizes batchSizes = 2;
+        bool imagesRequireUnmeteredConnection = 3;
     }
 
     message CoSyncUpSynchronizationConfiguration {

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigSharedPrefsMigrationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigSharedPrefsMigrationTest.kt
@@ -501,6 +501,7 @@ class ProjectConfigSharedPrefsMigrationTest {
                         .setSimprints(
                             ProtoUpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration.newBuilder()
                                 .setKind(ProtoUpSynchronizationConfiguration.UpSynchronizationKind.ALL)
+                                .setBatchSizes(ProtoUpSyncBatchSizes.newBuilder().setSessions(1).setUpSyncs(1).setDownSyncs(1).build())
                                 .build()
                         )
                         .setCoSync(
@@ -526,6 +527,7 @@ class ProjectConfigSharedPrefsMigrationTest {
                         .setSimprints(
                             ProtoUpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration.newBuilder()
                                 .setKind(ProtoUpSynchronizationConfiguration.UpSynchronizationKind.ALL)
+                                .setBatchSizes(ProtoUpSyncBatchSizes.newBuilder().setSessions(1).setUpSyncs(1).setDownSyncs(1).build())
                                 .build()
                         )
                         .setCoSync(
@@ -551,6 +553,7 @@ class ProjectConfigSharedPrefsMigrationTest {
                         .setSimprints(
                             ProtoUpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration.newBuilder()
                                 .setKind(ProtoUpSynchronizationConfiguration.UpSynchronizationKind.NONE)
+                                .setBatchSizes(ProtoUpSyncBatchSizes.newBuilder().setSessions(1).setUpSyncs(1).setDownSyncs(1).build())
                                 .build()
                         )
                         .setCoSync(
@@ -577,6 +580,7 @@ class ProjectConfigSharedPrefsMigrationTest {
                         .setSimprints(
                             ProtoUpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration.newBuilder()
                                 .setKind(ProtoUpSynchronizationConfiguration.UpSynchronizationKind.NONE)
+                                .setBatchSizes(ProtoUpSyncBatchSizes.newBuilder().setSessions(1).setUpSyncs(1).setDownSyncs(1).build())
                                 .build()
                         )
                         .setCoSync(

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ProjectConfigurationTest.kt
@@ -6,6 +6,7 @@ import com.simprints.infra.config.store.models.UpSynchronizationConfiguration.Co
 import com.simprints.infra.config.store.models.UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration
 import com.simprints.infra.config.store.models.UpSynchronizationConfiguration.UpSynchronizationKind.*
 import com.simprints.infra.config.store.testtools.projectConfiguration
+import com.simprints.infra.config.store.testtools.simprintsUpSyncConfigurationConfiguration
 import com.simprints.infra.config.store.testtools.synchronizationConfiguration
 import org.junit.Test
 
@@ -116,13 +117,8 @@ class ProjectConfigurationTest {
             val config = projectConfiguration.copy(
                 synchronization = synchronizationConfiguration.copy(
                     up = synchronizationConfiguration.up.copy(
-                        simprints = SimprintsUpSynchronizationConfiguration(
+                        simprints = simprintsUpSyncConfigurationConfiguration.copy(
                             kind = it.key,
-                            batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes(
-                                sessions = 1,
-                                upSyncs = 1,
-                                downSyncs = 1
-                            ),
                         )
                     )
                 )
@@ -144,13 +140,8 @@ class ProjectConfigurationTest {
             val config = projectConfiguration.copy(
                 synchronization = synchronizationConfiguration.copy(
                     up = synchronizationConfiguration.up.copy(
-                        simprints = SimprintsUpSynchronizationConfiguration(
+                        simprints = simprintsUpSyncConfigurationConfiguration.copy(
                             kind = it.key,
-                            batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes(
-                                sessions = 1,
-                                upSyncs = 1,
-                                downSyncs = 1
-                            ),
                         )
                     )
                 )
@@ -174,11 +165,8 @@ class ProjectConfigurationTest {
                     up = synchronizationConfiguration.up.copy(
                         simprints = SimprintsUpSynchronizationConfiguration(
                             kind = it.key,
-                            batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes(
-                                sessions = 1,
-                                upSyncs = 1,
-                                downSyncs = 1
-                            ),
+                            batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes.default(),
+                            imagesRequireUnmeteredConnection = false
                         )
                     )
                 )
@@ -200,13 +188,8 @@ class ProjectConfigurationTest {
             val config = projectConfiguration.copy(
                 synchronization = synchronizationConfiguration.copy(
                     up = synchronizationConfiguration.up.copy(
-                        simprints = SimprintsUpSynchronizationConfiguration(
+                        simprints = simprintsUpSyncConfigurationConfiguration.copy(
                             kind = it.key,
-                            batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes(
-                                sessions = 1,
-                                upSyncs = 1,
-                                downSyncs = 1
-                            ),
                         )
                     )
                 )
@@ -240,7 +223,11 @@ class ProjectConfigurationTest {
         values.forEach {
             val config = projectConfiguration.copy(
                 synchronization = synchronizationConfiguration.copy(
-                    up = synchronizationConfiguration.up.copy(imagesRequireUnmeteredConnection = it)
+                    up = synchronizationConfiguration.up.copy(
+                        simprints = simprintsUpSyncConfigurationConfiguration.copy(
+                            imagesRequireUnmeteredConnection = it
+                        ),
+                    )
                 )
             )
             assertThat(config.imagesUploadRequiresUnmeteredConnection()).isEqualTo(it)

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ProjectConfigurationTest.kt
@@ -117,7 +117,12 @@ class ProjectConfigurationTest {
                 synchronization = synchronizationConfiguration.copy(
                     up = synchronizationConfiguration.up.copy(
                         simprints = SimprintsUpSynchronizationConfiguration(
-                            kind = it.key
+                            kind = it.key,
+                            batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes(
+                                sessions = 1,
+                                upSyncs = 1,
+                                downSyncs = 1
+                            ),
                         )
                     )
                 )
@@ -140,7 +145,12 @@ class ProjectConfigurationTest {
                 synchronization = synchronizationConfiguration.copy(
                     up = synchronizationConfiguration.up.copy(
                         simprints = SimprintsUpSynchronizationConfiguration(
-                            kind = it.key
+                            kind = it.key,
+                            batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes(
+                                sessions = 1,
+                                upSyncs = 1,
+                                downSyncs = 1
+                            ),
                         )
                     )
                 )
@@ -163,7 +173,12 @@ class ProjectConfigurationTest {
                 synchronization = synchronizationConfiguration.copy(
                     up = synchronizationConfiguration.up.copy(
                         simprints = SimprintsUpSynchronizationConfiguration(
-                            kind = it.key
+                            kind = it.key,
+                            batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes(
+                                sessions = 1,
+                                upSyncs = 1,
+                                downSyncs = 1
+                            ),
                         )
                     )
                 )
@@ -186,7 +201,12 @@ class ProjectConfigurationTest {
                 synchronization = synchronizationConfiguration.copy(
                     up = synchronizationConfiguration.up.copy(
                         simprints = SimprintsUpSynchronizationConfiguration(
-                            kind = it.key
+                            kind = it.key,
+                            batchSizes = UpSynchronizationConfiguration.UpSyncBatchSizes(
+                                sessions = 1,
+                                upSyncs = 1,
+                                downSyncs = 1
+                            ),
                         )
                     )
                 )

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/testtools/Models.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/testtools/Models.kt
@@ -11,6 +11,7 @@ import com.simprints.infra.config.store.local.models.ProtoIdentificationConfigur
 import com.simprints.infra.config.store.local.models.ProtoProject
 import com.simprints.infra.config.store.local.models.ProtoProjectConfiguration
 import com.simprints.infra.config.store.local.models.ProtoSynchronizationConfiguration
+import com.simprints.infra.config.store.local.models.ProtoUpSyncBatchSizes
 import com.simprints.infra.config.store.local.models.ProtoUpSynchronizationConfiguration
 import com.simprints.infra.config.store.local.models.ProtoVero2Configuration
 import com.simprints.infra.config.store.local.models.toProto
@@ -200,7 +201,8 @@ internal val apiSynchronizationConfiguration = ApiSynchronizationConfiguration(
     ApiSynchronizationConfiguration.Frequency.PERIODICALLY,
     ApiSynchronizationConfiguration.ApiUpSynchronizationConfiguration(
         ApiSynchronizationConfiguration.ApiUpSynchronizationConfiguration.ApiSimprintsUpSynchronizationConfiguration(
-            ApiSynchronizationConfiguration.ApiUpSynchronizationConfiguration.UpSynchronizationKind.ALL
+            ApiSynchronizationConfiguration.ApiUpSynchronizationConfiguration.UpSynchronizationKind.ALL,
+            ApiSynchronizationConfiguration.ApiUpSynchronizationConfiguration.ApiUpSyncBatchSizes(1, 2, 3),
         ),
         ApiSynchronizationConfiguration.ApiUpSynchronizationConfiguration.ApiCoSyncUpSynchronizationConfiguration(
             ApiSynchronizationConfiguration.ApiUpSynchronizationConfiguration.UpSynchronizationKind.NONE
@@ -218,7 +220,8 @@ internal val synchronizationConfiguration = SynchronizationConfiguration(
     SynchronizationConfiguration.Frequency.PERIODICALLY,
     UpSynchronizationConfiguration(
         UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(
-            UpSynchronizationConfiguration.UpSynchronizationKind.ALL
+            UpSynchronizationConfiguration.UpSynchronizationKind.ALL,
+            UpSynchronizationConfiguration.UpSyncBatchSizes(1, 2, 3),
         ),
         UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration(
             UpSynchronizationConfiguration.UpSynchronizationKind.NONE
@@ -239,6 +242,13 @@ internal val protoSynchronizationConfiguration = ProtoSynchronizationConfigurati
             .setSimprints(
                 ProtoUpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration.newBuilder()
                     .setKind(ProtoUpSynchronizationConfiguration.UpSynchronizationKind.ALL)
+                    .setBatchSizes(
+                        ProtoUpSyncBatchSizes.newBuilder()
+                            .setSessions(1)
+                            .setUpSyncs(2)
+                            .setDownSyncs(3)
+                            .build()
+                    )
                     .build()
             )
             .setCoSync(

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/testtools/Models.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/testtools/Models.kt
@@ -203,11 +203,11 @@ internal val apiSynchronizationConfiguration = ApiSynchronizationConfiguration(
         ApiSynchronizationConfiguration.ApiUpSynchronizationConfiguration.ApiSimprintsUpSynchronizationConfiguration(
             ApiSynchronizationConfiguration.ApiUpSynchronizationConfiguration.UpSynchronizationKind.ALL,
             ApiSynchronizationConfiguration.ApiUpSynchronizationConfiguration.ApiUpSyncBatchSizes(1, 2, 3),
+            false,
         ),
         ApiSynchronizationConfiguration.ApiUpSynchronizationConfiguration.ApiCoSyncUpSynchronizationConfiguration(
             ApiSynchronizationConfiguration.ApiUpSynchronizationConfiguration.UpSynchronizationKind.NONE
         ),
-        false,
     ),
     ApiSynchronizationConfiguration.ApiDownSynchronizationConfiguration(
         ApiSynchronizationConfiguration.ApiDownSynchronizationConfiguration.PartitionType.PROJECT,
@@ -216,17 +216,19 @@ internal val apiSynchronizationConfiguration = ApiSynchronizationConfiguration(
     )
 )
 
+internal val simprintsUpSyncConfigurationConfiguration = UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(
+    UpSynchronizationConfiguration.UpSynchronizationKind.ALL,
+    UpSynchronizationConfiguration.UpSyncBatchSizes(1, 2, 3),
+    false
+)
+
 internal val synchronizationConfiguration = SynchronizationConfiguration(
     SynchronizationConfiguration.Frequency.PERIODICALLY,
     UpSynchronizationConfiguration(
-        UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(
-            UpSynchronizationConfiguration.UpSynchronizationKind.ALL,
-            UpSynchronizationConfiguration.UpSyncBatchSizes(1, 2, 3),
-        ),
+        simprintsUpSyncConfigurationConfiguration,
         UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration(
             UpSynchronizationConfiguration.UpSynchronizationKind.NONE
         ),
-        false,
     ),
     DownSynchronizationConfiguration(
         DownSynchronizationConfiguration.PartitionType.PROJECT,

--- a/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
+++ b/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
@@ -404,9 +404,11 @@ fun createEventUpSyncRequestEvent() = EventUpSyncRequestEvent(
     createdAt = CREATED_AT,
     endedAt = ENDED_AT,
     requestId = GUID1,
-    sessionCount = 1,
-    eventUpSyncCount = 2,
-    eventDownSyncCount = 3,
+    content = EventUpSyncRequestEvent.UpSyncContent(
+        sessionCount = 1,
+        eventUpSyncCount = 2,
+        eventDownSyncCount = 3,
+    ),
     responseStatus = 200,
     errorType = "OK",
 )

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/upsync/EventUpSyncRequestEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/upsync/EventUpSyncRequestEvent.kt
@@ -22,9 +22,7 @@ data class EventUpSyncRequestEvent(
         createdAt: Timestamp,
         endedAt: Timestamp,
         requestId: String,
-        sessionCount: Int = 0,
-        eventUpSyncCount: Int = 0,
-        eventDownSyncCount: Int = 0,
+        content: UpSyncContent = UpSyncContent(),
         responseStatus: Int? = null,
         errorType: String? = null,
     ) : this(
@@ -33,11 +31,7 @@ data class EventUpSyncRequestEvent(
             createdAt,
             endedAt,
             requestId,
-            UpSyncContent(
-                sessionCount,
-                eventUpSyncCount,
-                eventDownSyncCount,
-            ),
+            content,
             responseStatus,
             errorType,
             EVENT_VERSION,

--- a/infra/sync/src/test/java/com/simprints/infra/sync/SyncOrchestratorImplTest.kt
+++ b/infra/sync/src/test/java/com/simprints/infra/sync/SyncOrchestratorImplTest.kt
@@ -99,7 +99,7 @@ class SyncOrchestratorImplTest {
     @Test
     fun `schedules images with any connection if not specified`() = runTest {
         coEvery {
-            configRepo.getProjectConfiguration().synchronization.up.imagesRequireUnmeteredConnection
+            configRepo.getProjectConfiguration().synchronization.up.simprints.imagesRequireUnmeteredConnection
         } returns false
         every { authStore.signedInProjectId } returns "projectId"
 
@@ -117,7 +117,7 @@ class SyncOrchestratorImplTest {
     @Test
     fun `schedules images with unmetered constraint if requested`() = runTest {
         coEvery {
-            configRepo.getProjectConfiguration().synchronization.up.imagesRequireUnmeteredConnection
+            configRepo.getProjectConfiguration().synchronization.up.simprints.imagesRequireUnmeteredConnection
         } returns true
         every { authStore.signedInProjectId } returns "projectId"
         coEvery { shouldScheduleFirmwareUpdate.invoke() } returns false

--- a/infra/sync/src/test/java/com/simprints/infra/sync/config/testtools/Models.kt
+++ b/infra/sync/src/test/java/com/simprints/infra/sync/config/testtools/Models.kt
@@ -63,7 +63,8 @@ internal val synchronizationConfiguration = SynchronizationConfiguration(
     SynchronizationConfiguration.Frequency.PERIODICALLY,
     UpSynchronizationConfiguration(
         UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(
-            UpSynchronizationConfiguration.UpSynchronizationKind.ALL
+            UpSynchronizationConfiguration.UpSynchronizationKind.ALL,
+            UpSynchronizationConfiguration.UpSyncBatchSizes.default()
         ),
         UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration(
             UpSynchronizationConfiguration.UpSynchronizationKind.NONE

--- a/infra/sync/src/test/java/com/simprints/infra/sync/config/testtools/Models.kt
+++ b/infra/sync/src/test/java/com/simprints/infra/sync/config/testtools/Models.kt
@@ -59,17 +59,19 @@ internal val consentConfiguration = ConsentConfiguration(
     ),
 )
 
+internal val simprintsUpSyncConfigurationConfiguration = UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(
+    UpSynchronizationConfiguration.UpSynchronizationKind.ALL,
+    UpSynchronizationConfiguration.UpSyncBatchSizes.default(),
+    false,
+)
+
 internal val synchronizationConfiguration = SynchronizationConfiguration(
     SynchronizationConfiguration.Frequency.PERIODICALLY,
     UpSynchronizationConfiguration(
-        UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration(
-            UpSynchronizationConfiguration.UpSynchronizationKind.ALL,
-            UpSynchronizationConfiguration.UpSyncBatchSizes.default()
-        ),
+        simprintsUpSyncConfigurationConfiguration,
         UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration(
             UpSynchronizationConfiguration.UpSynchronizationKind.NONE
         ),
-        false,
     ),
     DownSynchronizationConfiguration(
         DownSynchronizationConfiguration.PartitionType.PROJECT,

--- a/infra/sync/src/test/java/com/simprints/infra/sync/config/usecase/RescheduleWorkersIfConfigChangedUseCaseTest.kt
+++ b/infra/sync/src/test/java/com/simprints/infra/sync/config/usecase/RescheduleWorkersIfConfigChangedUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.simprints.infra.sync.config.usecase
 
 import com.simprints.infra.sync.SyncOrchestrator
 import com.simprints.infra.sync.config.testtools.projectConfiguration
+import com.simprints.infra.sync.config.testtools.simprintsUpSyncConfigurationConfiguration
 import com.simprints.infra.sync.config.testtools.synchronizationConfiguration
 import io.mockk.MockKAnnotations
 import io.mockk.coVerify
@@ -30,12 +31,20 @@ class RescheduleWorkersIfConfigChangedUseCaseTest {
             useCase(
                 projectConfiguration.copy(
                     synchronization = synchronizationConfiguration.copy(
-                        up = synchronizationConfiguration.up.copy(imagesRequireUnmeteredConnection = true)
+                        up = synchronizationConfiguration.up.copy(
+                            simprints = simprintsUpSyncConfigurationConfiguration.copy(
+                                imagesRequireUnmeteredConnection = true
+                            )
+                        )
                     )
                 ),
                 projectConfiguration.copy(
                     synchronization = synchronizationConfiguration.copy(
-                        up = synchronizationConfiguration.up.copy(imagesRequireUnmeteredConnection = true)
+                        up = synchronizationConfiguration.up.copy(
+                            simprints = simprintsUpSyncConfigurationConfiguration.copy(
+                                imagesRequireUnmeteredConnection = true
+                            )
+                        )
                     )
                 ),
             )
@@ -49,12 +58,20 @@ class RescheduleWorkersIfConfigChangedUseCaseTest {
             useCase(
                 projectConfiguration.copy(
                     synchronization = synchronizationConfiguration.copy(
-                        up = synchronizationConfiguration.up.copy(imagesRequireUnmeteredConnection = false)
+                        up = synchronizationConfiguration.up.copy(
+                            simprints = simprintsUpSyncConfigurationConfiguration.copy(
+                                imagesRequireUnmeteredConnection = false
+                            )
+                        )
                     )
                 ),
                 projectConfiguration.copy(
                     synchronization = synchronizationConfiguration.copy(
-                        up = synchronizationConfiguration.up.copy(imagesRequireUnmeteredConnection = true)
+                        up = synchronizationConfiguration.up.copy(
+                            simprints = simprintsUpSyncConfigurationConfiguration.copy(
+                                imagesRequireUnmeteredConnection = true
+                            )
+                        )
                     )
                 ),
             )


### PR DESCRIPTION
Main changes:
* Added batch size configuration to `synchronization.up.simprints`. Defaulting all batch sizes to 1 if no config provided to mimic existing behaviour. 
* Using new configuration to upload events in the batches of provided sizes
* Split out-of-session events into separate request per scope to allow batching those events separately. 