### PR TITLE
Save app bundle in artifacts for manual uploads to google play

### DIFF
--- a/.github/workflows/deploy-to-internal.yml
+++ b/.github/workflows/deploy-to-internal.yml
@@ -64,6 +64,12 @@ jobs:
 
             -   name: Build the Release bundle
                 run: ./gradlew id:bundleRelease
+            -   name: Upload Release bundle
+                uses: actions/upload-artifact@v4
+                with:
+                    name: release-bundle
+                    path: id/build/outputs/bundle/release/*.aab
 
             -   name: Publish Release bundle
                 run: ./gradlew id:publishReleaseBundle
+                continue-on-error: true


### PR DESCRIPTION
As we started to use the foreground services permission. We need an app bundle to be uploaded manually to Google Play.