### PR TITLE
Apply correct Keep annotation for image ref and path models

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
@@ -70,7 +70,7 @@ internal class OrchestratorViewModel @Inject constructor(
     }
 
     fun handleResult(result: Serializable) {
-        Simber.i(result.toString())
+        Simber.d(result.toString())
         val errorResponse = mapRefusalOrErrorResult(result)
         if (errorResponse != null) {
             // Shortcut the flow execution if any refusal or error result is found

--- a/infra/images/src/main/java/com/simprints/infra/images/model/Path.kt
+++ b/infra/images/src/main/java/com/simprints/infra/images/model/Path.kt
@@ -1,6 +1,7 @@
 package com.simprints.infra.images.model
 
 import android.os.Parcelable
+import androidx.annotation.Keep
 import kotlinx.parcelize.Parcelize
 import java.io.File
 
@@ -12,6 +13,7 @@ import java.io.File
  *           e.g.: for dir1/dir2/file.txt [parts] should be
  *           @sample [arrayOf("dir1", "dir2", "file.txt")]
  */
+@Keep
 @Parcelize
 data class Path(val parts: Array<String>) : Parcelable {
 

--- a/infra/images/src/main/java/com/simprints/infra/images/model/SecuredImageRef.kt
+++ b/infra/images/src/main/java/com/simprints/infra/images/model/SecuredImageRef.kt
@@ -1,6 +1,6 @@
 package com.simprints.infra.images.model
 
-import com.google.errorprone.annotations.Keep
+import androidx.annotation.Keep
 
 @Keep
 data class SecuredImageRef(override val relativePath: Path) : ImageRef(relativePath)


### PR DESCRIPTION
`SecuredImageRef` was incorrectly obfuscated due to an erroneous import for annotation with the same name from a completely unrelated package.

PS. Ironically, the name of the package is "Google.ErrorProne.Annotations" :D