### PR TITLE
[MS-418] Don't include projectConfigurationUpdatedAt if it's empty

### DIFF
--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/session/ApiEventScope.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/session/ApiEventScope.kt
@@ -1,6 +1,8 @@
 package com.simprints.infra.eventsync.event.remote.models.session
 
 import androidx.annotation.Keep
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.simprints.infra.events.event.domain.models.Event
 import com.simprints.infra.events.event.domain.models.scope.EventScope
 import com.simprints.infra.eventsync.event.remote.models.ApiEvent
@@ -22,6 +24,7 @@ internal data class ApiEventScope(
     val device: ApiDevice,
     val databaseInfo: ApiDatabaseInfo,
     val location: ApiLocation?,
+    @JsonInclude(Include.NON_EMPTY)
     val projectConfigurationUpdatedAt: String,
     val events: List<ApiEvent>,
 ) {

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/session/ApiEventScopeTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/session/ApiEventScopeTest.kt
@@ -1,0 +1,63 @@
+package com.simprints.infra.eventsync.event.remote.models.session
+
+import com.google.common.truth.Truth
+import com.simprints.core.tools.json.JsonHelper
+import com.simprints.infra.eventsync.event.remote.models.ApiTimestamp
+import org.junit.Test
+
+class ApiEventScopeTest {
+
+    @Test
+    fun `projectConfigurationUpdatedAt is not included in JSON when empty`() {
+        // Arrange
+        val apiEventScope = ApiEventScope(
+            id = "testId",
+            projectId = "testProjectId",
+            startTime = ApiTimestamp(0),
+            endTime = null,
+            endCause = ApiEventScopeEndCause.WORKFLOW_ENDED,
+            modalities = emptyList(),
+            sidVersion = "testSidVersion",
+            libSimprintsVersion = "testLibSimprintsVersion",
+            language = "testLanguage",
+            device = ApiDevice("testDeviceId", "testDeviceModel"),
+            databaseInfo = ApiDatabaseInfo(0, 0),
+            location = null,
+            projectConfigurationUpdatedAt = "",
+            events = emptyList()
+        )
+
+        // Act
+        val json = JsonHelper.toJson(apiEventScope)
+
+        // Assert
+        Truth.assertThat(json).doesNotContain("projectConfigurationUpdatedAt")
+    }
+
+    @Test
+    fun `projectConfigurationUpdatedAt is included in JSON when not empty`() {
+        // Arrange
+        val apiEventScope = ApiEventScope(
+            id = "testId",
+            projectId = "testProjectId",
+            startTime = ApiTimestamp(0),
+            endTime = null,
+            endCause = ApiEventScopeEndCause.WORKFLOW_ENDED,
+            modalities = emptyList(),
+            sidVersion = "testSidVersion",
+            libSimprintsVersion = "testLibSimprintsVersion",
+            language = "testLanguage",
+            device = ApiDevice("testDeviceId", "testDeviceModel"),
+            databaseInfo = ApiDatabaseInfo(0, 0),
+            location = null,
+            projectConfigurationUpdatedAt = "123",
+            events = emptyList()
+        )
+
+        // Act
+        val json = JsonHelper.toJson(apiEventScope)
+
+        // Assert
+        Truth.assertThat(json).contains("projectConfigurationUpdatedAt")
+    }
+}


### PR DESCRIPTION
More info in the ticket. Opting for the much simpler solution to avoid more work and potential problems arising from changing the type of the field.