### PR TITLE
[MS-417] Mark DeviceConfigDownSyncWorker as HiltWorker

### DIFF
--- a/infra/sync/src/main/java/com/simprints/infra/sync/config/worker/DeviceConfigDownSyncWorker.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/config/worker/DeviceConfigDownSyncWorker.kt
@@ -1,6 +1,7 @@
 package com.simprints.infra.sync.config.worker
 
 import android.content.Context
+import androidx.hilt.work.HiltWorker
 import androidx.work.WorkerParameters
 import com.simprints.core.DispatcherBG
 import com.simprints.core.workers.SimCoroutineWorker
@@ -12,6 +13,7 @@ import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 
+@HiltWorker
 internal class DeviceConfigDownSyncWorker @AssistedInject constructor(
     @Assisted context: Context,
     @Assisted params: WorkerParameters,


### PR DESCRIPTION

The DeviceConfigDownSyncWorker can’t be started as it leaks the @HiltWorker annotation.
```
Could not instantiate com.simprints.infra.sync.config.worker.DeviceConfigDownSyncWorker
java.lang.NoSuchMethodException: com.simprints.infra.sync.config.worker.DeviceConfigDownSyncWorker.<init> [class android.content.Context, class androidx.work.WorkerParameters]
	at java.lang.Class.getConstructor0(Class.java:3325)
	at java.lang.Class.getDeclaredConstructor(Class.java:3063)
	at androidx.work.WorkerFactory.createWorkerWithDefaultFallback(WorkerFactory.java:94)
	at androidx.work.impl.WorkerWrapper.runWorker(WorkerWrapper.java:243)
	at androidx.work.impl.WorkerWrapper.run(WorkerWrapper.java:144)
	at androidx.work.impl.utils.SerialExecutorImpl$Task.run(SerialExecutorImpl.java:96)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
	at java.lang.Thread.run(Thread.java:1012)
Could not create Worker com.simprints.infra.sync.config.worker.DeviceConfigDownSyncWorker
```