### PR TITLE
[MS-271] Skip Fingerprint Template Extraction for Low-Quality Images

### DIFF
--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
@@ -339,18 +339,15 @@ internal class FingerprintCaptureViewModel @Inject constructor(
                 val capturedFingerprint = bioSdkWrapper.acquireFingerprintTemplate(
                     bioSdkConfiguration.vero2?.captureStrategy?.toInt(),
                     bioSdkWrapper.scanningTimeoutMs.toInt(),
-                    qualityThreshold()
+                    qualityThreshold(),
+                    // is this is the last bad scan, we allow low quality extraction
+                    tooManyBadScans(state.currentCaptureState(), plusBadScan = true)
                 )
 
                 handleCaptureSuccess(capturedFingerprint)
             } catch (ex: CancellationException) {
                 // ignore cancellation exception, but log behaviour
                 Simber.d("Fingerprint scanning was cancelled")
-            } catch (ex: BioSdkException.ImageQualityBelowThresholdException) {
-                // this exception is thrown when the image quality is below the threshold
-                // and it is thrown from NEC SDK it should be handled as a no finger detected exception not
-                // as a low quality scan issue because there is no template extracted from the image
-                handleNoFingerDetected()
             } catch (ex: Throwable) {
                 handleScannerCommunicationsError(ex)
             }

--- a/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModelTest.kt
+++ b/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModelTest.kt
@@ -330,7 +330,7 @@ class FingerprintCaptureViewModelTest {
     fun scanPressed_scannerDisconnectedDuringScan_updatesStateCorrectlyAndReconnects() = runTest {
         mockScannerSetUiIdle()
         coEvery {
-            bioSdkWrapper.acquireFingerprintTemplate(any(), any(), any())
+            bioSdkWrapper.acquireFingerprintTemplate(any(), any(), any(),any())
         } throws ScannerDisconnectedException()
         withImageTransfer()
 
@@ -398,6 +398,8 @@ class FingerprintCaptureViewModelTest {
         assertThat(vm.stateLiveData.value?.isShowingSplashScreen).isFalse()
         assertThat(vm.stateLiveData.value?.currentFingerIndex).isEqualTo(1)
 
+        coVerify(exactly = 2) { bioSdkWrapper.acquireFingerprintTemplate(any(), any(), any(), false) }
+        coVerify(exactly = 1) { bioSdkWrapper.acquireFingerprintTemplate(any(), any(), any(), true) }
         coVerify(exactly = 1) { bioSdkWrapper.acquireFingerprintImage() }
         coVerify(exactly = 3) { addCaptureEventsUseCase.invoke(any(), any(), any(), any()) }
     }
@@ -1243,7 +1245,7 @@ class FingerprintCaptureViewModelTest {
 
     @ExperimentalTime
     private fun setupCaptureFingerprintResponses(vararg mockResponses: MockCaptureFingerprintResponse) {
-        val initialMock = coEvery { bioSdkWrapper.acquireFingerprintTemplate(any(), any(), any()) }
+        val initialMock = coEvery { bioSdkWrapper.acquireFingerprintTemplate(any(), any(), any(),any()) }
         val fingerprintResponses = mockResponses.map { it.toCaptureFingerprintResponse() }
 
         // capture the first response in the list

--- a/fingerprint/infra/base-bio-sdk/src/main/java/com/simprints/fingerprint/infra/basebiosdk/exceptions/BioSdkException.kt
+++ b/fingerprint/infra/base-bio-sdk/src/main/java/com/simprints/fingerprint/infra/basebiosdk/exceptions/BioSdkException.kt
@@ -14,9 +14,6 @@ sealed class BioSdkException(
     class ImageQualityCheckingException(override val cause: Throwable?) :
         BioSdkException("Cannot check image quality")
 
-    class ImageQualityBelowThresholdException(val imageQualityScore: Int) :
-        BioSdkException("Image quality below threshold")
-
     class TemplateExtractionException(override val cause: Throwable?) :
         BioSdkException("Cannot extract template")
 

--- a/fingerprint/infra/bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdk/BioSdkWrapper.kt
+++ b/fingerprint/infra/bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdk/BioSdkWrapper.kt
@@ -23,7 +23,8 @@ interface BioSdkWrapper {
     suspend fun acquireFingerprintTemplate(
         capturingResolution: Int?,
         timeOutMs: Int,
-        qualityThreshold: Int
+        qualityThreshold: Int,
+        allowLowQualityExtraction: Boolean
     ): AcquireFingerprintTemplateResponse
 
     suspend fun acquireFingerprintImage(): AcquireFingerprintImageResponse

--- a/fingerprint/infra/bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdk/NECBioSdkWrapper.kt
+++ b/fingerprint/infra/bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdk/NECBioSdkWrapper.kt
@@ -34,12 +34,14 @@ class NECBioSdkWrapper @Inject constructor(
     override suspend fun acquireFingerprintTemplate(
         capturingResolution: Int?,
         timeOutMs: Int,
-        qualityThreshold: Int
+        qualityThreshold: Int,
+        allowLowQualityExtraction: Boolean
     ): AcquireFingerprintTemplateResponse {
         val settings = FingerprintTemplateAcquisitionSettings(
             capturingResolution?.let { Dpi(it.toShort()) },
             timeOutMs,
-            qualityThreshold
+            qualityThreshold,
+            allowLowQualityExtraction
         )
         return bioSdk.acquireFingerprintTemplate(settings).toDomain()
     }

--- a/fingerprint/infra/bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdk/SimprintsBioSdkWrapper.kt
+++ b/fingerprint/infra/bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdk/SimprintsBioSdkWrapper.kt
@@ -33,12 +33,14 @@ class SimprintsBioSdkWrapper @Inject constructor(
     override suspend fun acquireFingerprintTemplate(
         capturingResolution: Int?,
         timeOutMs: Int,
-        qualityThreshold: Int
+        qualityThreshold: Int,
+        allowLowQualityExtraction: Boolean
     ): AcquireFingerprintTemplateResponse {
         val settings = FingerprintTemplateAcquisitionSettings(
             capturingResolution?.let { Dpi(it.toShort()) },
             timeOutMs,
-            qualityThreshold
+            qualityThreshold,
+            allowLowQualityExtraction
         )
         return bioSdk.acquireFingerprintTemplate(settings).toDomain()
     }

--- a/fingerprint/infra/bio-sdk/src/test/java/com/simprints/fingerprint/infra/biosdk/NECBioSdkWrapperTest.kt
+++ b/fingerprint/infra/bio-sdk/src/test/java/com/simprints/fingerprint/infra/biosdk/NECBioSdkWrapperTest.kt
@@ -82,6 +82,7 @@ class NECBioSdkWrapperTest {
         val captureFingerprintStrategy = 1000
         val captureTimeOutMs = 1000
         val captureQualityThreshold = 100
+        val captureAllowLowQualityExtraction = true
 
         val bioSdkResponse = TemplateResponse(
             byteArrayOf(1, 2, 3), FingerprintTemplateMetadata(
@@ -93,7 +94,7 @@ class NECBioSdkWrapperTest {
 
         //When
         val response = necBioSdkWrapper.acquireFingerprintTemplate(
-            captureFingerprintStrategy, captureTimeOutMs, captureQualityThreshold
+            captureFingerprintStrategy, captureTimeOutMs, captureQualityThreshold, captureAllowLowQualityExtraction
         )
 
         //Then
@@ -103,6 +104,7 @@ class NECBioSdkWrapperTest {
                 .isEqualTo(captureFingerprintStrategy.toShort())
             Truth.assertThat(timeOutMs).isEqualTo(captureTimeOutMs)
             Truth.assertThat(qualityThreshold).isEqualTo(captureQualityThreshold)
+            Truth.assertThat(allowLowQualityExtraction).isEqualTo(captureAllowLowQualityExtraction)
         }
         Truth.assertThat(bioSdkResponse.template).isEqualTo(response.template)
         Truth.assertThat(bioSdkResponse.templateMetadata?.templateFormat)
@@ -122,7 +124,7 @@ class NECBioSdkWrapperTest {
         )
 
         assertThrows<IllegalArgumentException> {
-            necBioSdkWrapper.acquireFingerprintTemplate(1, 1, 1)
+            necBioSdkWrapper.acquireFingerprintTemplate(1, 1, 1, true)
         }
     }
 

--- a/fingerprint/infra/bio-sdk/src/test/java/com/simprints/fingerprint/infra/biosdk/SimprintsBioSdkWrapperTest.kt
+++ b/fingerprint/infra/bio-sdk/src/test/java/com/simprints/fingerprint/infra/biosdk/SimprintsBioSdkWrapperTest.kt
@@ -77,6 +77,7 @@ class SimprintsBioSdkWrapperTest {
         val captureFingerprintStrategy = 1000
         val captureTimeOutMs = 1000
         val captureQualityThreshold = 100
+        val captureAllowLowQualityExtraction = true
 
         val bioSdkResponse = TemplateResponse(
             byteArrayOf(1, 2, 3), FingerprintTemplateMetadata(
@@ -88,7 +89,7 @@ class SimprintsBioSdkWrapperTest {
 
         //When
         val response = simprintsBioSdkWrapper.acquireFingerprintTemplate(
-            captureFingerprintStrategy, captureTimeOutMs, captureQualityThreshold
+            captureFingerprintStrategy, captureTimeOutMs, captureQualityThreshold, captureAllowLowQualityExtraction
         )
 
         //Then
@@ -97,6 +98,7 @@ class SimprintsBioSdkWrapperTest {
             assertThat(captureFingerprintDpi?.value).isEqualTo(captureFingerprintStrategy.toShort())
             assertThat(timeOutMs).isEqualTo(captureTimeOutMs)
             assertThat(qualityThreshold).isEqualTo(captureQualityThreshold)
+            assertThat(allowLowQualityExtraction).isEqualTo(captureAllowLowQualityExtraction)
         }
         assertThat(bioSdkResponse.template).isEqualTo(response.template)
         assertThat(bioSdkResponse.templateMetadata?.templateFormat).isEqualTo(response.templateFormat)
@@ -114,7 +116,7 @@ class SimprintsBioSdkWrapperTest {
         )
 
         assertThrows<IllegalArgumentException> {
-            simprintsBioSdkWrapper.acquireFingerprintTemplate(1, 1, 1)
+            simprintsBioSdkWrapper.acquireFingerprintTemplate(1, 1, 1, true)
         }
     }
 

--- a/fingerprint/infra/nec-bio-sdk/src/main/java/com/simprints/fingerprint/infra/necsdkimpl/acquisition/template/FingerprintTemplateAcquisitionSettings.kt
+++ b/fingerprint/infra/nec-bio-sdk/src/main/java/com/simprints/fingerprint/infra/necsdkimpl/acquisition/template/FingerprintTemplateAcquisitionSettings.kt
@@ -7,5 +7,5 @@ data class FingerprintTemplateAcquisitionSettings(
     val processingResolution: Dpi?,
     val timeOutMs: Int,
     val qualityThreshold: Int,
-    val allowLowQualityExtraction: Boolean=false
+    val allowLowQualityExtraction: Boolean
 )

--- a/fingerprint/infra/nec-bio-sdk/src/main/java/com/simprints/fingerprint/infra/necsdkimpl/acquisition/template/FingerprintTemplateAcquisitionSettings.kt
+++ b/fingerprint/infra/nec-bio-sdk/src/main/java/com/simprints/fingerprint/infra/necsdkimpl/acquisition/template/FingerprintTemplateAcquisitionSettings.kt
@@ -6,5 +6,6 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.un20.model
 data class FingerprintTemplateAcquisitionSettings(
     val processingResolution: Dpi?,
     val timeOutMs: Int,
-    val qualityThreshold: Int
+    val qualityThreshold: Int,
+    val allowLowQualityExtraction: Boolean=false
 )

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintCaptureWrapper.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintCaptureWrapper.kt
@@ -13,7 +13,8 @@ interface FingerprintCaptureWrapper {
     suspend fun acquireFingerprintTemplate(
         captureDpi: Dpi?,
         timeOutMs: Int,
-        qualityThreshold: Int
+        qualityThreshold: Int,
+        allowLowQualityExtraction: Boolean
     ): AcquireFingerprintTemplateResponse
 
     val templateFormat: String

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintCaptureWrapperV1.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintCaptureWrapperV1.kt
@@ -40,7 +40,10 @@ internal class FingerprintCaptureWrapperV1(
         captureDpi: Dpi?,
         timeOutMs: Int,
         qualityThreshold: Int,
+        allowLowQualityExtraction: Boolean,
     ): AcquireFingerprintTemplateResponse = withContext(ioDispatcher) {
+        // V1 scanner does not have a separate method to extract fingerprint template so we should
+        // ignore the allowLowQualityExtraction parameter
         suspendCancellableCoroutine { cont ->
             scannerV1.startContinuousCapture(
                 qualityThreshold,

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintCaptureWrapperV1Test.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintCaptureWrapperV1Test.kt
@@ -91,7 +91,8 @@ class FingerprintCaptureWrapperV1Test {
     private suspend fun startCapturing() = scannerWrapper.acquireFingerprintTemplate(
         Dpi(1000),
         3000,
-        60
+        60,
+        false
     )
 
 }

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintCaptureWrapperV2Test.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintCaptureWrapperV2Test.kt
@@ -278,8 +278,28 @@ class FingerprintCaptureWrapperV2Test {
             )
 
             verify(exactly = 1) { scannerUiHelper.badScanLedState() }
+            verify(exactly = 0) {scannerV2.acquireTemplate(any())  }
         }
+    @Test
+    fun `should extract template when captured fingerprint's image quality score is less than specified image quality_threshold and allowLowQualityExtraction is true`() =
+        runTest {
+            val qualityThreshold = 50
+            every { scannerV2.getImageQualityScore() } returns Maybe.just(qualityThreshold - 10)
+            every { scannerV2.setSmileLedState(any()) } returns Completable.complete()
+            every { scannerV2.captureFingerprint(any()) } answers {
+                (Single.just(CaptureFingerprintResult.OK))
+            }
+            every { scannerV2.acquireTemplate(any()) } returns Maybe.just(TemplateData(byteArrayOf()))
 
+            scannerWrapper.acquireFingerprintTemplate(
+                Dpi(1300),
+                1000,
+                qualityThreshold,
+                true
+            )
+
+            verify(exactly = 1) {scannerV2.acquireTemplate(any())  }
+        }
     @Test
     fun `should trigger good_scan LED when captured fingerprint's image quality score is greater or equal to specified image quality_threshold`() =
         runTest {

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintCaptureWrapperV2Test.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintCaptureWrapperV2Test.kt
@@ -94,7 +94,8 @@ class FingerprintCaptureWrapperV2Test {
             scannerWrapper.acquireFingerprintTemplate(
                 null,
                 1000,
-                50
+                50,
+                false
             )
         }
     }
@@ -105,7 +106,8 @@ class FingerprintCaptureWrapperV2Test {
             scannerWrapper.acquireFingerprintTemplate(
                 Dpi(499),
                 1000,
-                50
+                50,
+                false
             )
         }
     }
@@ -117,7 +119,8 @@ class FingerprintCaptureWrapperV2Test {
                 scannerWrapper.acquireFingerprintTemplate(
                     Dpi(1701),
                     1000,
-                    50
+                    50,
+                    false
                 )
             }
         }
@@ -140,7 +143,8 @@ class FingerprintCaptureWrapperV2Test {
             scannerWrapper.acquireFingerprintTemplate(
                 Dpi(1300),
                 1000,
-                50
+                50,
+                false
             )
         }
         // and then throws UnexpectedScannerException
@@ -148,7 +152,8 @@ class FingerprintCaptureWrapperV2Test {
             scannerWrapper.acquireFingerprintTemplate(
                 Dpi(1300),
                 1000,
-                50
+                50,
+                false
             )
         }
         // and then throws UnknownScannerIssueException
@@ -156,7 +161,8 @@ class FingerprintCaptureWrapperV2Test {
             scannerWrapper.acquireFingerprintTemplate(
                 Dpi(1300),
                 1000,
-                50
+                50,
+                false
             )
         }
     }
@@ -195,7 +201,8 @@ class FingerprintCaptureWrapperV2Test {
             scannerWrapper.acquireFingerprintTemplate(
                 Dpi(1300),
                 timeOutMs = 30000,
-                qualityThreshold = 7
+                qualityThreshold = 7,
+                false
             )
         }
 
@@ -223,7 +230,8 @@ class FingerprintCaptureWrapperV2Test {
             val actualResponse = scannerWrapper.acquireFingerprintTemplate(
                 Dpi(1300),
                 1000,
-                qualityThreshold
+                qualityThreshold,
+                false
             )
 
             assertThat(expectedCaptureResponse.template).isEqualTo(actualResponse.template)
@@ -245,7 +253,8 @@ class FingerprintCaptureWrapperV2Test {
                 scannerWrapper.acquireFingerprintTemplate(
                     Dpi(1300),
                     1000,
-                    qualityThreshold
+                    qualityThreshold,
+                    false
                 )
             }
         }
@@ -264,7 +273,8 @@ class FingerprintCaptureWrapperV2Test {
             scannerWrapper.acquireFingerprintTemplate(
                 Dpi(1300),
                 1000,
-                qualityThreshold
+                qualityThreshold,
+                false
             )
 
             verify(exactly = 1) { scannerUiHelper.badScanLedState() }
@@ -284,7 +294,8 @@ class FingerprintCaptureWrapperV2Test {
             scannerWrapper.acquireFingerprintTemplate(
                 Dpi(1300),
                 1000,
-                qualityThreshold
+                qualityThreshold,
+                false
             )
 
             verify(exactly = 1) { scannerUiHelper.goodScanLedState() }
@@ -303,7 +314,8 @@ class FingerprintCaptureWrapperV2Test {
                 scannerWrapper.acquireFingerprintTemplate(
                     Dpi(1300),
                     1000,
-                    50
+                    50,
+                    false
                 )
             }
         }

--- a/fingerprint/infra/simprints-bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdkimpl/acquisition/template/FingerprintTemplateAcquisitionSettings.kt
+++ b/fingerprint/infra/simprints-bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdkimpl/acquisition/template/FingerprintTemplateAcquisitionSettings.kt
@@ -6,5 +6,6 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.un20.model
 data class FingerprintTemplateAcquisitionSettings(
     val captureFingerprintDpi: Dpi?,
     val timeOutMs: Int,
-    val qualityThreshold: Int
+    val qualityThreshold: Int,
+    val allowLowQualityExtraction: Boolean=false
 )

--- a/fingerprint/infra/simprints-bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdkimpl/acquisition/template/FingerprintTemplateProviderImpl.kt
+++ b/fingerprint/infra/simprints-bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdkimpl/acquisition/template/FingerprintTemplateProviderImpl.kt
@@ -13,7 +13,8 @@ internal class FingerprintTemplateProviderImpl @Inject constructor(
         val response = fingerprintCaptureWrapperFactory.captureWrapper.acquireFingerprintTemplate(
             settings.captureFingerprintDpi,
             settings.timeOutMs,
-            settings.qualityThreshold
+            settings.qualityThreshold,
+            settings.allowLowQualityExtraction
         )
         return TemplateResponse(
             response.template,

--- a/fingerprint/infra/simprints-bio-sdk/src/test/java/com/simprints/fingerprint/infra/biosdkimpl/acquisition/template/FingerPrintTemplateProviderImplTest.kt
+++ b/fingerprint/infra/simprints-bio-sdk/src/test/java/com/simprints/fingerprint/infra/biosdkimpl/acquisition/template/FingerPrintTemplateProviderImplTest.kt
@@ -48,7 +48,8 @@ class FingerPrintTemplateProviderImplTest {
             fingerprintCaptureWrapperFactory.captureWrapper.acquireFingerprintTemplate(
                 settings.captureFingerprintDpi,
                 settings.timeOutMs,
-                settings.qualityThreshold
+                settings.qualityThreshold,
+                settings.allowLowQualityExtraction
             )
         } returns templateResponse
         //When


### PR DESCRIPTION
- Save useless template extraction time in Vero2 only. 
- Skip Fingerprint Template Extraction for Low-Quality Images 