### PR TITLE
[MS-422] Immediate foreground service type for preventing ForegroundServiceDidNotStartInTimeException

### DIFF
--- a/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
+++ b/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
@@ -95,7 +95,7 @@ abstract class SimCoroutineWorker(
             .setOnlyAlertOnce(true)
             .apply {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    foregroundServiceBehavior = Notification.FOREGROUND_SERVICE_DEFERRED
+                    foregroundServiceBehavior = Notification.FOREGROUND_SERVICE_IMMEDIATE
                 }
             }
             .build()


### PR DESCRIPTION
See Android foreground services documentation https://developer.android.com/develop/background-work/services/foreground-services#notification-immediate - clause 4.