### PR TITLE
MS-438 Prevent invalid person creation event

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/FaceCaptureResult.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/FaceCaptureResult.kt
@@ -11,6 +11,7 @@ data class FaceCaptureResult(
 
     @Keep
     data class Item(
+        val captureEventId: String?,
         val index: Int,
         val sample: Sample?,
     ) : Serializable

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/FaceCaptureViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/FaceCaptureViewModel.kt
@@ -62,7 +62,6 @@ internal class FaceCaptureViewModel @Inject constructor(
         get() = _finishFlowEvent
     private val _finishFlowEvent = MutableLiveData<LiveDataEventWithContent<FaceCaptureResult>>()
 
-
     val invalidLicense: LiveData<LiveDataEvent>
         get() = _invalidLicense
     private val _invalidLicense = MutableLiveData<LiveDataEvent>()
@@ -106,12 +105,13 @@ internal class FaceCaptureViewModel @Inject constructor(
 
             val items = faceDetections.mapIndexed { index, detection ->
                 FaceCaptureResult.Item(
-                    index,
-                    FaceCaptureResult.Sample(
-                        detection.id,
-                        detection.face?.template ?: ByteArray(0),
-                        detection.securedImageRef,
-                        detection.face?.format ?: "",
+                    captureEventId = detection.id,
+                    index = index,
+                    sample = FaceCaptureResult.Sample(
+                        faceId = detection.id,
+                        template = detection.face?.template ?: ByteArray(0),
+                        imageRef = detection.securedImageRef,
+                        format = detection.face?.format ?: "",
                     )
                 )
             }
@@ -158,6 +158,5 @@ internal class FaceCaptureViewModel @Inject constructor(
     fun addCaptureConfirmationAction(startTime: Timestamp, isContinue: Boolean) {
         eventReporter.addCaptureConfirmationEvent(startTime, isContinue)
     }
-
 
 }

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/CreatePersonEventUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/CreatePersonEventUseCase.kt
@@ -5,20 +5,16 @@ import com.simprints.core.domain.face.uniqueId
 import com.simprints.core.domain.fingerprint.FingerprintSample
 import com.simprints.core.domain.fingerprint.uniqueId
 import com.simprints.core.tools.time.TimeHelper
-import com.simprints.core.tools.utils.EncodingUtils
 import com.simprints.face.capture.FaceCaptureResult
 import com.simprints.fingerprint.capture.FingerprintCaptureResult
 import com.simprints.infra.events.SessionEventRepository
 import com.simprints.infra.events.event.domain.models.PersonCreationEvent
-import com.simprints.infra.events.event.domain.models.face.FaceCaptureBiometricsEvent
-import com.simprints.infra.events.event.domain.models.fingerprint.FingerprintCaptureBiometricsEvent
 import java.io.Serializable
 import javax.inject.Inject
 
 internal class CreatePersonEventUseCase @Inject constructor(
     private val eventRepository: SessionEventRepository,
     private val timeHelper: TimeHelper,
-    private val encodingUtils: EncodingUtils,
 ) {
 
     suspend operator fun invoke(results: List<Serializable>) {
@@ -27,70 +23,53 @@ internal class CreatePersonEventUseCase @Inject constructor(
         // If a personCreationEvent is already in the current session,
         // we don' want to add it again (the capture steps would still be the same)
         if (sessionEvents.none { it is PersonCreationEvent }) {
-            val faceCaptureBiometricsEvents = sessionEvents.filterIsInstance<FaceCaptureBiometricsEvent>()
-            val fingerprintCaptureBiometricsEvents = sessionEvents.filterIsInstance<FingerprintCaptureBiometricsEvent>()
+            val faceCaptures = extractFaceCaptures(results)
+            val fingerprintCaptures = extractFingerprintCaptures(results)
 
-            val faceSamples = extractFaceSamples(results)
-            val fingerprintSamples = extractFingerprintSamples(results)
+            val personCreationEvent = build(faceCaptures, fingerprintCaptures)
 
-            val personCreationEvent = build(
-                faceCaptureBiometricsEvents,
-                fingerprintCaptureBiometricsEvents,
-                faceSamples,
-                fingerprintSamples
-            )
             if (personCreationEvent.hasBiometricData()) {
                 eventRepository.addOrUpdateEvent(personCreationEvent)
             }
         }
     }
 
-    private fun extractFaceSamples(responses: List<Serializable>) = responses
+    private fun extractFaceCaptures(responses: List<Serializable>) = responses
         .filterIsInstance<FaceCaptureResult>()
         .flatMap { it.results }
-        .mapNotNull { it.sample }
-        .map { FaceSample(it.template, it.format) }
 
-    private fun extractFingerprintSamples(responses: List<Serializable>) = responses
+    private fun extractFingerprintCaptures(responses: List<Serializable>) = responses
         .filterIsInstance<FingerprintCaptureResult>()
         .flatMap { it.results }
-        .mapNotNull { it.sample }
-        .map { FingerprintSample(it.fingerIdentifier, it.template, it.templateQualityScore, it.format) }
 
     private fun build(
-        faceCaptureBiometricsEvents: List<FaceCaptureBiometricsEvent>,
-        fingerprintCaptureBiometricsEvents: List<FingerprintCaptureBiometricsEvent>,
-        faceSamplesForPersonCreation: List<FaceSample>?,
-        fingerprintSamplesForPersonCreation: List<FingerprintSample>?
-    ) = PersonCreationEvent(
-        startTime = timeHelper.now(),
-        fingerprintCaptureIds = extractFingerprintCaptureEventIdsBasedOnPersonTemplate(
-            fingerprintCaptureBiometricsEvents,
-            fingerprintSamplesForPersonCreation?.map { encodingUtils.byteArrayToBase64(it.template) }
-        ),
-        fingerprintReferenceId = fingerprintSamplesForPersonCreation?.uniqueId(),
-        faceCaptureIds = extractFaceCaptureEventIdsBasedOnPersonTemplate(
-            faceCaptureBiometricsEvents,
-            faceSamplesForPersonCreation?.map { encodingUtils.byteArrayToBase64(it.template) }
-        ),
-        faceReferenceId = faceSamplesForPersonCreation?.uniqueId()
-    )
+        faceSamplesForPersonCreation: List<FaceCaptureResult.Item>,
+        fingerprintSamplesForPersonCreation: List<FingerprintCaptureResult.Item>,
+    ): PersonCreationEvent {
+        val fingerprintCaptureIds = fingerprintSamplesForPersonCreation
+            .mapNotNull { it.captureEventId }
+            .ifEmpty { null }
+        val fingerprintReferenceId = fingerprintSamplesForPersonCreation
+            .mapNotNull { it.sample }
+            .map { FingerprintSample(it.fingerIdentifier, it.template, it.templateQualityScore, it.format) }
+            .uniqueId()
 
-    private fun extractFingerprintCaptureEventIdsBasedOnPersonTemplate(
-        captureEvents: List<FingerprintCaptureBiometricsEvent>,
-        personTemplates: List<String>?
-    ): List<String>? = captureEvents
-        .filter { personTemplates?.contains(it.payload.fingerprint.template) == true }
-        .map { it.payload.id }
-        .ifEmpty { null }
+        val faceCaptureIds = faceSamplesForPersonCreation
+            .mapNotNull { it.captureEventId }
+            .ifEmpty { null }
+        val faceReferenceId = faceSamplesForPersonCreation
+            .mapNotNull { it.sample }
+            .map { FaceSample(it.template, it.format) }
+            .uniqueId()
 
-    private fun extractFaceCaptureEventIdsBasedOnPersonTemplate(
-        captureEvents: List<FaceCaptureBiometricsEvent>,
-        personTemplates: List<String>?
-    ): List<String>? = captureEvents
-        .filter { personTemplates?.contains(it.payload.face.template) == true }
-        .map { it.payload.id }
-        .ifEmpty { null }
+        return PersonCreationEvent(
+            startTime = timeHelper.now(),
+            fingerprintCaptureIds = fingerprintCaptureIds,
+            fingerprintReferenceId = fingerprintReferenceId,
+            faceCaptureIds = faceCaptureIds,
+            faceReferenceId = faceReferenceId,
+        )
+    }
 
     private fun PersonCreationEvent.hasBiometricData() =
         payload.fingerprintCaptureIds?.isNotEmpty() == true || payload.faceCaptureIds?.isNotEmpty() == true

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/cache/OrchestratorCacheIntegrationTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/cache/OrchestratorCacheIntegrationTest.kt
@@ -10,6 +10,7 @@ import com.simprints.feature.orchestrator.steps.Step
 import com.simprints.feature.orchestrator.steps.StepId
 import com.simprints.feature.orchestrator.steps.StepStatus
 import com.simprints.fingerprint.capture.FingerprintCaptureResult
+import com.simprints.infra.events.sampledata.SampleDefaults.GUID1
 import com.simprints.infra.security.SecurityManager
 import io.mockk.MockKAnnotations
 import io.mockk.every
@@ -62,6 +63,7 @@ class OrchestratorCacheIntegrationTest {
                 result = FingerprintCaptureResult(
                     results = listOf(
                         FingerprintCaptureResult.Item(
+                            captureEventId = GUID1,
                             identifier = IFingerIdentifier.LEFT_THUMB,
                             sample = null
                         )

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/MapStepsForLastBiometricEnrolUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/MapStepsForLastBiometricEnrolUseCaseTest.kt
@@ -11,6 +11,7 @@ import com.simprints.infra.config.store.models.Finger
 import com.simprints.matcher.FaceMatchResult
 import com.simprints.matcher.FingerprintMatchResult
 import com.simprints.core.domain.fingerprint.IFingerIdentifier
+import com.simprints.infra.events.sampledata.SampleDefaults.GUID1
 import org.junit.Before
 import org.junit.Test
 import java.io.Serializable
@@ -48,13 +49,17 @@ internal class MapStepsForLastBiometricEnrolUseCaseTest {
         val result = useCase(listOf(
             FaceCaptureResult(
                 results = listOf(
-                    FaceCaptureResult.Item(0, null),
-                    FaceCaptureResult.Item(0, FaceCaptureResult.Sample(
-                        faceId = "faceId",
-                        template = byteArrayOf(),
-                        imageRef = null,
-                        format = "format"
-                    ))
+                    FaceCaptureResult.Item(captureEventId = null, index = 0, sample = null),
+                    FaceCaptureResult.Item(
+                        captureEventId = GUID1,
+                        index = 0,
+                        sample = FaceCaptureResult.Sample(
+                            faceId = "faceId",
+                            template = byteArrayOf(),
+                            imageRef = null,
+                            format = "format"
+                        )
+                    )
                 ),
             )
         ))
@@ -81,15 +86,18 @@ internal class MapStepsForLastBiometricEnrolUseCaseTest {
         val result = useCase(listOf(
             FingerprintCaptureResult(
                 results = listOf(
-                    FingerprintCaptureResult.Item(IFingerIdentifier.LEFT_THUMB, null),
+                    FingerprintCaptureResult.Item(null, IFingerIdentifier.LEFT_THUMB, null),
                     FingerprintCaptureResult.Item(
-                      IFingerIdentifier.RIGHT_THUMB, FingerprintCaptureResult.Sample(
-                        fingerIdentifier = IFingerIdentifier.RIGHT_THUMB,
-                        template = byteArrayOf(),
-                        templateQualityScore = 0,
-                        imageRef = null,
-                        format = "format"
-                    ))
+                        identifier = IFingerIdentifier.RIGHT_THUMB,
+                        captureEventId = GUID1,
+                        sample = FingerprintCaptureResult.Sample(
+                            fingerIdentifier = IFingerIdentifier.RIGHT_THUMB,
+                            template = byteArrayOf(),
+                            templateQualityScore = 0,
+                            imageRef = null,
+                            format = "format"
+                        )
+                    )
                 ),
             )
         ))

--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/FingerprintCaptureResult.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/FingerprintCaptureResult.kt
@@ -12,6 +12,7 @@ data class FingerprintCaptureResult(
 
     @Keep
     data class Item(
+        val captureEventId: String?,
         val identifier: IFingerIdentifier,
         val sample: Sample?,
     ) : Serializable

--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import java.util.UUID
 import javax.inject.Inject
 import kotlin.math.min
 
@@ -600,6 +601,7 @@ internal class FingerprintCaptureViewModel @Inject constructor(
         val resultItems = collectedFingers.map { (captureId, collectedFinger) ->
             FingerprintCaptureResult.Item(
                 identifier = captureId.finger,
+                captureEventId = captureEventIds[captureId],
                 sample = FingerprintCaptureResult.Sample(
                     fingerIdentifier = captureId.finger,
                     template = collectedFinger.scanResult.template,

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/down/tasks/SubjectFactoryTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/down/tasks/SubjectFactoryTest.kt
@@ -16,6 +16,7 @@ import com.simprints.infra.events.event.domain.models.subject.FaceTemplate
 import com.simprints.infra.events.event.domain.models.subject.FingerprintReference
 import com.simprints.infra.events.event.domain.models.subject.FingerprintTemplate
 import com.simprints.core.domain.fingerprint.IFingerIdentifier
+import com.simprints.infra.events.sampledata.SampleDefaults.GUID1
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -153,6 +154,7 @@ class SubjectFactoryTest {
             moduleId = expected.moduleId,
             fingerprintResponse = FingerprintCaptureResult(listOf(
                 FingerprintCaptureResult.Item(
+                    captureEventId = GUID1,
                     identifier = IDENTIFIER,
                     sample = FingerprintCaptureResult.Sample(
                         template = BASE_64_BYTES,
@@ -165,6 +167,7 @@ class SubjectFactoryTest {
             )),
             faceResponse = FaceCaptureResult(listOf(
                 FaceCaptureResult.Item(
+                    captureEventId = GUID1,
                     index = 0,
                     sample = FaceCaptureResult.Sample(
                         template = BASE_64_BYTES,


### PR DESCRIPTION
For historical reasons, the "PersonCreated" event data was collected as a combination of capture event IDs from the events in the database and captured templates in orchestrator step results.

In some erroneous edge cases, the capture data in step results and the database events might not match. Most likely, it was when one session was abruptly stopped, and another took its place (but that has to be proven). In any case, such mismatch causes invalid "PersonCreation" - one or more modalities do not have matching sets of capture reference IDs and event IDs.

This change ensures that the "CreatePerson" event has the correct sets of IDs since all the info comes only from step results. This does not address the edge case itself, but it at least makes it easier to recover the data. 

**Note**: IMO, the change, while relatively small, can have some unintended effects. Therefore, depending on the urgency, it should be considered only as part of the next hotfix or major release cycle.