### PR TITLE
[MS-437] Prevent saving of empty VM data when Fragment is destroyed and restored multiple times without being visible

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorFragment.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorFragment.kt
@@ -74,9 +74,8 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
     private val clientApiVm by viewModels<ClientApiViewModel>()
     private val orchestratorVm by viewModels<OrchestratorViewModel>()
 
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         if (savedInstanceState != null) {
             orchestratorVm.requestProcessed = savedInstanceState.getBoolean(KEY_REQUEST_PROCESSED)
             savedInstanceState.getString(KEY_ACTION_REQUEST)
@@ -84,6 +83,11 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
             orchestratorVm.restoreStepsIfNeeded()
             orchestratorVm.restoreModalitiesIfNeeded()
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
         observeLoginCheckVm()
         observeClientApiVm()
         observeOrchestratorVm()

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/AppResponseBuilderUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/AppResponseBuilderUseCase.kt
@@ -1,6 +1,5 @@
 package com.simprints.feature.orchestrator.usecases.response
 
-import android.os.Parcelable
 import com.simprints.infra.orchestration.data.responses.AppErrorResponse
 import com.simprints.infra.config.store.models.ProjectConfiguration
 import com.simprints.infra.orchestration.data.ActionRequest


### PR DESCRIPTION
To reproduce original bug:
1. Turn on "Don't keep activities"
2. Trigger a flow with dual modalities
3. Capture fingerprints
4. After face onboarding is shown minimize app
5. Bring app back to foreground
6. Capture face
7. Minimize app
8. Bring app back to foreground
9. Minimize app
10. Bring app back to foreground
11. Confirm face capture
12. Kaboom!