### PR TITLE
Handle exception when trying to obtain local DB key while creating Realm config

### DIFF
--- a/infra/realm/src/main/java/com/simprints/infra/realm/RealmWrapperImpl.kt
+++ b/infra/realm/src/main/java/com/simprints/infra/realm/RealmWrapperImpl.kt
@@ -102,10 +102,16 @@ class RealmWrapperImpl @Inject constructor(
     private fun getLocalDbKey(): LocalDbKey =
         authStore.signedInProjectId.let {
             return if (it.isNotEmpty()) {
-                securityManager.getLocalDbKeyOrThrow(it)
-            } else {
-                throw RealmUninitialisedException("No signed in project id found")
-            }
+                try {
+                    securityManager.getLocalDbKeyOrThrow(it)
+                } catch (ex: Exception) {
+                    Simber.e(ex)
+                    securityManager.recreateLocalDatabaseKey(it)
+                    securityManager.getLocalDbKeyOrThrow(it)
+                }
+              } else {
+                  throw RealmUninitialisedException("No signed in project id found")
+              }
         }
 
     private fun recreateLocalDbKey() =


### PR DESCRIPTION
If key is missing - create a new one and log the exception. 