### PR TITLE
MS-402 Prevent a navigation race condition on logout

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModel.kt
@@ -4,14 +4,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
-import com.simprints.core.ExternalScope
 import com.simprints.core.livedata.LiveDataEventWithContent
 import com.simprints.feature.dashboard.logout.usecase.LogoutUseCase
-import com.simprints.infra.authlogic.AuthManager
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.SettingsPasswordConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -19,7 +16,6 @@ import javax.inject.Inject
 internal class LogoutSyncViewModel @Inject constructor(
     private val configRepository: ConfigRepository,
     private val logoutUseCase: LogoutUseCase,
-    @ExternalScope private val externalScope: CoroutineScope,
 ) : ViewModel() {
 
     val settingsLocked: LiveData<LiveDataEventWithContent<SettingsPasswordConfig>>
@@ -29,6 +25,6 @@ internal class LogoutSyncViewModel @Inject constructor(
 
 
     fun logout() {
-        externalScope.launch { logoutUseCase() }
+        viewModelScope.launch { logoutUseCase() }
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCase.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCase.kt
@@ -1,18 +1,26 @@
 package com.simprints.feature.dashboard.logout.usecase
 
+import com.simprints.core.ExternalScope
 import com.simprints.infra.authlogic.AuthManager
 import com.simprints.infra.sync.SyncOrchestrator
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 internal class LogoutUseCase @Inject constructor(
     private val syncOrchestrator: SyncOrchestrator,
     private val authManager: AuthManager,
+    @ExternalScope private val externalScope: CoroutineScope,
 ) {
 
     suspend operator fun invoke() {
-        // Cancel all background sync
-        syncOrchestrator.cancelBackgroundWork()
-        syncOrchestrator.deleteEventSyncInfo()
         authManager.signOut()
+
+        // Cancel all background sync
+        externalScope.launch {
+            syncOrchestrator.cancelBackgroundWork()
+            syncOrchestrator.deleteEventSyncInfo()
+        }
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncViewModel.kt
@@ -58,7 +58,6 @@ internal class SyncViewModel @Inject constructor(
     private val authStore: AuthStore,
     private val logoutUseCase: LogoutUseCase,
     private val recentUserActivityManager: RecentUserActivityManager,
-    @ExternalScope private val externalScope: CoroutineScope,
 ) : ViewModel() {
 
     companion object {
@@ -106,7 +105,7 @@ internal class SyncViewModel @Inject constructor(
                     configRepository.getProject(authStore.signedInProjectId).state == ProjectState.PROJECT_ENDING
 
                 if (isSyncComplete && isProjectEnding) {
-                    externalScope.launch {
+                    viewModelScope.launch {
                         logoutUseCase()
                         _signOutEventLiveData.postValue(LiveDataEvent())
                     }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.simprints.core.ExternalScope
 import com.simprints.core.livedata.LiveDataEventWithContent
 import com.simprints.core.livedata.send
 import com.simprints.feature.dashboard.logout.usecase.LogoutUseCase
@@ -16,7 +15,6 @@ import com.simprints.infra.eventsync.EventSyncManager
 import com.simprints.infra.recent.user.activity.RecentUserActivityManager
 import com.simprints.infra.recent.user.activity.domain.RecentUserActivity
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -27,7 +25,6 @@ internal class AboutViewModel @Inject constructor(
     private val logoutUseCase: LogoutUseCase,
     private val eventSyncManager: EventSyncManager,
     private val recentUserActivityManager: RecentUserActivityManager,
-    @ExternalScope private val externalScope: CoroutineScope,
 ) : ViewModel() {
 
     val syncAndSearchConfig: LiveData<SyncAndSearchConfig>
@@ -76,7 +73,7 @@ internal class AboutViewModel @Inject constructor(
         configRepository.getProjectConfiguration().canSyncDataToSimprints()
 
     private fun logout() {
-        externalScope.launch { logoutUseCase() }
+        viewModelScope.launch { logoutUseCase() }
     }
 
     private fun load() = viewModelScope.launch {

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModelTest.kt
@@ -13,7 +13,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineScope
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -43,7 +42,6 @@ internal class LogoutSyncViewModelTest {
         val viewModel = LogoutSyncViewModel(
             configRepository = configRepository,
             logoutUseCase = logoutUseCase,
-            externalScope = CoroutineScope(testCoroutineRule.testCoroutineDispatcher)
         )
 
         viewModel.logout()
@@ -62,7 +60,6 @@ internal class LogoutSyncViewModelTest {
         val viewModel = LogoutSyncViewModel(
             configRepository = configRepository,
             logoutUseCase = logoutUseCase,
-            externalScope = CoroutineScope(testCoroutineRule.testCoroutineDispatcher),
         )
         val resultConfig = viewModel.settingsLocked.getOrAwaitValue()
         assertThat(resultConfig.peekContent()).isEqualTo(config)

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCaseTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCaseTest.kt
@@ -1,0 +1,53 @@
+package com.simprints.feature.dashboard.logout.usecase
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.simprints.infra.authlogic.AuthManager
+import com.simprints.infra.sync.SyncOrchestrator
+import com.simprints.testtools.common.coroutines.TestCoroutineRule
+import io.mockk.MockKAnnotations
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class LogoutUseCaseTest {
+
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val testCoroutineRule = TestCoroutineRule()
+
+    @MockK
+    private lateinit var syncOrchestrator: SyncOrchestrator
+
+    @MockK
+    private lateinit var authManager: AuthManager
+
+    private lateinit var useCase: LogoutUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        useCase = LogoutUseCase(
+            syncOrchestrator = syncOrchestrator,
+            authManager = authManager,
+            CoroutineScope(testCoroutineRule.testCoroutineDispatcher),
+        )
+    }
+
+    @Test
+    fun `Fully logs out when called`() = runTest {
+        useCase.invoke()
+
+        coVerify {
+            syncOrchestrator.cancelBackgroundWork()
+            syncOrchestrator.deleteEventSyncInfo()
+            authManager.signOut()
+        }
+    }
+}

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/main/sync/SyncViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/main/sync/SyncViewModelTest.kt
@@ -44,7 +44,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flowOf
 import org.junit.Before
 import org.junit.Rule
@@ -446,6 +445,5 @@ internal class SyncViewModelTest {
         authStore = authStore,
         logoutUseCase = logoutUseCase,
         recentUserActivityManager = recentUserActivityManager,
-        externalScope = CoroutineScope(testCoroutineRule.testCoroutineDispatcher)
     )
 }

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/about/AboutViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/about/AboutViewModelTest.kt
@@ -20,7 +20,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -67,7 +66,6 @@ class AboutViewModelTest {
             eventSyncManager = eventSyncManager,
             recentUserActivityManager = recentUserActivityManager,
             logoutUseCase = logoutUseCase,
-            externalScope = CoroutineScope(testCoroutineRule.testCoroutineDispatcher),
         )
 
         assertThat(viewModel.modalities.value).isEqualTo(MODALITIES)
@@ -186,7 +184,6 @@ class AboutViewModelTest {
             configRepository = configRepository,
             eventSyncManager = eventSyncManager,
             recentUserActivityManager = recentUserActivityManager,
-            externalScope = CoroutineScope(testCoroutineRule.testCoroutineDispatcher),
             logoutUseCase = logoutUseCase,
         )
     }


### PR DESCRIPTION
* The logout use case in the dashboard was fully executed in the background
* In some conditions, the main thread could crunch through several navigation events (logout fragment -> request login fragment -> main fragment) before the logout got to the clearing auth store.
* In this version, the auth clearing happens synchronously in the view model scope to ensure it is done before continuing with the navigation. Background work cancellation still happens asynchronously in the background after that.