### PR TITLE
[MS-366] Early logging of DB corruptions

### DIFF
--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/EventLocalDataSource.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/EventLocalDataSource.kt
@@ -81,12 +81,12 @@ internal open class EventLocalDataSource @Inject constructor(
 
     private suspend fun rebuildDatabase(ex: Throwable) = mutex.withLock {
         //DB corruption detected; either DB file or key is corrupt
-        //1. Delete DB file in order to create a new one at next init
-        eventDatabaseFactory.deleteDatabase()
-        //2. Recreate the DB key
-        eventDatabaseFactory.recreateDatabaseKey()
-        //3. Log exception after recreating the key so we get extra info
+        //1. Log exception after recreating the key so we get extra info
         Simber.tag(DB_CORRUPTION.name).e(ex)
+        //2. Delete DB file in order to create a new one at next init
+        eventDatabaseFactory.deleteDatabase()
+        //3. Recreate the DB key
+        eventDatabaseFactory.recreateDatabaseKey()
         //4. Rebuild database
         eventDao = eventDatabaseFactory.build().eventDao
         scopeDao = eventDatabaseFactory.build().scopeDao

--- a/infra/realm/src/main/java/com/simprints/infra/realm/RealmWrapperImpl.kt
+++ b/infra/realm/src/main/java/com/simprints/infra/realm/RealmWrapperImpl.kt
@@ -59,12 +59,12 @@ class RealmWrapperImpl @Inject constructor(
         } catch (ex: Exception) {
             if (isFileCorruptException(ex)) {
                 //DB corruption detected; either DB file or key is corrupt
-                //1. Delete DB file in order to create a new one at next init
-                Realm.deleteRealm(config)
-                //2. Recreate the DB key
-                recreateLocalDbKey()
-                //3. Log exception after recreating the key so we get extra info
+                //1. Log exception after recreating the key so we get extra info
                 Simber.tag(DB_CORRUPTION.name).e(ex)
+                //2. Delete DB file in order to create a new one at next init
+                Realm.deleteRealm(config)
+                //3. Recreate the DB key
+                recreateLocalDbKey()
                 //4. Update Realm config with the new key
                 config = createAndSaveRealmConfig()
                 //5. Delete "last sync" info and start new sync


### PR DESCRIPTION
Provides more log info when DB corruption exception handling fails. Not a fix.