### PR TITLE
Save & restore OrchestratorViewModel's data in case of Activity kill & restore

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorFragment.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorFragment.kt
@@ -81,6 +81,8 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
             orchestratorVm.requestProcessed = savedInstanceState.getBoolean(KEY_REQUEST_PROCESSED)
             savedInstanceState.getString(KEY_ACTION_REQUEST)
                 ?.run(orchestratorVm::setActionRequestFromJson)
+            orchestratorVm.restoreStepsIfNeeded()
+            orchestratorVm.restoreModalitiesIfNeeded()
         }
         observeLoginCheckVm()
         observeClientApiVm()

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
@@ -101,6 +101,22 @@ internal class OrchestratorViewModel @Inject constructor(
         doNextStep()
     }
 
+    fun restoreStepsIfNeeded() {
+        if (steps.isEmpty()) {
+            // Restore the steps from cache
+            steps = cache.steps
+        }
+    }
+
+    fun restoreModalitiesIfNeeded() {
+        viewModelScope.launch {
+            if (modalities.isEmpty()) {
+                val projectConfiguration = configRepository.getProjectConfiguration()
+                modalities = projectConfiguration.general.modalities.toSet()
+            }
+        }
+    }
+
     override fun onCleared() {
         cache.steps = steps
         super.onCleared()

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/ShouldCreatePersonUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/ShouldCreatePersonUseCase.kt
@@ -5,6 +5,7 @@ import com.simprints.feature.orchestrator.steps.Step
 import com.simprints.feature.orchestrator.steps.StepId
 import com.simprints.fingerprint.capture.FingerprintCaptureResult
 import com.simprints.infra.config.store.models.GeneralConfiguration
+import com.simprints.infra.logging.Simber
 import com.simprints.infra.orchestration.data.ActionRequest
 import javax.inject.Inject
 
@@ -15,7 +16,12 @@ internal class ShouldCreatePersonUseCase @Inject constructor() {
         modalities: Set<GeneralConfiguration.Modality>,
         results: List<Step>
     ): Boolean {
-        if (actionRequest !is ActionRequest.FlowAction || modalities.isEmpty()) {
+        if (actionRequest !is ActionRequest.FlowAction) {
+            return false
+        }
+
+        if (modalities.isEmpty()) {
+            Simber.e("Modalities are empty")
             return false
         }
 

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/CreateEnrolResponseUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/CreateEnrolResponseUseCase.kt
@@ -7,6 +7,7 @@ import com.simprints.fingerprint.capture.FingerprintCaptureResult
 import com.simprints.infra.eventsync.sync.down.tasks.SubjectFactory
 import com.simprints.infra.orchestration.data.ActionRequest
 import com.simprints.core.domain.response.AppErrorReason
+import com.simprints.infra.logging.Simber
 import com.simprints.infra.orchestration.data.responses.AppResponse
 import java.io.Serializable
 import javax.inject.Inject
@@ -32,7 +33,7 @@ internal class CreateEnrolResponseUseCase @Inject constructor(
 
             AppEnrolResponse(subject.subjectId)
         } catch (e: Exception) {
-            e.printStackTrace()
+            Simber.e(e)
             AppErrorResponse(AppErrorReason.UNEXPECTED_ERROR)
         }
     }

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/OrchestratorViewModelTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/OrchestratorViewModelTest.kt
@@ -25,6 +25,7 @@ import com.simprints.feature.setup.LocationStore
 import com.simprints.feature.setup.SetupResult
 import com.simprints.fingerprint.capture.FingerprintCaptureResult
 import com.simprints.infra.config.store.ConfigRepository
+import com.simprints.infra.config.store.models.GeneralConfiguration
 import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
 import com.simprints.infra.enrolment.records.store.domain.models.SubjectQuery
 import com.simprints.infra.orchestration.data.responses.AppErrorResponse
@@ -37,6 +38,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -218,6 +220,71 @@ internal class OrchestratorViewModelTest {
         viewModel.currentStep.test().value().peekContent()?.let { step ->
             assertThat(step.id).isEqualTo(StepId.FINGERPRINT_MATCHER)
         }
+    }
+
+    @Test
+    fun `Restores steps if empty`() = runTest {
+        every { stepsBuilder.build(any(), any()) } returns emptyList()
+        val savedSteps = listOf(
+            createMockStep(StepId.SETUP),
+            createMockStep(StepId.CONSENT),
+        )
+        every { cache.steps } returns savedSteps
+
+        viewModel.handleAction(mockk())
+        viewModel.restoreStepsIfNeeded()
+
+        verify { cache.steps }
+    }
+
+    @Test
+    fun `Does not restore steps if not empty`() = runTest {
+        val originalSteps = listOf(
+            createMockStep(StepId.FINGERPRINT_CAPTURE),
+        )
+        every { stepsBuilder.build(any(), any()) } returns originalSteps
+        val savedSteps = listOf(
+            createMockStep(StepId.SETUP),
+            createMockStep(StepId.CONSENT),
+        )
+        every { cache.steps } returns savedSteps
+
+        viewModel.handleAction(mockk())
+        viewModel.restoreStepsIfNeeded()
+
+        verify(exactly = 0) { cache.steps }
+    }
+
+    @Test
+    fun `Restores modalities if empty`() = runTest {
+        val projectModalities = listOf<GeneralConfiguration.Modality>(
+            mockk(),
+            mockk(),
+        )
+        coEvery { configRepository.getProjectConfiguration() } returns mockk {
+            every { general.modalities } returns emptyList() andThen projectModalities
+        }
+
+        viewModel.handleAction(mockk())
+        viewModel.restoreModalitiesIfNeeded()
+
+        coVerify(exactly = 3) { configRepository.getProjectConfiguration() }
+    }
+
+    @Test
+    fun `Does not restore modalities if not empty`() = runTest {
+        val projectModalities = listOf<GeneralConfiguration.Modality>(
+            mockk(),
+            mockk(),
+        )
+        coEvery { configRepository.getProjectConfiguration() } returns mockk {
+            every { general.modalities } returns projectModalities
+        }
+
+        viewModel.handleAction(mockk())
+        viewModel.restoreModalitiesIfNeeded()
+
+        coVerify(exactly = 2) { configRepository.getProjectConfiguration() }
     }
 
     private fun createMockStep(stepId: Int, payload: Bundle = Bundle()) = Step(

--- a/infra/images/src/main/java/com/simprints/infra/images/model/Path.kt
+++ b/infra/images/src/main/java/com/simprints/infra/images/model/Path.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.annotation.Keep
 import kotlinx.parcelize.Parcelize
 import java.io.File
+import java.io.Serializable
 
 /**
  * An abstraction of a file path
@@ -15,8 +16,7 @@ import java.io.File
  */
 @Keep
 @Parcelize
-data class Path(val parts: Array<String>) : Parcelable {
-
+data class Path(val parts: Array<String>) : Parcelable, Serializable {
     /**
      * Constructor with a string path
      * @param pathString the path as a string

--- a/infra/orchestrator-data/build.gradle.kts
+++ b/infra/orchestrator-data/build.gradle.kts
@@ -13,4 +13,6 @@ dependencies {
     implementation(project(":infra:events"))
 
     implementation(project(":feature:exit-form"))
+
+    implementation(libs.jackson.core)
 }

--- a/infra/orchestrator-data/src/main/java/com/simprints/infra/orchestration/data/ActionRequest.kt
+++ b/infra/orchestrator-data/src/main/java/com/simprints/infra/orchestration/data/ActionRequest.kt
@@ -1,10 +1,23 @@
 package com.simprints.infra.orchestration.data
 
 import androidx.annotation.Keep
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.simprints.core.domain.tokenization.TokenizableString
 import java.io.Serializable
 
-
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(value = ActionRequest.EnrolActionRequest::class, name = "EnrolActionRequest"),
+    JsonSubTypes.Type(value = ActionRequest.IdentifyActionRequest::class, name = "IdentifyActionRequest"),
+    JsonSubTypes.Type(value = ActionRequest.VerifyActionRequest::class, name = "VerifyActionRequest"),
+    JsonSubTypes.Type(value = ActionRequest.ConfirmIdentityActionRequest::class, name = "ConfirmIdentityActionRequest"),
+    JsonSubTypes.Type(value = ActionRequest.EnrolLastBiometricActionRequest::class, name = "EnrolLastBiometricActionRequest")
+)
 sealed class ActionRequest(
     open val actionIdentifier: ActionRequestIdentifier,
     open val projectId: String,


### PR DESCRIPTION
The initial problem was [this crash](https://console.firebase.google.com/u/0/project/simprints-152315/crashlytics/app/android:com.simprints.id/issues/f4fd6e8c368b3fd2572a543a9f9721b3?time=last-thirty-days&types=crash&sessionEventKey=6638EB700306000139CB7542230944E9_1944343093486226798) that was caused by the Path class not being Serializable. 
However, after fixing that I found out that when OrchestratorActivity is killed, the VM is killed, too. In the VM's onCleared() we save the steps but we never load them when Activity/Fragment is restored. 
Fixing the above uncovered that we also need to restore the modalities, too.
Fixing the above uncovered that ActionRequest is not properly deserialized because it lacks subtype info.

IMO, we can improve the VM saving & restoration by unifying the current 3 separate calls. However, I did not want to do too much refactoring at this point in the release. I'll create a ticket to consider and fix this in the next release.