### PR TITLE
MS-439 Move requestID logic from network interceptors to sync tasks

### DIFF
--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/EventRemoteInterface.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/EventRemoteInterface.kt
@@ -16,26 +16,28 @@ internal interface EventRemoteInterface : SimRemoteInterface {
         @Query("l_attendantId") attendantId: String?,
         @Query("l_subjectId") subjectId: String?,
         @Query("l_mode") modes: List<ApiModes>,
-        @Query("lastEventId") lastEventId: String?
+        @Query("lastEventId") lastEventId: String?,
     ): Response<Void>
 
     @Headers("Content-Encoding: gzip")
     @POST("projects/{projectId}/events")
     suspend fun uploadEvents(
+        @Header("X-Request-ID") requestId: String,
         @Path("projectId") projectId: String,
         @Query("acceptInvalidEvents") acceptInvalidEvents: Boolean = true,
-        @Body body: ApiUploadEventsBody
+        @Body body: ApiUploadEventsBody,
     ): Response<ResponseBody>
 
     @Streaming
     @GET("projects/{projectId}/events")
     suspend fun downloadEvents(
+        @Header("X-Request-ID") requestId: String,
         @Path("projectId") projectId: String,
         @Query("l_moduleId") moduleId: String?,
         @Query("l_attendantId") attendantId: String?,
         @Query("l_subjectId") subjectId: String?,
         @Query("l_mode") modes: List<ApiModes>,
-        @Query("lastEventId") lastEventId: String?
+        @Query("lastEventId") lastEventId: String?,
     ): Response<ResponseBody>
 
     @Headers("Content-Encoding: gzip")

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/status/down/domain/EventDownSyncResult.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/status/down/domain/EventDownSyncResult.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.channels.ReceiveChannel
 
 data class EventDownSyncResult(
     val totalCount: Int?,
-    val requestId: String,
     val status: Int,
     val eventStream: ReceiveChannel<EnrolmentRecordEvent>
 )

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/status/up/domain/EventUpSyncResult.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/status/up/domain/EventUpSyncResult.kt
@@ -1,6 +1,5 @@
 package com.simprints.infra.eventsync.status.up.domain
 
 data class EventUpSyncResult(
-    val requestId: String,
     val status: Int,
 )

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/EventDownSyncTask.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/EventDownSyncTask.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.flow
+import java.util.UUID
 import javax.inject.Inject
 
 internal class EventDownSyncTask @Inject constructor(
@@ -58,11 +59,13 @@ internal class EventDownSyncTask @Inject constructor(
         val requestStartTime = timeHelper.now()
 
         var firstEventTimestamp: Timestamp? = null
+        val requestId = UUID.randomUUID().toString()
         var result: EventDownSyncResult? = null
         var errorType: String? = null
 
         try {
             result = eventRemoteDataSource.getEvents(
+                requestId,
                 operation.queryEvent.fromDomainToApi(),
                 scope
             )
@@ -118,7 +121,7 @@ internal class EventDownSyncTask @Inject constructor(
                 EventDownSyncRequestEvent(
                     createdAt = requestStartTime,
                     endedAt = timeHelper.now(),
-                    requestId = result?.requestId.orEmpty(),
+                    requestId = requestId,
                     query = operation.queryEvent.let { query ->
                         EventDownSyncRequestEvent.QueryParameters(
                             query.moduleId,


### PR DESCRIPTION
Network interceptors cannot be reliably used in case of a network error (where the response is not available). Therefore it would be better to make the request IDs an explicit part of the business logic. 

This also limits the network request IDs to network calls where it is relevant (i.e. up-sync and down-sync)

Based on @ethiery branch from a while back. 