### PR TITLE
MS-255 Adjust execution tracker to correctly restore the correct activity

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorActivity.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorActivity.kt
@@ -21,7 +21,6 @@ internal class OrchestratorActivity : BaseActivity() {
     @Inject
     lateinit var activityTracker: ExecutionTracker
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         lifecycle.addObserver(activityTracker)
@@ -33,8 +32,6 @@ internal class OrchestratorActivity : BaseActivity() {
             R.id.orchestratorRootFragment
         ) { result ->
             setResult(result.resultCode, Intent().putExtras(result.extras))
-
-            activityTracker.isExecuting.set(false)
             finish()
         }
     }
@@ -42,7 +39,7 @@ internal class OrchestratorActivity : BaseActivity() {
     override fun onStart() {
         super.onStart()
 
-        if (activityTracker.isExecuting.compareAndSet(false, true)) {
+        if (activityTracker.isMain(activity = this)) {
             val action = intent.action.orEmpty()
             val extras = intent.extras ?: bundleOf()
 

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorModule.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorModule.kt
@@ -1,0 +1,23 @@
+package com.simprints.feature.orchestrator
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+internal annotation class ExecutorLockTimeoutSec
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object OrchestratorModule {
+
+    @Provides
+    @Singleton
+    @ExecutorLockTimeoutSec
+    fun provideExecutorLockTimeout(): Int = 60
+}

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/ExecutionTrackerTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/ExecutionTrackerTest.kt
@@ -1,7 +1,11 @@
 package com.simprints.feature.orchestrator
 
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import com.google.common.truth.Truth.assertThat
+import com.simprints.core.tools.time.TimeHelper
+import com.simprints.core.tools.time.Timestamp
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.Before
 import org.junit.Test
@@ -9,31 +13,106 @@ import org.junit.Test
 class ExecutionTrackerTest {
 
     private lateinit var executionTracker: ExecutionTracker
+    private lateinit var timeHelper: TimeHelper
+    private val executionTimeLimitSec: Int = 1
 
     @Before
     fun setUp() {
-        executionTracker = ExecutionTracker()
+        timeHelper = mockk()
+        every { timeHelper.now() } returns Timestamp(0L)
+        every { timeHelper.msBetweenNowAndTime(any()) } returns 0L
+
+        executionTracker = ExecutionTracker(
+            timeHelper = timeHelper,
+            executionTimeLimitSec = executionTimeLimitSec
+        )
     }
 
     @Test
-    fun `resets execution flag if single activity created and destroyed`() {
-        executionTracker.onStateChanged(mockk(), Lifecycle.Event.ON_CREATE)
-        executionTracker.isExecuting.set(true)
+    fun `when owner is created, then it becomes the main executor`() {
+        val ownerId = 123
+        val owner = mockk<LifecycleOwner>()
+        every { owner.hashCode() } returns ownerId
 
-        executionTracker.onStateChanged(mockk(), Lifecycle.Event.ON_DESTROY)
-        assertThat(executionTracker.isExecuting.get()).isFalse()
+        executionTracker.onStateChanged(owner, Lifecycle.Event.ON_CREATE)
+
+        assertThat(executionTracker.isMain(owner)).isTrue()
     }
 
     @Test
-    fun `resets execution flag if multiple activity created and destroyed`() {
-        executionTracker.onStateChanged(mockk(), Lifecycle.Event.ON_CREATE)
-        executionTracker.onStateChanged(mockk(), Lifecycle.Event.ON_CREATE)
-        executionTracker.isExecuting.set(true)
+    fun `when owner is destroyed, then it is no longer remains the main executor`() {
+        val ownerId = 123
+        val owner = mockk<LifecycleOwner>()
+        every { owner.hashCode() } returns ownerId
 
-        executionTracker.onStateChanged(mockk(), Lifecycle.Event.ON_DESTROY)
-        assertThat(executionTracker.isExecuting.get()).isTrue()
+        executionTracker.onStateChanged(owner, Lifecycle.Event.ON_CREATE)
+        executionTracker.onStateChanged(owner, Lifecycle.Event.ON_DESTROY)
 
-        executionTracker.onStateChanged(mockk(), Lifecycle.Event.ON_DESTROY)
-        assertThat(executionTracker.isExecuting.get()).isFalse()
+        assertThat(executionTracker.isMain(owner)).isFalse()
+    }
+
+    @Test
+    fun `given second owner, when first owner is destroyed, then the second owner becomes the main executor`() {
+        val ownerId1 = 123
+        val ownerId2 = 456
+        val firstOwner = mockk<LifecycleOwner>()
+        val secondOwner = mockk<LifecycleOwner>()
+        every { firstOwner.hashCode() } returns ownerId1
+        every { secondOwner.hashCode() } returns ownerId2
+
+        executionTracker.onStateChanged(firstOwner, Lifecycle.Event.ON_CREATE)
+        executionTracker.onStateChanged(firstOwner, Lifecycle.Event.ON_DESTROY)
+        executionTracker.onStateChanged(secondOwner, Lifecycle.Event.ON_CREATE)
+
+        assertThat(executionTracker.isMain(secondOwner)).isTrue()
+    }
+
+    @Test
+    fun `given second owner, when first owner is not yet destroyed, then the first owner remains the main executor`() {
+        val ownerId1 = 123
+        val ownerId2 = 456
+        val firstOwner = mockk<LifecycleOwner>()
+        val secondOwner = mockk<LifecycleOwner>()
+        every { firstOwner.hashCode() } returns ownerId1
+        every { secondOwner.hashCode() } returns ownerId2
+
+        executionTracker.onStateChanged(firstOwner, Lifecycle.Event.ON_CREATE)
+        executionTracker.onStateChanged(secondOwner, Lifecycle.Event.ON_CREATE)
+
+        assertThat(executionTracker.isMain(firstOwner)).isTrue()
+    }
+
+    @Test
+    fun `given second owner and not enough time passed to unlock the main executor, when first owner is not yet destroyed, then the first owner remains the main executor`() {
+        val ownerId1 = 123
+        val ownerId2 = 456
+        val firstOwner = mockk<LifecycleOwner>()
+        val secondOwner = mockk<LifecycleOwner>()
+
+        every { firstOwner.hashCode() } returns ownerId1
+        every { secondOwner.hashCode() } returns ownerId2
+        every { timeHelper.msBetweenNowAndTime(any()) } returns 1000L * (executionTimeLimitSec)
+
+        executionTracker.onStateChanged(firstOwner, Lifecycle.Event.ON_CREATE)
+        executionTracker.onStateChanged(secondOwner, Lifecycle.Event.ON_CREATE)
+
+        assertThat(executionTracker.isMain(firstOwner)).isTrue()
+    }
+
+    @Test
+    fun `given second owner and enough time passed to unlock the main executor, when first owner is not yet destroyed, then the second owner becomes the main executor`() {
+        val ownerId1 = 123
+        val ownerId2 = 456
+        val firstOwner = mockk<LifecycleOwner>()
+        val secondOwner = mockk<LifecycleOwner>()
+
+        every { firstOwner.hashCode() } returns ownerId1
+        every { secondOwner.hashCode() } returns ownerId2
+        every { timeHelper.msBetweenNowAndTime(any()) } returns 1000L * (executionTimeLimitSec + 1)
+
+        executionTracker.onStateChanged(firstOwner, Lifecycle.Event.ON_CREATE)
+        executionTracker.onStateChanged(secondOwner, Lifecycle.Event.ON_CREATE)
+
+        assertThat(executionTracker.isMain(secondOwner)).isTrue()
     }
 }


### PR DESCRIPTION
ExecutionTracker now saves the 'currentLifecycleOwnerId' as a reference to the current main executing activity. All subsequent OrchestratorActivity instances will be finished if another one is executed.