### PR TITLE
[MS-353] Reverting the Dashboard navigation back to the ::navigate invocation

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/base/BaseFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/base/BaseFragment.kt
@@ -4,7 +4,6 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.simprints.feature.dashboard.R
 import com.simprints.infra.authstore.AuthStore
-import com.simprints.infra.uibase.navigation.navigateSafely
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -17,9 +16,9 @@ internal class BaseFragment : Fragment(R.layout.fragment_base) {
     override fun onResume() {
         super.onResume()
         if (authStore.signedInProjectId.isNotEmpty()) {
-            findNavController().navigateSafely(this, R.id.action_baseFragment_to_mainFragment)
+            findNavController().navigate(R.id.action_baseFragment_to_mainFragment)
         } else {
-            findNavController().navigateSafely(this, R.id.action_baseFragment_to_requestLoginFragment)
+            findNavController().navigate(R.id.action_baseFragment_to_requestLoginFragment)
         }
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/sync/LogoutSyncFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/sync/LogoutSyncFragment.kt
@@ -18,7 +18,6 @@ import com.simprints.feature.dashboard.views.SyncCardState
 import com.simprints.feature.login.LoginContract
 import com.simprints.feature.login.LoginResult
 import com.simprints.infra.uibase.navigation.handleResult
-import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -46,7 +45,7 @@ class LogoutSyncFragment : Fragment(R.layout.fragment_logout_sync) {
         logoutSyncCard.onOfflineButtonClick =
             { startActivity(Intent(Settings.ACTION_WIRELESS_SETTINGS)) }
         logoutSyncCard.onSelectNoModulesButtonClick =
-            { findNavController().navigateSafely(this@LogoutSyncFragment, R.id.action_logoutSyncFragment_to_moduleSelectionFragment) }
+            { findNavController().navigate(R.id.action_logoutSyncFragment_to_moduleSelectionFragment) }
         logoutSyncCard.onLoginButtonClick = { syncViewModel.login() }
         logoutSyncToolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
@@ -56,7 +55,7 @@ class LogoutSyncFragment : Fragment(R.layout.fragment_logout_sync) {
         }
         logoutButton.setOnClickListener {
             logoutSyncViewModel.logout()
-            findNavController().navigateSafely(this@LogoutSyncFragment, R.id.action_logoutSyncFragment_to_requestLoginFragment)
+            findNavController().navigate(R.id.action_logoutSyncFragment_to_requestLoginFragment)
         }
     }
 
@@ -69,8 +68,7 @@ class LogoutSyncFragment : Fragment(R.layout.fragment_logout_sync) {
             logoutSyncInfo.isInvisible = isLogoutButtonVisible
         }
         syncViewModel.loginRequestedEventLiveData.observe(viewLifecycleOwner, LiveDataEventWithContentObserver { loginArgs ->
-            findNavController().navigateSafely(
-                this@LogoutSyncFragment,
+            findNavController().navigate(
                 R.id.action_logOutSyncFragment_to_login,
                 loginArgs
             )

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/syncdecline/LogoutSyncDeclineFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/syncdecline/LogoutSyncDeclineFragment.kt
@@ -12,7 +12,6 @@ import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentLogoutSyncDeclineBinding
 import com.simprints.feature.dashboard.logout.LogoutSyncViewModel
 import com.simprints.feature.dashboard.settings.password.SettingsPasswordDialogFragment
-import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import com.simprints.infra.resources.R as IDR
@@ -64,6 +63,6 @@ class LogoutSyncDeclineFragment : Fragment(R.layout.fragment_logout_sync_decline
 
     private fun processLogoutConfirmation() {
         viewModel.logout()
-        findNavController().navigateSafely(this, R.id.action_logoutSyncDeclineFragment_to_requestLoginFragment)
+        findNavController().navigate(R.id.action_logoutSyncDeclineFragment_to_requestLoginFragment)
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncFragment.kt
@@ -15,7 +15,6 @@ import com.simprints.feature.dashboard.requestlogin.RequestLoginFragmentArgs
 import com.simprints.feature.login.LoginContract
 import com.simprints.feature.login.LoginResult
 import com.simprints.infra.uibase.navigation.handleResult
-import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import com.simprints.infra.resources.R as IDR
@@ -25,7 +24,12 @@ internal class SyncFragment : Fragment(R.layout.fragment_dashboard_card_sync) {
 
     private val viewModel by viewModels<SyncViewModel>()
     private val binding by viewBinding(FragmentDashboardCardSyncBinding::bind)
+    private val hostFragment: Fragment?
+        get() = childFragmentManager
+            .findFragmentById(R.id.mainFragment)
 
+    private val currentlyDisplayedInternalFragment: Fragment?
+        get() = hostFragment?.childFragmentManager?.fragments?.first()
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initViews()
@@ -42,7 +46,7 @@ internal class SyncFragment : Fragment(R.layout.fragment_dashboard_card_sync) {
         onSyncButtonClick = { viewModel.sync() }
         onOfflineButtonClick = { startActivity(Intent(Settings.ACTION_WIRELESS_SETTINGS)) }
         onSelectNoModulesButtonClick =
-            { findNavController().navigateSafely(this@SyncFragment, R.id.action_mainFragment_to_moduleSelectionFragment) }
+            { findNavController().navigate(R.id.action_mainFragment_to_moduleSelectionFragment) }
         onLoginButtonClick = { viewModel.login() }
     }
 
@@ -62,15 +66,13 @@ internal class SyncFragment : Fragment(R.layout.fragment_dashboard_card_sync) {
                 title = getString(IDR.string.dashboard_sync_project_ending_alert_title),
                 body = getString(IDR.string.dashboard_sync_project_ending_message)
             )
-            findNavController().navigateSafely(
-                this,
+            findNavController().navigate(
                 R.id.action_mainFragment_to_requestLoginFragment,
                 RequestLoginFragmentArgs(logoutReason = logoutReason).toBundle()
             )
         }
         viewModel.loginRequestedEventLiveData.observe(viewLifecycleOwner, LiveDataEventWithContentObserver { loginArgs ->
-            findNavController().navigateSafely(
-                this,
+            findNavController().navigate(
                 R.id.action_mainFragment_to_login,
                 loginArgs
             )

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncFragment.kt
@@ -24,12 +24,7 @@ internal class SyncFragment : Fragment(R.layout.fragment_dashboard_card_sync) {
 
     private val viewModel by viewModels<SyncViewModel>()
     private val binding by viewBinding(FragmentDashboardCardSyncBinding::bind)
-    private val hostFragment: Fragment?
-        get() = childFragmentManager
-            .findFragmentById(R.id.mainFragment)
 
-    private val currentlyDisplayedInternalFragment: Fragment?
-        get() = hostFragment?.childFragmentManager?.fragments?.first()
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initViews()

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/requestlogin/RequestLoginFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/requestlogin/RequestLoginFragment.kt
@@ -11,7 +11,6 @@ import com.simprints.core.PackageVersionName
 import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentRequestLoginBinding
 import com.simprints.infra.authstore.AuthStore
-import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -53,7 +52,7 @@ internal class RequestLoginFragment : Fragment(R.layout.fragment_request_login) 
     override fun onResume() {
         super.onResume()
         if (authStore.signedInProjectId.isNotEmpty())
-            findNavController().navigateSafely(this, R.id.action_requestLoginFragment_to_mainFragment)
+            findNavController().navigate(R.id.action_requestLoginFragment_to_mainFragment)
     }
 
     private fun displayLogoutReasonDialog(logoutReason: LogoutReason) {

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
@@ -18,7 +18,6 @@ import com.simprints.feature.dashboard.databinding.FragmentSettingsBinding
 import com.simprints.feature.dashboard.settings.password.SettingsPasswordDialogFragment
 import com.simprints.infra.config.store.models.GeneralConfiguration
 import com.simprints.infra.config.store.models.GeneralConfiguration.Modality.FINGERPRINT
-import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -79,17 +78,17 @@ internal class SettingsFragment : PreferenceFragmentCompat() {
         }
 
         getFingerSelectionPreference()?.setOnPreferenceClickListener {
-            findNavController().navigateSafely(this, R.id.action_settingsFragment_to_fingerSelectionFragment)
+            findNavController().navigate(R.id.action_settingsFragment_to_fingerSelectionFragment)
             true
         }
 
         getSyncInfoPreference()?.setOnPreferenceClickListener {
-            findNavController().navigateSafely(this, R.id.action_settingsFragment_to_syncInfoFragment)
+            findNavController().navigate(R.id.action_settingsFragment_to_syncInfoFragment)
             true
         }
 
         getAboutPreference()?.setOnPreferenceClickListener {
-            findNavController().navigateSafely(this, R.id.action_settingsFragment_to_aboutFragment)
+            findNavController().navigate(R.id.action_settingsFragment_to_aboutFragment)
             true
         }
     }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutFragment.kt
@@ -18,7 +18,6 @@ import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentSettingsAboutBinding
 import com.simprints.feature.dashboard.settings.password.SettingsPasswordDialogFragment
 import com.simprints.infra.config.store.models.GeneralConfiguration.Modality.FINGERPRINT
-import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.system.Clipboard
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -88,7 +87,7 @@ internal class AboutFragment : PreferenceFragmentCompat() {
                     LogoutDestination.LogoutDataSyncScreen -> R.id.action_aboutFragment_to_logout_navigation
                     LogoutDestination.LoginScreen -> R.id.action_aboutFragment_to_requestLoginFragment
                 }
-                findNavController().navigateSafely(this, destination)
+                findNavController().navigate(destination)
             })
     }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
@@ -19,7 +19,6 @@ import com.simprints.infra.config.store.models.SynchronizationConfiguration
 import com.simprints.infra.config.store.models.canSyncDataToSimprints
 import com.simprints.infra.config.store.models.isEventDownSyncAllowed
 import com.simprints.infra.uibase.navigation.handleResult
-import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import com.simprints.infra.resources.R as IDR
@@ -53,7 +52,7 @@ internal class SyncInfoFragment : Fragment(R.layout.fragment_sync_info) {
 
     private fun setupClickListeners() {
         binding.moduleSelectionButton.setOnClickListener {
-            findNavController().navigateSafely(this, R.id.action_syncInfoFragment_to_moduleSelectionFragment)
+            findNavController().navigate(R.id.action_syncInfoFragment_to_moduleSelectionFragment)
         }
         binding.syncInfoToolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
@@ -119,8 +118,7 @@ internal class SyncInfoFragment : Fragment(R.layout.fragment_sync_info) {
             }
         }
         viewModel.loginRequestedEventLiveData.observe(viewLifecycleOwner, LiveDataEventWithContentObserver { loginArgs ->
-            findNavController().navigateSafely(
-                this,
+            findNavController().navigate(
                 R.id.action_syncInfoFragment_to_login,
                 loginArgs
             )


### PR DESCRIPTION
This simplifies things and should not impact the app, as the `::navigateSafely` was implemented to fix the orchestator's navigation issues