### PR TITLE
[MS-255] Fixing and issue when the biometrics flow is not restored after moving application to the background

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/ExecutionTracker.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/ExecutionTracker.kt
@@ -3,36 +3,70 @@ package com.simprints.feature.orchestrator
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
+import com.simprints.core.tools.time.TimeHelper
 import com.simprints.infra.logging.Simber
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-internal class ExecutionTracker @Inject constructor() : LifecycleEventObserver {
+internal class ExecutionTracker @Inject constructor(
+    private val timeHelper: TimeHelper,
+    @ExecutorLockTimeoutSec private val executionTimeLimitSec: Int
+) : LifecycleEventObserver {
 
     /**
-     * There have been a number of cases when calling app makes several requests tens of ms apart, while it
-     * is not exactly clear why this is happening, it is clear that it is not the intended behavior.
+     * Timestamp representing when the [currentLifecycleOwnerId] was set. This is a safeguard
+     * measure for cases when [Lifecycle.Event.ON_DESTROY] is not called by the system. Should it
+     * ever happen, the [ExecutionTracker] has a check for whether enough time has passed, and if
+     * the [currentLifecycleOwnerId] can be released.
      *
-     * This in-memory flag is used to prevent the orchestrator from starting multiple times.
-     * It will cause any consecutive requests to return `Activity.RESULT_CANCELED` and it is callers
-     * responsibility to handle this case.
+     * Limit for execution is set by the [executionTimeLimitSec] (in seconds).
      */
-    val isExecuting = AtomicBoolean(false)
+    private var timestamp: Long = 0
 
-    private var activityCount = 0
+    /**
+     * ID of the [LifecycleOwner] that is considered the main executor.
+     */
+    private var currentLifecycleOwnerId: Int? = null
 
     override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        val ownerId = source.id()
         if (event == Lifecycle.Event.ON_CREATE) {
-            activityCount++
+            Simber.i("Lifecycle owner [$ownerId] is set as main executor")
+            if (currentLifecycleOwnerId == null || enoughTimePassedSinceLastLock()) {
+                currentLifecycleOwnerId = ownerId
+                timestamp = timeHelper.now()
+            }
+
         } else if (event == Lifecycle.Event.ON_DESTROY) {
-            activityCount = (activityCount - 1).coerceAtLeast(0)
-            if (activityCount == 0) {
-                isExecuting.set(false)
-                Simber.i("All activities have been closed.")
+            if (currentLifecycleOwnerId == ownerId) {
+                currentLifecycleOwnerId = null
+                timestamp = 0
+                Simber.i("Lifecycle owner [$ownerId] removed from main executor")
             }
         }
+    }
 
+    /**
+     * Check for whether enough time has passed since the last set of the [currentLifecycleOwnerId].
+     *
+     * @return true when the difference between current time and the [timestamp] is greater than
+     * amount of seconds specified in the [executionTimeLimitSec]. False otherwise.
+     */
+    private fun enoughTimePassedSinceLastLock() =
+        timeHelper.msBetweenNowAndTime(timestamp) > 1000 * executionTimeLimitSec
+
+    fun LifecycleOwner.id(): Int = hashCode()
+
+    /**
+     * Checks whether the current activity (more technically, its [LifecycleOwner]) has rights to be
+     * executed at this moment.
+     *
+     * @param activity reference to the corresponding [LifecycleOwner]
+     * @return true if there are no other instances of this lifecycle owner running. False
+     * otherwise.
+     */
+    fun isMain(activity: LifecycleOwner): Boolean {
+        return currentLifecycleOwnerId == activity.hashCode()
     }
 }

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorActivity.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorActivity.kt
@@ -21,7 +21,6 @@ internal class OrchestratorActivity : BaseActivity() {
     @Inject
     lateinit var activityTracker: ExecutionTracker
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         lifecycle.addObserver(activityTracker)
@@ -33,8 +32,6 @@ internal class OrchestratorActivity : BaseActivity() {
             R.id.orchestratorRootFragment
         ) { result ->
             setResult(result.resultCode, Intent().putExtras(result.extras))
-
-            activityTracker.isExecuting.set(false)
             finish()
         }
     }
@@ -42,7 +39,7 @@ internal class OrchestratorActivity : BaseActivity() {
     override fun onStart() {
         super.onStart()
 
-        if (activityTracker.isExecuting.compareAndSet(false, true)) {
+        if (activityTracker.isMain(activity = this)) {
             val action = intent.action.orEmpty()
             val extras = intent.extras ?: bundleOf()
 

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorModule.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorModule.kt
@@ -1,0 +1,23 @@
+package com.simprints.feature.orchestrator
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+internal annotation class ExecutorLockTimeoutSec
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object OrchestratorModule {
+
+    @Provides
+    @Singleton
+    @ExecutorLockTimeoutSec
+    fun provideExecutorLockTimeout(): Int = 60
+}

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/ExecutionTrackerTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/ExecutionTrackerTest.kt
@@ -1,39 +1,118 @@
 package com.simprints.feature.orchestrator
 
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import com.google.common.truth.Truth.assertThat
+import com.simprints.core.tools.time.TimeHelper
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.Before
 import org.junit.Test
 
 class ExecutionTrackerTest {
-
     private lateinit var executionTracker: ExecutionTracker
+    private lateinit var timeHelper: TimeHelper
+    private val executionTimeLimitSec: Int = 1
 
     @Before
     fun setUp() {
-        executionTracker = ExecutionTracker()
+        timeHelper = mockk()
+        every { timeHelper.now() } returns 0L
+        every { timeHelper.msBetweenNowAndTime(any()) } returns 0L
+
+        executionTracker = ExecutionTracker(
+            timeHelper = timeHelper,
+            executionTimeLimitSec = executionTimeLimitSec
+        )
     }
 
     @Test
-    fun `resets execution flag if single activity created and destroyed`() {
-        executionTracker.onStateChanged(mockk(), Lifecycle.Event.ON_CREATE)
-        executionTracker.isExecuting.set(true)
+    fun `when owner is created, then it becomes the main executor`() {
+        val ownerId = 123
+        val owner = mockk<LifecycleOwner>()
+        every { owner.hashCode() } returns ownerId
 
-        executionTracker.onStateChanged(mockk(), Lifecycle.Event.ON_DESTROY)
-        assertThat(executionTracker.isExecuting.get()).isFalse()
+        executionTracker.onStateChanged(owner, Lifecycle.Event.ON_CREATE)
+
+        assertThat(executionTracker.isMain(owner)).isTrue()
     }
 
     @Test
-    fun `resets execution flag if multiple activity created and destroyed`() {
-        executionTracker.onStateChanged(mockk(), Lifecycle.Event.ON_CREATE)
-        executionTracker.onStateChanged(mockk(), Lifecycle.Event.ON_CREATE)
-        executionTracker.isExecuting.set(true)
+    fun `when owner is destroyed, then it is no longer remains the main executor`() {
+        val ownerId = 123
+        val owner = mockk<LifecycleOwner>()
+        every { owner.hashCode() } returns ownerId
 
-        executionTracker.onStateChanged(mockk(), Lifecycle.Event.ON_DESTROY)
-        assertThat(executionTracker.isExecuting.get()).isTrue()
+        executionTracker.onStateChanged(owner, Lifecycle.Event.ON_CREATE)
+        executionTracker.onStateChanged(owner, Lifecycle.Event.ON_DESTROY)
 
-        executionTracker.onStateChanged(mockk(), Lifecycle.Event.ON_DESTROY)
-        assertThat(executionTracker.isExecuting.get()).isFalse()
+        assertThat(executionTracker.isMain(owner)).isFalse()
+    }
+
+    @Test
+    fun `given second owner, when first owner is destroyed, then the second owner becomes the main executor`() {
+        val ownerId1 = 123
+        val ownerId2 = 456
+        val firstOwner = mockk<LifecycleOwner>()
+        val secondOwner = mockk<LifecycleOwner>()
+        every { firstOwner.hashCode() } returns ownerId1
+        every { secondOwner.hashCode() } returns ownerId2
+
+        executionTracker.onStateChanged(firstOwner, Lifecycle.Event.ON_CREATE)
+        executionTracker.onStateChanged(firstOwner, Lifecycle.Event.ON_DESTROY)
+        executionTracker.onStateChanged(secondOwner, Lifecycle.Event.ON_CREATE)
+
+        assertThat(executionTracker.isMain(secondOwner)).isTrue()
+    }
+
+    @Test
+    fun `given second owner, when first owner is not yet destroyed, then the first owner remains the main executor`() {
+        val ownerId1 = 123
+        val ownerId2 = 456
+        val firstOwner = mockk<LifecycleOwner>()
+        val secondOwner = mockk<LifecycleOwner>()
+        every { firstOwner.hashCode() } returns ownerId1
+        every { secondOwner.hashCode() } returns ownerId2
+
+        executionTracker.onStateChanged(firstOwner, Lifecycle.Event.ON_CREATE)
+        executionTracker.onStateChanged(secondOwner, Lifecycle.Event.ON_CREATE)
+
+        assertThat(executionTracker.isMain(firstOwner)).isTrue()
+    }
+
+    @Test
+    fun `given second owner and not enough time passed to unlock the main executor, when first owner is not yet destroyed, then the first owner remains the main executor`() {
+        val ownerId1 = 123
+        val ownerId2 = 456
+        val firstOwner = mockk<LifecycleOwner>()
+        val secondOwner = mockk<LifecycleOwner>()
+
+        every { firstOwner.hashCode() } returns ownerId1
+        every { secondOwner.hashCode() } returns ownerId2
+        every { timeHelper.now() } returns 0L
+        every { timeHelper.msBetweenNowAndTime(any()) } returns 1000L * (executionTimeLimitSec)
+
+        executionTracker.onStateChanged(firstOwner, Lifecycle.Event.ON_CREATE)
+        executionTracker.onStateChanged(secondOwner, Lifecycle.Event.ON_CREATE)
+
+        assertThat(executionTracker.isMain(firstOwner)).isTrue()
+    }
+
+    @Test
+    fun `given second owner and enough time passed to unlock the main executor, when first owner is not yet destroyed, then the second owner becomes the main executor`() {
+        val ownerId1 = 123
+        val ownerId2 = 456
+        val firstOwner = mockk<LifecycleOwner>()
+        val secondOwner = mockk<LifecycleOwner>()
+
+        every { firstOwner.hashCode() } returns ownerId1
+        every { secondOwner.hashCode() } returns ownerId2
+        every { timeHelper.now() } returns 0L
+        every { timeHelper.msBetweenNowAndTime(any()) } returns 1000L * (executionTimeLimitSec + 1)
+
+        executionTracker.onStateChanged(firstOwner, Lifecycle.Event.ON_CREATE)
+        executionTracker.onStateChanged(secondOwner, Lifecycle.Event.ON_CREATE)
+
+        assertThat(executionTracker.isMain(secondOwner)).isTrue()
     }
 }


### PR DESCRIPTION
ExecutionTracker now saves the 'currentLifecycleOwnerId' as a reference to the current main executing activity. All subsequent OrchestratorActivity instances will be finished, if another one is executing.