### PR TITLE
Only add sessionId label to an event if it was previously empty

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorActivity.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorActivity.kt
@@ -5,36 +5,52 @@ import android.os.Bundle
 import androidx.core.os.bundleOf
 import androidx.navigation.findNavController
 import com.simprints.core.tools.activity.BaseActivity
+import com.simprints.feature.orchestrator.cache.OrchestratorCache
 import com.simprints.feature.orchestrator.databinding.ActivityOrchestratorBinding
+import com.simprints.infra.logging.Simber
 import com.simprints.infra.orchestration.data.results.AppResult
 import com.simprints.infra.uibase.navigation.handleResult
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 internal class OrchestratorActivity : BaseActivity() {
 
     private val binding by viewBinding(ActivityOrchestratorBinding::inflate)
 
+    @Inject
+    lateinit var orchestratorCache: OrchestratorCache
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
-        binding.orchestrationHost.handleResult<AppResult>(this, R.id.orchestratorRootFragment) { result ->
+        binding.orchestrationHost.handleResult<AppResult>(
+            this,
+            R.id.orchestratorRootFragment
+        ) { result ->
             setResult(result.resultCode, Intent().putExtras(result.extras))
+
+            orchestratorCache.isExecuting.set(false)
             finish()
         }
     }
 
     override fun onStart() {
         super.onStart()
-        val action = intent.action.orEmpty()
-        val extras = intent.extras ?: bundleOf()
+        if (orchestratorCache.isExecuting.compareAndSet(false, true))  {
+            val action = intent.action.orEmpty()
+            val extras = intent.extras ?: bundleOf()
 
-        findNavController(R.id.orchestrationHost).setGraph(
-            R.navigation.graph_orchestration,
-            OrchestratorFragmentArgs(action, extras).toBundle()
-        )
+            findNavController(R.id.orchestrationHost).setGraph(
+                R.navigation.graph_orchestration,
+                OrchestratorFragmentArgs(action, extras).toBundle()
+            )
+        } else {
+            Simber.e("Orchestrator already executing, finishing with RESULT_CANCELED")
+            finish()
+        }
     }
 
 }

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorFragment.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorFragment.kt
@@ -64,7 +64,6 @@ import javax.inject.Inject
 @AndroidEntryPoint
 internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
 
-    private var isActivityRestored = false
     private var requestProcessed = false
 
     @Inject
@@ -182,7 +181,7 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
     override fun onResume() {
         super.onResume()
 
-        if (!isActivityRestored && !requestProcessed) {
+        if (!requestProcessed) {
             if (loginCheckVm.isDeviceSafe()) {
                 requestProcessed = true
                 lifecycleScope.launch {

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/cache/OrchestratorCache.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/cache/OrchestratorCache.kt
@@ -9,6 +9,7 @@ import com.simprints.feature.orchestrator.steps.SerializableMixin
 import com.simprints.feature.orchestrator.steps.Step
 import com.simprints.infra.security.SecurityManager
 import java.io.Serializable
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -47,6 +48,16 @@ internal class OrchestratorCache @Inject constructor(
             remove(KEY_STEPS)
         }
     }
+
+    /**
+     * There have been a number of cases when calling app makes several requests tens of ms apart, while it
+     * is not exactly clear why this is happening, it is clear that it is not the intended behavior.
+     *
+     * This in-memory flag is used to prevent the orchestrator from starting multiple times.
+     * It will cause any consecutive requests to return `Activity.RESULT_CANCELED` and it is callers
+     * responsibility to handle this case.
+     */
+    val isExecuting = AtomicBoolean(false)
 
     companion object {
         private const val ORCHESTRATION_CACHE = "ORCHESTRATOR_CACHE"

--- a/infra/events/src/main/java/com/simprints/infra/events/EventRepositoryImpl.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/EventRepositoryImpl.kt
@@ -108,7 +108,7 @@ internal open class EventRepositoryImpl @Inject constructor(
 
     private fun checkAndUpdateLabels(event: Event, session: SessionCaptureEvent) {
         event.labels = event.labels.copy(
-            sessionId = session.id,
+            sessionId = event.labels.sessionId ?: session.id,
             projectId = session.payload.projectId,
             deviceId = deviceId,
         )


### PR DESCRIPTION
My understanding of the problem: 
* This only happened if several sessions were fired with unfortunate timing - the second session started processing around the time the first one got to the end of `UpdateProjectInCurrentSessionUseCase`. The timing is hard to estimate, but luckily I got a very slow device, and there is a 3-4 second window between intent firing and splash screen.
* Somehow, the new session manages to add a new `SessionCaptureEvent` with a new session ID and it gets stored in `EventRepository` event cache.
* At the same time previous session events are going through "read -> update labels -> write" sequence within the use case.
* But since the event in the cache has been changed, the session ID label in the updated events gets overwritten. Therefore we get `SessionCaptureEvents` from different sessions clash in the validator.

The fix is to never override the session ID in event labels if it is not null. I might be wrong here, but there should be no valid reason why events ever change the session to which they belong.