### PR TITLE
[MS-405] Saving the Action Request in the bundle so it can survive the process death

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorFragment.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorFragment.kt
@@ -79,6 +79,8 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
         super.onViewCreated(view, savedInstanceState)
         if (savedInstanceState != null) {
             orchestratorVm.requestProcessed = savedInstanceState.getBoolean(KEY_REQUEST_PROCESSED)
+            savedInstanceState.getString(KEY_ACTION_REQUEST)
+                ?.run(orchestratorVm::setActionRequestFromJson)
         }
         observeLoginCheckVm()
         observeClientApiVm()
@@ -180,6 +182,10 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putBoolean(KEY_REQUEST_PROCESSED, orchestratorVm.requestProcessed)
+        // [MS-405] Saving the action request in the bundle, since ViewModels don't survive the
+        // process death. ActionRequest is important in mapping the correct SID response, hence it
+        // is important for it to be able to survive both configuration changes and process death.
+        outState.putString(KEY_ACTION_REQUEST, orchestratorVm.getActionRequestJson())
     }
 
     override fun onResume() {
@@ -201,5 +207,6 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
 
     companion object {
         private const val KEY_REQUEST_PROCESSED = "requestProcessed"
+        private const val KEY_ACTION_REQUEST = "actionRequest"
     }
 }

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.simprints.core.livedata.LiveDataEventWithContent
 import com.simprints.core.livedata.send
+import com.simprints.core.tools.json.JsonHelper
 import com.simprints.face.capture.FaceCaptureResult
 import com.simprints.feature.orchestrator.cache.OrchestratorCache
 import com.simprints.feature.orchestrator.model.OrchestratorResult
@@ -159,6 +160,22 @@ internal class OrchestratorViewModel @Inject constructor(
                     matchingStep.payload = newPayload
                 }
             }
+        }
+    }
+    fun setActionRequestFromJson(json: String) {
+        try {
+            actionRequest = JsonHelper.fromJson<ActionRequest>(json)
+        } catch (e: Exception) {
+            Simber.e(e)
+        }
+    }
+
+    fun getActionRequestJson(): String? {
+        return try {
+            actionRequest?.run(JsonHelper::toJson)
+        } catch (e: Exception) {
+            Simber.e(e)
+            null
         }
     }
 }


### PR DESCRIPTION
Initially, when the activity's process was killed (i.e. under load or with `Don't keep activities` flag turned on), the `ActionRequest` wasn't restored because the ViewModel was re-created.

This fix addresses this issue by saving the `ActionRequest` JSON in the `onSaveInstanceState`