### PR TITLE
[MS-425] Return JSON path for attendantId and moduleId tokenizedFields

### DIFF
--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/downsync/ApiEventDownSyncRequestPayload.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/downsync/ApiEventDownSyncRequestPayload.kt
@@ -45,5 +45,10 @@ internal data class ApiEventDownSyncRequestPayload(
         val lastEventId: String?,
     )
 
-    override fun getTokenizedFieldJsonPath(tokenKeyType: TokenKeyType): String? = null
+    override fun getTokenizedFieldJsonPath(tokenKeyType: TokenKeyType): String? =
+        when (tokenKeyType) {
+            TokenKeyType.AttendantId -> "queryParameters.attendantId"
+            TokenKeyType.ModuleId -> "queryParameters.moduleId"
+            else -> null
+        }
 }

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/downsync/ApiEventDownSyncRequestPayloadTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/downsync/ApiEventDownSyncRequestPayloadTest.kt
@@ -1,0 +1,35 @@
+package com.simprints.infra.eventsync.event.remote.models.downsync
+
+import com.simprints.infra.config.store.models.TokenKeyType
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ApiEventDownSyncRequestPayloadTest {
+
+    @Test
+    fun testGetTokenizedFieldJsonPath() {
+        // Arrange
+        val payload = ApiEventDownSyncRequestPayload(
+            startTime = mockk(),
+            endTime = mockk(),
+            requestId = "requestId",
+            queryParameters = ApiEventDownSyncRequestPayload.ApiQueryParameters(
+                moduleId = "moduleId",
+                attendantId = "attendantId",
+                subjectId = null,
+                modes = null,
+                lastEventId = null,
+            ),
+            responseStatus = 200,
+            errorType = null,
+            msToFirstResponseByte = 1000L,
+            eventsRead = 10
+        )
+
+        // Act & Assert
+        assertEquals("queryParameters.attendantId", payload.getTokenizedFieldJsonPath(TokenKeyType.AttendantId))
+        assertEquals("queryParameters.moduleId", payload.getTokenizedFieldJsonPath(TokenKeyType.ModuleId))
+        assertEquals(null, payload.getTokenizedFieldJsonPath(TokenKeyType.Unknown))
+    }
+}


### PR DESCRIPTION
I missed this part in [the previous PR](https://github.com/Simprints/Android-Simprints-ID/pull/685) as I didn't have a full understanding of how forming`tokenizedFields` works.