### PR TITLE
[MS-405] Adding serialization modules when unmarshalling the actionRequest

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
@@ -4,6 +4,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.simprints.core.domain.tokenization.TokenizableString
+import com.simprints.core.domain.tokenization.serialization.TokenizationClassNameDeserializer
+import com.simprints.core.domain.tokenization.serialization.TokenizationClassNameSerializer
 import com.simprints.core.livedata.LiveDataEventWithContent
 import com.simprints.core.livedata.send
 import com.simprints.core.tools.json.JsonHelper
@@ -151,7 +156,13 @@ internal class OrchestratorViewModel @Inject constructor(
 
             if (matchingStep != null) {
                 val fingerprintSamples = result.results.mapNotNull { it.sample }
-                    .map { MatchParams.FingerprintSample(it.fingerIdentifier, it.format, it.template) }
+                    .map {
+                        MatchParams.FingerprintSample(
+                            it.fingerIdentifier,
+                            it.format,
+                            it.template
+                        )
+                    }
                 val newPayload = matchingStep.payload
                     .getParcelable<MatchStepStubPayload>(MatchStepStubPayload.STUB_KEY)
                     ?.toFingerprintStepArgs(fingerprintSamples)
@@ -162,9 +173,13 @@ internal class OrchestratorViewModel @Inject constructor(
             }
         }
     }
+
     fun setActionRequestFromJson(json: String) {
         try {
-            actionRequest = JsonHelper.fromJson<ActionRequest>(json)
+            actionRequest = JsonHelper.fromJson(
+                json = json,
+                module = dbSerializationModule,
+                type = object : TypeReference<ActionRequest>() {})
         } catch (e: Exception) {
             Simber.e(e)
         }
@@ -172,10 +187,19 @@ internal class OrchestratorViewModel @Inject constructor(
 
     fun getActionRequestJson(): String? {
         return try {
-            actionRequest?.run(JsonHelper::toJson)
+            actionRequest?.let {
+                JsonHelper.toJson(it, dbSerializationModule)
+            }
         } catch (e: Exception) {
             Simber.e(e)
             null
+        }
+    }
+
+    companion object {
+        val dbSerializationModule = SimpleModule().apply {
+            addSerializer(TokenizableString::class.java, TokenizationClassNameSerializer())
+            addDeserializer(TokenizableString::class.java, TokenizationClassNameDeserializer())
         }
     }
 }


### PR DESCRIPTION
Explicitly specifying the serialization modules within the `OrchestratorViewModel` so that `JsonHelper` knows how to unmarshal tokenization strings within the `ActionRequest`