### PR TITLE
[MS-241] Add -keep declarations for all classes saved in the OrchestratorCache

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/steps/Step.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/steps/Step.kt
@@ -29,26 +29,14 @@ import java.io.Serializable
     JsonSubTypes.Type(value = ConsentResult::class, name = "ConsentResult"),
     JsonSubTypes.Type(value = FingerprintConnectResult::class, name = "FingerprintConnectResult"),
     JsonSubTypes.Type(value = FingerprintCaptureResult::class, name = "FingerprintCaptureResult"),
-    JsonSubTypes.Type(
-        value = FingerprintCaptureResult.Item::class,
-        name = "FingerprintCaptureResult.Item"
-    ),
-    JsonSubTypes.Type(
-        value = FingerprintCaptureResult.Sample::class,
-        name = "FingerprintCaptureResult.Sample"
-    ),
-
+    JsonSubTypes.Type(value = FingerprintCaptureResult.Item::class, name = "FingerprintCaptureResult.Item"),
+    JsonSubTypes.Type(value = FingerprintCaptureResult.Sample::class, name = "FingerprintCaptureResult.Sample"),
     JsonSubTypes.Type(value = FingerprintMatchResult::class, name = "FingerprintMatchResult"),
-    JsonSubTypes.Type(
-        value = FingerprintMatchResult.Item::class,
-        name = "FingerprintMatchResult.Item"
-    ),
-
+    JsonSubTypes.Type(value = FingerprintMatchResult.Item::class, name = "FingerprintMatchResult.Item"),
     JsonSubTypes.Type(value = FaceConfigurationResult::class, name = "FaceConfigurationResult"),
     JsonSubTypes.Type(value = FaceCaptureResult::class, name = "FaceCaptureResult"),
     JsonSubTypes.Type(value = FaceCaptureResult.Item::class, name = "FaceCaptureResult.Item"),
     JsonSubTypes.Type(value = FaceCaptureResult.Sample::class, name = "FaceCaptureResult.Sample"),
-
     JsonSubTypes.Type(value = FaceMatchResult::class, name = "FaceMatchResult"),
     JsonSubTypes.Type(value = FaceMatchResult.Item::class, name = "FaceMatchResult.Item"),
     JsonSubTypes.Type(value = EnrolLastBiometricResult::class, name = "EnrolLastBiometricResult"),

--- a/id/proguard-rules.pro
+++ b/id/proguard-rules.pro
@@ -52,6 +52,21 @@
 -keep class com.simprints.infra.events.event.domain.models.** { *; }
 -keep class com.simprints.infra.events.event.local.** { *; }
 
+-keep class com.simprints.feature.orchestrator.steps.** { *; }
+-keep class com.simprints.face.capture.** { *; }
+-keep class com.simprints.face.configuration.** { *; }
+-keep class com.simprints.feature.alert.** { *; }
+-keep class com.simprints.feature.consent.** { *; }
+-keep class com.simprints.feature.enrollast.** { *; }
+-keep class com.simprints.feature.exitform.** { *; }
+-keep class com.simprints.feature.fetchsubject.** { *; }
+-keep class com.simprints.feature.login.** { *; }
+-keep class com.simprints.feature.selectsubject.** { *; }
+-keep class com.simprints.feature.setup.** { *; }
+-keep class com.simprints.fingerprint.capture.** { *; }
+-keep class com.simprints.fingerprint.connect.** { *; }
+-keep class com.simprints.matcher.** { *; }
+
 # Deobfuscations for Crashlytics:
 # https://firebase.google.com/docs/crashlytics/get-deobfuscated-reports
 -keepattributes SourceFile,LineNumberTable,*Annotation*


### PR DESCRIPTION
FSR the @Keep annotation doesn’t work and in release builds the result classes are obfuscated which prevents Jackson from properly (de)serializing them and without the step results Enrol Last Bio cannot work.
To reproduce - either use a prod version or a debug one with isMinifyEnabled = true . Then log into a project with “Duplicate biometric check enabled” set to true and try to do an Identification followed by Enrol Last Bio. In 2023.4.2 it fails with a gray screen saying that there was a duplicate (another issue we need to fix later).