### PR TITLE
[MS-368] Opting out of setting worker service foreground when battery optimization on

### DIFF
--- a/infra/core/src/main/java/com/simprints/core/tools/utils/BatteryOptimizationUtils.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/utils/BatteryOptimizationUtils.kt
@@ -2,7 +2,9 @@ package com.simprints.core.tools.utils
 
 import android.content.Context
 import android.os.PowerManager
+import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
 
+@ExcludedFromGeneratedTestCoverageReports("Platform glue code")
 object BatteryOptimizationUtils {
 
     fun isFollowingBatteryOptimizations(context: Context): Boolean =

--- a/infra/core/src/main/java/com/simprints/core/tools/utils/BatteryOptimizationUtils.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/utils/BatteryOptimizationUtils.kt
@@ -1,0 +1,13 @@
+package com.simprints.core.tools.utils
+
+import android.content.Context
+import android.os.PowerManager
+
+object BatteryOptimizationUtils {
+
+    fun isFollowingBatteryOptimizations(context: Context): Boolean =
+        (context.getSystemService(Context.POWER_SERVICE) as PowerManager)
+            .isIgnoringBatteryOptimizations(context.packageName)
+            .not()
+
+}

--- a/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
+++ b/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
@@ -58,10 +58,10 @@ abstract class SimCoroutineWorker(
     }
 
     protected suspend fun showProgressNotification() {
-        if (BatteryOptimizationUtils.isFollowingBatteryOptimizations(context)) {
-            return
-        }
         try {
+            if (BatteryOptimizationUtils.isFollowingBatteryOptimizations(context)) {
+                return
+            }
             setForeground(getForegroundInfo())
         } catch (setForegroundException: Throwable) {
             // Setting foreground (showing the notification) may be restricted by the system

--- a/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
+++ b/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
@@ -13,6 +13,7 @@ import androidx.work.Data
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
+import com.simprints.core.tools.utils.BatteryOptimizationUtils
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.exceptions.NetworkConnectionException
@@ -57,6 +58,9 @@ abstract class SimCoroutineWorker(
     }
 
     protected suspend fun showProgressNotification() {
+        if (BatteryOptimizationUtils.isFollowingBatteryOptimizations(context)) {
+            return
+        }
         try {
             setForeground(getForegroundInfo())
         } catch (setForegroundException: Throwable) {

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/workers/EventDownSyncDownloaderWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/workers/EventDownSyncDownloaderWorker.kt
@@ -76,8 +76,8 @@ internal class EventDownSyncDownloaderWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result = withContext(dispatcher) {
         try {
-            Simber.tag(SYNC_LOG_TAG).d("[DOWNLOADER] Started")
             showProgressNotification()
+            Simber.tag(SYNC_LOG_TAG).d("[DOWNLOADER] Started")
 
             val workerId = this@EventDownSyncDownloaderWorker.id.toString()
             var count = syncCache.readProgress(workerId)

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventEndSyncReporterWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventEndSyncReporterWorker.kt
@@ -32,9 +32,9 @@ internal class EventEndSyncReporterWorker @AssistedInject constructor(
     override suspend fun doWork(): Result =
         withContext(dispatcher) {
             try {
+                showProgressNotification()
                 val syncId = inputData.getString(SYNC_ID_TO_MARK_AS_COMPLETED)
                 crashlyticsLog("Start - Params: $syncId")
-                showProgressNotification()
 
                 inputData.getString(EVENT_DOWN_SYNC_SCOPE_TO_CLOSE)?.let { scopeId ->
                     eventRepository.closeEventScope(scopeId, EventScopeEndCause.WORKFLOW_ENDED)

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventStartSyncReporterWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventStartSyncReporterWorker.kt
@@ -30,9 +30,9 @@ internal class EventStartSyncReporterWorker @AssistedInject constructor(
     override suspend fun doWork(): Result =
         withContext(dispatcher) {
             try {
+                showProgressNotification()
                 val syncId = inputData.getString(SYNC_ID_STARTED)
                 crashlyticsLog("Start - Params: $syncId")
-                showProgressNotification()
                 success(inputData)
             } catch (t: Throwable) {
                 fail(t)

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorker.kt
@@ -63,10 +63,10 @@ class EventSyncMasterWorker @AssistedInject internal constructor(
     override suspend fun doWork(): Result =
         withContext(dispatcher) {
             try {
+                showProgressNotification()
                 // check if device is rooted before starting the sync
                 securityManager.checkIfDeviceIsRooted()
                 crashlyticsLog("Start")
-                showProgressNotification()
                 val configuration = configRepository.getProjectConfiguration()
 
                 if (!configuration.canSyncDataToSimprints() && !isEventDownSyncAllowed(configuration)) return@withContext success(

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/workers/EventUpSyncUploaderWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/workers/EventUpSyncUploaderWorker.kt
@@ -74,8 +74,8 @@ internal class EventUpSyncUploaderWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result = withContext(dispatcher) {
         try {
-            Simber.tag(SYNC_LOG_TAG).d("[UPLOADER] Started")
             showProgressNotification()
+            Simber.tag(SYNC_LOG_TAG).d("[UPLOADER] Started")
 
             val workerId = this@EventUpSyncUploaderWorker.id.toString()
             var count = eventSyncCache.readProgress(workerId)

--- a/infra/sync/src/main/java/com/simprints/infra/sync/config/worker/DeviceConfigDownSyncWorker.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/config/worker/DeviceConfigDownSyncWorker.kt
@@ -27,8 +27,8 @@ internal class DeviceConfigDownSyncWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result =
         withContext(dispatcher) {
-            crashlyticsLog("Fetching device config state")
             showProgressNotification()
+            crashlyticsLog("Fetching device config state")
 
             try {
                 val state = configRepository.getDeviceState()


### PR DESCRIPTION
A fix for some cases of uncaught `BackgroundServiceStartNotAllowedException`, before an improved solution is found.