### PR TITLE
MS-157 Login form updates

### DIFF
--- a/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
@@ -8,15 +8,18 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.simprints.feature.login.LoginError
 import com.simprints.feature.login.LoginResult
 import com.simprints.feature.login.R
 import com.simprints.feature.login.databinding.FragmentLoginFormBinding
+import com.simprints.feature.login.databinding.ViewUrlChangeInputBinding
 import com.simprints.feature.login.screens.form.SignInState.BackendMaintenanceError
 import com.simprints.feature.login.screens.form.SignInState.BadCredentials
 import com.simprints.feature.login.screens.form.SignInState.IntegrityException
@@ -30,6 +33,7 @@ import com.simprints.feature.login.screens.form.SignInState.QrCodeValid
 import com.simprints.feature.login.screens.form.SignInState.QrGenericError
 import com.simprints.feature.login.screens.form.SignInState.QrInvalidCode
 import com.simprints.feature.login.screens.form.SignInState.QrNoCameraPermission
+import com.simprints.feature.login.screens.form.SignInState.ShowUrlChangeDialog
 import com.simprints.feature.login.screens.form.SignInState.Success
 import com.simprints.feature.login.screens.form.SignInState.TechnicalFailure
 import com.simprints.feature.login.screens.form.SignInState.Unknown
@@ -90,6 +94,11 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
         binding.loginUserId.setText(args.loginParams.userId.value)
         binding.loginProjectId.setText(args.loginParams.projectId)
 
+        binding.loginChangeUrlButton.setOnClickListener {
+            Simber.tag(LoggingConstants.CrashReportTag.LOGIN.name).i("Change URL button clicked")
+            viewModel.changeUrlClicked()
+        }
+
         binding.loginButtonScanQr.setOnClickListener {
             Simber.tag(LoggingConstants.CrashReportTag.LOGIN.name).i("Scan QR button clicked")
             findNavController().navigate(R.id.action_loginFormFragment_to_loginQrScanner)
@@ -135,6 +144,8 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
             QrInvalidCode -> showToast(IDR.string.login_invalid_qr_code_error)
             QrNoCameraPermission -> showToast(IDR.string.login_qr_code_scanning_camera_permission_error)
 
+            is ShowUrlChangeDialog -> createChangeUrlDialog(result).show()
+
             // Showing error card
             is BackendMaintenanceError -> showOutageErrorCard(result.estimatedOutage)
 
@@ -155,13 +166,36 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
 
     private fun showOutageErrorCard(estimatedOutage: String?) {
         binding.loginErrorText.text = estimatedOutage
-            ?.let { getString(IDR.string.error_backend_maintenance_with_time_message, estimatedOutage) }
+            ?.let {
+                getString(
+                    IDR.string.error_backend_maintenance_with_time_message,
+                    estimatedOutage
+                )
+            }
             ?: getString(IDR.string.error_backend_maintenance_message)
         binding.loginErrorCard.isVisible = true
     }
 
     private fun showToast(@StringRes messageId: Int) {
         Toast.makeText(requireContext(), getString(messageId), Toast.LENGTH_LONG).show()
+    }
+
+    private fun createChangeUrlDialog(result: ShowUrlChangeDialog): AlertDialog {
+        val binding = ViewUrlChangeInputBinding.inflate(layoutInflater)
+            .apply { loginUrlChangeInput.setText(result.currentUrl) }
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(IDR.string.login_change_url)
+            .setView(binding.root)
+            .setNeutralButton(IDR.string.login_change_url_reset) { di, _ ->
+                viewModel.saveNewUrl(null)
+                di.dismiss()
+            }
+            .setPositiveButton(IDR.string.login_change_url_save) { di, _ ->
+                viewModel.saveNewUrl(binding.loginUrlChangeInput.text.toString())
+                di.dismiss()
+            }
+            .setNegativeButton(IDR.string.login_change_url_cancel) { di, _ -> di.dismiss() }
+            .create()
     }
 
     private fun finishWithSuccess() {

--- a/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
@@ -52,6 +52,7 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
     private val viewModel by viewModels<LoginFormViewModel>()
 
     private lateinit var checkForPlayServicesResultLauncher: ActivityResultLauncher<IntentSenderRequest>
+
     init {
         checkForPlayServicesResultLauncher =
             registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) {
@@ -87,6 +88,8 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
 
     private fun initUi() {
         binding.loginUserId.setText(args.loginParams.userId.value)
+        binding.loginProjectId.setText(args.loginParams.projectId)
+
         binding.loginButtonScanQr.setOnClickListener {
             Simber.tag(LoggingConstants.CrashReportTag.LOGIN.name).i("Scan QR button clicked")
             findNavController().navigate(R.id.action_loginFormFragment_to_loginQrScanner)

--- a/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
@@ -77,7 +77,7 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
             viewLifecycleOwner,
             R.id.loginFormFragment,
             R.id.loginQrScanner
-        ) { viewModel.handleQrResult(it) }
+        ) { viewModel.handleQrResult(args.loginParams.projectId, it) }
 
         initUi()
         observeUiState()
@@ -150,7 +150,6 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
     }
 
     private fun updateFields(result: QrCodeValid) {
-        binding.loginProjectId.setText(result.projectId)
         binding.loginProjectSecret.setText(result.projectSecret)
     }
 

--- a/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormViewModel.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormViewModel.kt
@@ -46,7 +46,12 @@ internal class LoginFormViewModel @Inject constructor(
             _signInState.send(SignInState.ProjectIdMismatch)
         } else {
             viewModelScope.launch {
-                val result = authManager.authenticateSafely(loginParams.userId.value, projectId, projectSecret, deviceId)
+                val result = authManager.authenticateSafely(
+                    loginParams.userId.value,
+                    projectId,
+                    projectSecret,
+                    deviceId
+                )
                 _signInState.send(mapAuthDataResult(result))
             }
         }
@@ -69,7 +74,7 @@ internal class LoginFormViewModel @Inject constructor(
     private fun areMandatoryCredentialsPresent(
         projectId: String,
         projectSecret: String,
-        userId: String
+        userId: String,
     ) = projectId.isNotEmpty() && projectSecret.isNotEmpty() && userId.isNotEmpty()
 
     fun handleQrResult(projectId: String, result: QrScannerResult) {
@@ -84,7 +89,12 @@ internal class LoginFormViewModel @Inject constructor(
                     _signInState.send(SignInState.ProjectIdMismatch)
                 } else {
                     qrContent.apiBaseUrl?.let { simNetwork.setApiBaseUrl(it) }
-                    _signInState.send(SignInState.QrCodeValid(qrContent.projectId, qrContent.projectSecret))
+                    _signInState.send(
+                        SignInState.QrCodeValid(
+                            qrContent.projectId,
+                            qrContent.projectSecret
+                        )
+                    )
                 }
             } catch (e: Exception) {
                 Simber.tag(CrashReportTag.LOGIN.name).i("QR scanning unsuccessful")
@@ -100,6 +110,16 @@ internal class LoginFormViewModel @Inject constructor(
         QrScannerError.NoPermission -> SignInState.QrNoCameraPermission
         QrScannerError.CameraNotAvailable -> SignInState.QrCameraUnavailable
         QrScannerError.UnknownError -> SignInState.QrGenericError
+    }
+
+    fun changeUrlClicked() {
+        _signInState.send(SignInState.ShowUrlChangeDialog(simNetwork.getApiBaseUrlPrefix()))
+    }
+
+    fun saveNewUrl(newUrl: String?) = if (newUrl.isNullOrEmpty()) {
+        simNetwork.resetApiBaseUrl()
+    } else {
+        simNetwork.setApiBaseUrl(newUrl)
     }
 
 }

--- a/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormViewModel.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormViewModel.kt
@@ -72,16 +72,20 @@ internal class LoginFormViewModel @Inject constructor(
         userId: String
     ) = projectId.isNotEmpty() && projectSecret.isNotEmpty() && userId.isNotEmpty()
 
-    fun handleQrResult(result: QrScannerResult) {
+    fun handleQrResult(projectId: String, result: QrScannerResult) {
         if (result.error != null) {
             _signInState.send(mapQrError(result.error))
         } else if (!result.content.isNullOrEmpty()) {
             try {
                 val qrContent = jsonHelper.fromJson<QrCodeContent>(result.content)
-
                 Simber.tag(CrashReportTag.LOGIN.name).i("QR scanning successful")
-                qrContent.apiBaseUrl?.let { simNetwork.setApiBaseUrl(it) }
-                _signInState.send(SignInState.QrCodeValid(qrContent.projectId, qrContent.projectSecret))
+
+                if (projectId != qrContent.projectId) {
+                    _signInState.send(SignInState.ProjectIdMismatch)
+                } else {
+                    qrContent.apiBaseUrl?.let { simNetwork.setApiBaseUrl(it) }
+                    _signInState.send(SignInState.QrCodeValid(qrContent.projectId, qrContent.projectSecret))
+                }
             } catch (e: Exception) {
                 Simber.tag(CrashReportTag.LOGIN.name).i("QR scanning unsuccessful")
                 _signInState.send(SignInState.QrInvalidCode)

--- a/feature/login/src/main/java/com/simprints/feature/login/screens/form/SignInState.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/form/SignInState.kt
@@ -17,6 +17,8 @@ internal sealed class SignInState {
     data object QrInvalidCode : SignInState()
     data object QrGenericError : SignInState()
 
+    data class ShowUrlChangeDialog(val currentUrl: String) : SignInState()
+
     data object BadCredentials : SignInState()
     data object Offline : SignInState()
     data object TechnicalFailure : SignInState()

--- a/feature/login/src/main/res/layout/fragment_login_form.xml
+++ b/feature/login/src/main/res/layout/fragment_login_form.xml
@@ -28,8 +28,7 @@
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            app:passwordToggleEnabled="true">
+            android:layout_marginTop="8dp">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/loginUserId"

--- a/feature/login/src/main/res/layout/fragment_login_form.xml
+++ b/feature/login/src/main/res/layout/fragment_login_form.xml
@@ -28,13 +28,13 @@
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:enabled="false"
             android:layout_marginTop="8dp">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/loginUserId"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:enabled="false"
                 android:hint="@string/login_user_id_hint"
                 android:inputType="text"
                 android:minWidth="150dp"
@@ -44,13 +44,13 @@
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:enabled="false"
             android:layout_marginTop="8dp">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/loginProjectId"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:enabled="false"
                 android:hint="@string/login_id_hint"
                 android:inputType="textVisiblePassword"
                 tools:text="qwerty1235" />

--- a/feature/login/src/main/res/layout/fragment_login_form.xml
+++ b/feature/login/src/main/res/layout/fragment_login_form.xml
@@ -22,7 +22,7 @@
         <ImageView
             android:layout_width="100dp"
             android:layout_height="100dp"
-            android:layout_marginBottom="48dp"
+            android:layout_marginBottom="36dp"
             android:src="@drawable/simprints_logo" />
 
         <com.google.android.material.textfield.TextInputLayout
@@ -139,4 +139,18 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/loginChangeUrlButton"
+        style="@style/Widget.Simprints.Button.TextButton.White"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:alpha="0.5"
+        android:text="@string/login_change_url"
+        android:textAllCaps="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/login/src/main/res/layout/fragment_login_form.xml
+++ b/feature/login/src/main/res/layout/fragment_login_form.xml
@@ -39,8 +39,6 @@
                 android:inputType="text"
                 android:minWidth="150dp"
                 tools:text="UserName" />
-
-            <requestFocus />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -52,6 +50,7 @@
                 android:id="@+id/loginProjectId"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:enabled="false"
                 android:hint="@string/login_id_hint"
                 android:inputType="textVisiblePassword"
                 tools:text="qwerty1235" />
@@ -69,6 +68,8 @@
                 android:layout_height="wrap_content"
                 android:hint="@string/login_secret_hint"
                 android:inputType="textPassword" />
+
+            <requestFocus />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.button.MaterialButton

--- a/feature/login/src/main/res/layout/view_url_change_input.xml
+++ b/feature/login/src/main/res/layout/view_url_change_input.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.textfield.TextInputLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/login_url_change_input_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minWidth="200dp"
+    android:paddingHorizontal="24dp"
+    android:paddingTop="16dp">
+
+    <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/login_url_change_input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:imeOptions="actionDone"
+        android:inputType="textUri" />
+</com.google.android.material.textfield.TextInputLayout>

--- a/feature/login/src/test/java/com/simprints/feature/login/screens/form/LoginFormViewModelTest.kt
+++ b/feature/login/src/test/java/com/simprints/feature/login/screens/form/LoginFormViewModelTest.kt
@@ -192,6 +192,28 @@ internal class LoginFormViewModelTest {
         verify { simNetwork.setApiBaseUrl(eq(URL)) }
     }
 
+    @Test
+    fun `updates UI state when change URL clicked`() {
+        viewModel.changeUrlClicked()
+
+        val result = viewModel.signInState.getOrAwaitValue()
+        assertThat(result.getContentIfNotHandled()).isInstanceOf(SignInState.ShowUrlChangeDialog::class.java)
+    }
+
+    @Test
+    fun `saves provided base URL`() {
+        viewModel.saveNewUrl(URL)
+
+        verify { simNetwork.setApiBaseUrl(URL) }
+    }
+
+    @Test
+    fun `resets provided base URL`() {
+        viewModel.saveNewUrl(null)
+
+        verify { simNetwork.resetApiBaseUrl() }
+    }
+
     companion object {
 
 

--- a/feature/login/src/test/java/com/simprints/feature/login/screens/form/LoginFormViewModelTest.kt
+++ b/feature/login/src/test/java/com/simprints/feature/login/screens/form/LoginFormViewModelTest.kt
@@ -136,7 +136,7 @@ internal class LoginFormViewModelTest {
             QrScannerError.CameraNotAvailable to SignInState.QrCameraUnavailable::class.java,
             QrScannerError.UnknownError to SignInState.QrGenericError::class.java,
         ).forEach { (error, expected) ->
-            viewModel.handleQrResult(QrScannerResult(null, error))
+            viewModel.handleQrResult(PROJECT_ID, QrScannerResult(null, error))
             val result = viewModel.signInState.getOrAwaitValue()
 
             assertThat(result.getContentIfNotHandled()).isInstanceOf(expected)
@@ -145,7 +145,7 @@ internal class LoginFormViewModelTest {
 
     @Test
     fun `returns correct SignInState when empty QR result`() {
-        viewModel.handleQrResult(QrScannerResult(null, null))
+        viewModel.handleQrResult(PROJECT_ID, QrScannerResult(null, null))
         val result = viewModel.signInState.getOrAwaitValue()
 
         assertThat(result.getContentIfNotHandled()).isInstanceOf(SignInState.QrInvalidCode::class.java)
@@ -155,17 +155,27 @@ internal class LoginFormViewModelTest {
     fun `returns correct SignInState when QR code parsing fails`() {
         every { jsonHelper.fromJson<QrCodeContent>(any()) } throws RuntimeException("parsing fail")
 
-        viewModel.handleQrResult(QrScannerResult(QR_CONTENT, null))
+        viewModel.handleQrResult(PROJECT_ID, QrScannerResult(QR_CONTENT, null))
         val result = viewModel.signInState.getOrAwaitValue()
 
         assertThat(result.getContentIfNotHandled()).isInstanceOf(SignInState.QrInvalidCode::class.java)
     }
 
     @Test
+    fun `returns correct SignInState when QR contains wrong project ID`() {
+        every { jsonHelper.fromJson<QrCodeContent>(eq(QR_CONTENT)) } returns QrCodeContent("differentProjectId", PROJECT_SECRET)
+
+        viewModel.handleQrResult(PROJECT_ID, QrScannerResult(QR_CONTENT, null))
+        val result = viewModel.signInState.getOrAwaitValue()
+
+        assertThat(result.getContentIfNotHandled()).isInstanceOf(SignInState.ProjectIdMismatch::class.java)
+    }
+
+    @Test
     fun `returns correct SignInState when QR code parsing success`() {
         every { jsonHelper.fromJson<QrCodeContent>(eq(QR_CONTENT)) } returns QrCodeContent(PROJECT_ID, PROJECT_SECRET)
 
-        viewModel.handleQrResult(QrScannerResult(QR_CONTENT, null))
+        viewModel.handleQrResult(PROJECT_ID, QrScannerResult(QR_CONTENT, null))
         val result = viewModel.signInState.getOrAwaitValue()
 
         assertThat(result.getContentIfNotHandled()).isInstanceOf(SignInState.QrCodeValid::class.java)
@@ -177,7 +187,7 @@ internal class LoginFormViewModelTest {
     fun `updates base API url when QR code parsing success`() {
         every { jsonHelper.fromJson<QrCodeContent>(eq(QR_CONTENT)) } returns QrCodeContent(PROJECT_ID, PROJECT_SECRET, URL)
 
-        viewModel.handleQrResult(QrScannerResult(QR_CONTENT, null))
+        viewModel.handleQrResult(PROJECT_ID, QrScannerResult(QR_CONTENT, null))
 
         verify { simNetwork.setApiBaseUrl(eq(URL)) }
     }

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
@@ -50,7 +50,7 @@ internal class LoginInfoStore @Inject constructor(
                 putString(CORE_FIREBASE_APPLICATION_ID, prefs.getString(CORE_FIREBASE_APPLICATION_ID, ""))
                 putString(CORE_FIREBASE_API_KEY, prefs.getString(CORE_FIREBASE_API_KEY, ""))
             }
-            prefs.edit(commit = true) { clear() }
+            prefs.clearValues()
         }
         return securePrefs
     }
@@ -119,8 +119,8 @@ internal class LoginInfoStore @Inject constructor(
         signedInProjectId.isNotEmpty() && signedInProjectId == possibleProjectId
 
     fun cleanCredentials() {
-        securePrefs.edit { clear() }
-        prefs.edit { clear() }
+        securePrefs.clearValues()
+        prefs.clearValues()
     }
 
     fun clearCachedTokenClaims() {
@@ -130,5 +130,15 @@ internal class LoginInfoStore @Inject constructor(
             remove(CORE_FIREBASE_APPLICATION_ID)
             remove(CORE_FIREBASE_API_KEY)
         }
+    }
+
+    private fun SharedPreferences.clearValues() = edit(commit = true) {
+        remove(USER_ID_VALUE)
+        remove(USER_ID_TOKENIZED)
+        remove(PROJECT_ID)
+        remove(PROJECT_ID_CLAIM)
+        remove(CORE_FIREBASE_PROJECT_ID)
+        remove(CORE_FIREBASE_APPLICATION_ID)
+        remove(CORE_FIREBASE_API_KEY)
     }
 }

--- a/infra/auth-store/src/test/java/com/simprints/infra/authstore/domain/LoginInfoStoreTest.kt
+++ b/infra/auth-store/src/test/java/com/simprints/infra/authstore/domain/LoginInfoStoreTest.kt
@@ -65,11 +65,11 @@ class LoginInfoStoreTest {
             secureEditor.putString(any(), any())
             secureEditor.putBoolean(any(), any())
         }
+        // Check that legacy prefs cleared
+        verify(exactly = 7) { legacyEditor.remove(any()) }
         verify(exactly = 1) {
-            secureEditor.commit()
-            // Check that legacy prefs cleared
-            legacyEditor.clear()
             legacyEditor.commit()
+            secureEditor.commit()
         }
     }
 
@@ -261,10 +261,8 @@ class LoginInfoStoreTest {
     fun `cleanCredentials should reset all the credentials`() {
         loginInfoStoreImpl.cleanCredentials()
 
-        verify(exactly = 1) {
-            secureEditor.clear()
-            secureEditor.apply()
-        }
+        verify(exactly = 7) { secureEditor.remove(any()) }
+        verify(exactly = 1) { secureEditor.commit() }
     }
 
     @Test

--- a/infra/network/src/main/java/com/simprints/infra/network/SimNetwork.kt
+++ b/infra/network/src/main/java/com/simprints/infra/network/SimNetwork.kt
@@ -26,6 +26,7 @@ interface SimNetwork {
     ): SimApiClient<T>
 
     fun getApiBaseUrl(): String
+    fun getApiBaseUrlPrefix(): String
     fun setApiBaseUrl(apiBaseUrl: String?)
     fun resetApiBaseUrl()
 

--- a/infra/network/src/main/java/com/simprints/infra/network/SimNetworkImpl.kt
+++ b/infra/network/src/main/java/com/simprints/infra/network/SimNetworkImpl.kt
@@ -29,6 +29,10 @@ internal class SimNetworkImpl @Inject constructor(
         return baseUrlProvider.getApiBaseUrl()
     }
 
+    override fun getApiBaseUrlPrefix(): String {
+        return baseUrlProvider.getApiBaseUrlPrefix()
+    }
+
     override fun setApiBaseUrl(apiBaseUrl: String?) {
         baseUrlProvider.setApiBaseUrl(apiBaseUrl)
     }

--- a/infra/network/src/main/java/com/simprints/infra/network/url/BaseUrlProvider.kt
+++ b/infra/network/src/main/java/com/simprints/infra/network/url/BaseUrlProvider.kt
@@ -2,6 +2,7 @@ package com.simprints.infra.network.url
 
 internal interface BaseUrlProvider {
     fun getApiBaseUrl(): String
+    fun getApiBaseUrlPrefix(): String
     fun setApiBaseUrl(apiBaseUrl: String?)
     fun resetApiBaseUrl()
 }

--- a/infra/network/src/main/java/com/simprints/infra/network/url/BaseUrlProviderImpl.kt
+++ b/infra/network/src/main/java/com/simprints/infra/network/url/BaseUrlProviderImpl.kt
@@ -3,18 +3,26 @@ package com.simprints.infra.network.url
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
+import androidx.core.content.edit
+import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.BuildConfig
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import javax.inject.Singleton
 
-internal class BaseUrlProviderImpl @Inject constructor(@ApplicationContext context: Context) : BaseUrlProvider {
+@Singleton
+internal class BaseUrlProviderImpl @Inject constructor(
+    @ApplicationContext context: Context,
+) : BaseUrlProvider {
 
     companion object {
+
         private const val PREF_FILE_NAME = "b3f0cf9b-4f3f-4c5b-bf85-7b1f44eddd7a"
         private const val PREF_MODE = Context.MODE_PRIVATE
         private const val API_BASE_URL_KEY = "ApiBaseUrl"
         private const val API_VERSION = "v2"
         private const val BASE_URL_SUFFIX = "/androidapi/$API_VERSION/"
+
         @VisibleForTesting
         const val DEFAULT_BASE_URL =
             "https://${BuildConfig.BASE_URL_PREFIX}.simprints-apis.com$BASE_URL_SUFFIX"
@@ -24,6 +32,11 @@ internal class BaseUrlProviderImpl @Inject constructor(@ApplicationContext conte
     val prefs: SharedPreferences = context.getSharedPreferences(PREF_FILE_NAME, PREF_MODE)
 
     override fun getApiBaseUrl(): String = prefs.getString(API_BASE_URL_KEY, DEFAULT_BASE_URL)!!
+        .also { Simber.d("API base URL is $it") }
+
+    override fun getApiBaseUrlPrefix(): String = prefs.getString(API_BASE_URL_KEY, DEFAULT_BASE_URL)
+        ?.removeSuffix(BASE_URL_SUFFIX)
+        ?.also { Simber.d("API base URL prefix is $it") }!!
 
     override fun setApiBaseUrl(apiBaseUrl: String?) {
         val prefix = "https://"
@@ -36,11 +49,15 @@ internal class BaseUrlProviderImpl @Inject constructor(@ApplicationContext conte
             DEFAULT_BASE_URL
         }
 
-        prefs.edit().putString(API_BASE_URL_KEY, newValue).apply()
+        Simber.e("Setting API base URL to $newValue")
+
+        prefs.edit(commit = true) { putString(API_BASE_URL_KEY, newValue) }
+        Simber.e("Setting API base URL to ${getApiBaseUrl()}")
     }
 
-    override fun resetApiBaseUrl() =
-        prefs.edit().putString(API_BASE_URL_KEY, DEFAULT_BASE_URL).apply()
-
+    override fun resetApiBaseUrl() {
+        Simber.e("Resetting API base")
+        prefs.edit(commit = true) { putString(API_BASE_URL_KEY, DEFAULT_BASE_URL) }
+    }
 
 }

--- a/infra/network/src/test/java/com/simprints/infra/network/url/BaseUrlProviderImplTest.kt
+++ b/infra/network/src/test/java/com/simprints/infra/network/url/BaseUrlProviderImplTest.kt
@@ -14,7 +14,10 @@ import org.junit.Test
 class BaseUrlProviderImplTest {
 
     companion object {
+        private const val URL_SUFFIX = "/androidapi/v2/"
+
         private const val URL = "https://test"
+        private const val URL_WITH_SUFFIX = "https://test$URL_SUFFIX"
     }
 
     @RelaxedMockK
@@ -48,6 +51,15 @@ class BaseUrlProviderImplTest {
     }
 
     @Test
+    fun `get api base url prefix should return the actual url`() {
+        every { sharedPreferences.getString(any(), any()) } returns URL_WITH_SUFFIX
+
+        val url = baseUrlProviderImpl.getApiBaseUrlPrefix()
+
+        assertThat(url).isEqualTo(URL)
+    }
+
+    @Test
     fun `set api base url should set the url to the default one when the one passed is null`() {
         baseUrlProviderImpl.setApiBaseUrl(null)
 
@@ -59,7 +71,7 @@ class BaseUrlProviderImplTest {
         val url = "https://url.com"
         baseUrlProviderImpl.setApiBaseUrl(url)
 
-        verify(exactly = 1) { editor.putString(any(), "$url/androidapi/v2/") }
+        verify(exactly = 1) { editor.putString(any(), "$url$URL_SUFFIX") }
     }
 
     @Test
@@ -67,7 +79,7 @@ class BaseUrlProviderImplTest {
         val url = "url.com"
         baseUrlProviderImpl.setApiBaseUrl(url)
 
-        verify(exactly = 1) { editor.putString(any(), "https://$url/androidapi/v2/") }
+        verify(exactly = 1) { editor.putString(any(), "https://$url$URL_SUFFIX") }
     }
 
     @Test

--- a/infra/resources/src/main/res/color/input_text_background.xml
+++ b/infra/resources/src/main/res/color/input_text_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/simprints_grey_disabled" android:state_enabled="false" />
+    <item android:color="@color/simprints_white" />
+</selector>

--- a/infra/resources/src/main/res/values/colors.xml
+++ b/infra/resources/src/main/res/values/colors.xml
@@ -18,6 +18,7 @@
     <color name="simprints_off_white">#FFEEEEEE</color>
     <color name="simprints_grey">#FF888888</color>
     <color name="simprints_grey_light">#FFC0C0C0</color>
+    <color name="simprints_grey_disabled">#22000000</color>
     <color name="simprints_black">#000000</color>
     <color name="simprints_blue_grey_light">#A9B5C2</color>
     <color name="simprints_blue_grey">#384553</color>

--- a/infra/resources/src/main/res/values/strings.xml
+++ b/infra/resources/src/main/res/values/strings.xml
@@ -91,6 +91,10 @@
     <string name="login_no_network_error">Currently offline. Please check your internet connection.</string>
     <string name="login_integrity_service_down_error">A problem occurred trying to contact the Integrity Service. Please try again later.</string>
     <string name="login_server_error">A problem occurred trying to contact the server. Please try again later.</string>
+    <string name="login_change_url">Change backend URL</string>
+    <string name="login_change_url_save">Save</string>
+    <string name="login_change_url_reset">Use default</string>
+    <string name="login_change_url_cancel">Cancel</string>
 
     <!-- Matcher -->
     <string name="matcher_please_wait">Please wait while we proceed to identification</string>

--- a/infra/resources/src/main/res/values/styles-widget.xml
+++ b/infra/resources/src/main/res/values/styles-widget.xml
@@ -110,6 +110,7 @@
         <item name="android:textColorHint">@color/simprints_text_grey_light</item>
         <item name="endIconTint">@color/simprints_text_grey_light</item>
         <item name="android:textColor">@color/simprints_text_black</item>
+        <item name="boxBackgroundColor">@color/input_text_background</item>
     </style>
 
     <style name="ThemeOverlay.Simprints.TextInputLayout" parent="">


### PR DESCRIPTION
Main changes: 
* Removed unnecessary "hide password" toggle for user ID field
* Made project ID field read-only
* Made disabled input fields more obviously disabled
* Moved QR project ID comparison to the one provided by intent to happen right after the scan
* Added an option to manually change the backend URL for cases when QR code cannot be used for the login (extreme edge case, but still a valid one)