### PR TITLE
fix android.app.InvalidForegroundServiceTypeException in android 14

### DIFF
--- a/id/src/main/AndroidManifest.xml
+++ b/id/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <!-- Permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
@@ -22,7 +23,13 @@
 
         <service
             android:name=".services.sync.events.down.EventDownSyncResetService"
+            android:foregroundServiceType="dataSync"
             android:exported="false" />
+
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
 
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/id/src/main/java/com/simprints/id/services/sync/events/down/EventDownSyncResetService.kt
+++ b/id/src/main/java/com/simprints/id/services/sync/events/down/EventDownSyncResetService.kt
@@ -6,6 +6,7 @@ import android.app.NotificationManager
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
@@ -68,7 +69,12 @@ class EventDownSyncResetService : Service() {
                 .setPriority(NotificationManager.IMPORTANCE_LOW)
                 .setCategory(Notification.CATEGORY_SERVICE)
                 .build()
-            startForeground(1, notification)
+            // if runtime >= Q then use FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(1, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+            } else {
+                startForeground(1, notification)
+            }
         }
     }
 

--- a/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
+++ b/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
@@ -5,6 +5,7 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.content.pm.ServiceInfo
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
@@ -98,7 +99,11 @@ abstract class SimCoroutineWorker(
                 }
             }
             .build()
-        return ForegroundInfo(WORKER_FOREGROUND_NOTIFICATION_ID, notification)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(WORKER_FOREGROUND_NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            ForegroundInfo(WORKER_FOREGROUND_NOTIFICATION_ID, notification)
+        }
     }
 
     protected fun crashlyticsLog(message: String) {


### PR DESCRIPTION
As documented [here ](https://developer.android.com/about/versions/14/changes/fgs-types-required#include-fgs-type-runtime) 

Calling `startForeground() ` without declaring the appropriate foreground service type permission, the system throws a SecurityException `InvalidForegroundServiceTypeException `