### PR TITLE
MS-334 Ensure there is no race condition in event saving and forming app result

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
@@ -71,14 +71,14 @@ internal class OrchestratorViewModel @Inject constructor(
         doNextStep()
     }
 
-    fun handleResult(result: Serializable) {
+    fun handleResult(result: Serializable) = viewModelScope.launch {
         Simber.d(result.toString())
         val errorResponse = mapRefusalOrErrorResult(result)
         if (errorResponse != null) {
             // Shortcut the flow execution if any refusal or error result is found
             addCallbackEvent(errorResponse)
             _appResponse.send(OrchestratorResult(actionRequest, errorResponse))
-            return
+            return@launch
         }
 
         steps.firstOrNull { it.status == StepStatus.IN_PROGRESS }?.let {
@@ -89,7 +89,7 @@ internal class OrchestratorViewModel @Inject constructor(
         }
 
         if (shouldCreatePerson(actionRequest, modalities, steps)) {
-            viewModelScope.launch { createPersonEvent(steps.mapNotNull { it.result }) }
+            createPersonEvent(steps.mapNotNull { it.result })
         }
 
         doNextStep()


### PR DESCRIPTION
* `viewModelScope.launch {}` starts a concurrent coroutine, which can lead to a situation where the final app result is being created before saving of the `PersonCreationEvent` has fully finished, resulting in a "UNEXPECED_ERROR" response.
* This issue is "hidden" if the project has duplicate check enabled - save processes correctly while the match happens. Therefore to reproduce it, the project should be set up to return as soon as possible.