### PR TITLE
MS-339 Unauthorised session fix

### DIFF
--- a/infra/events/src/main/java/com/simprints/infra/events/EventRepositoryImpl.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/EventRepositoryImpl.kt
@@ -86,6 +86,12 @@ internal open class EventRepositoryImpl @Inject constructor(
         eventLocalDataSource.loadEventScope(downSyncEventScopeId)
 
     override suspend fun closeEventScope(eventScope: EventScope, reason: EventScopeEndCause?) {
+        if (eventScope.projectId == PROJECT_ID_FOR_NOT_SIGNED_IN) {
+            eventLocalDataSource.deleteEventScope(scopeId = eventScope.id)
+            eventLocalDataSource.deleteEventsInScope(scopeId = eventScope.id)
+            return
+        }
+
         val events = eventLocalDataSource.loadEventsInScope(eventScope.id)
         if (events.isEmpty()) {
             eventLocalDataSource.deleteEventScope(scopeId = eventScope.id)

--- a/infra/events/src/test/java/com/simprints/infra/events/EventRepositoryImplTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/EventRepositoryImplTest.kt
@@ -167,6 +167,18 @@ internal class EventRepositoryImplTest {
     }
 
     @Test
+    fun `should delete scope and events if project not signed in`() = runTest {
+        val scope = createSessionScope("scopeId", isClosed = false, projectId = PROJECT_ID_FOR_NOT_SIGNED_IN)
+
+        eventRepo.closeEventScope(scope, null)
+
+        coVerify {
+            eventLocalDataSource.deleteEventScope("scopeId")
+            eventLocalDataSource.deleteEventsInScope("scopeId")
+        }
+    }
+
+    @Test
     fun `add event to current session should add event related to current session into DB`() =
         runTest {
             val scope = createSessionScope("scopeId", isClosed = false)


### PR DESCRIPTION
Deleting sessions that were closed without setting the correct project ID. This happens when a session that starts before login is closed without successfully logging in. 