### PR TITLE
MS-338 New image saving strategy

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/FaceCaptureViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/FaceCaptureViewModel.kt
@@ -100,7 +100,7 @@ internal class FaceCaptureViewModel @Inject constructor(
     fun flowFinished() {
         viewModelScope.launch {
             val projectConfiguration = configRepository.getProjectConfiguration()
-            if (projectConfiguration.face?.imageSavingStrategy == FaceConfiguration.ImageSavingStrategy.ONLY_GOOD_SCAN) {
+            if (projectConfiguration.face?.imageSavingStrategy?.shouldSaveImage() == true) {
                 saveFaceDetections()
             }
 

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/FaceCaptureViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/FaceCaptureViewModelTest.kt
@@ -98,7 +98,7 @@ class FaceCaptureViewModelTest {
 
     @Test
     fun `Save face detections should be called when image saving strategy set to ONLY_GOO_SCAN`() {
-        coEvery { configRepository.getProjectConfiguration().face?.imageSavingStrategy } returns ImageSavingStrategy.ONLY_GOOD_SCAN
+        coEvery { configRepository.getProjectConfiguration().face?.imageSavingStrategy } returns ImageSavingStrategy.ONLY_USED_IN_REFERENCE
 
         viewModel.captureFinished(faceDetections)
         viewModel.flowFinished()

--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/extensions/SaveFingerprintImagesStrategy.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/extensions/SaveFingerprintImagesStrategy.kt
@@ -5,6 +5,7 @@ import com.simprints.infra.config.store.models.Vero2Configuration.ImageSavingStr
 
 internal fun ImageSavingStrategy.deduceFileExtension(): String = when (this) {
     ImageSavingStrategy.NEVER -> ""
+    ImageSavingStrategy.ONLY_USED_IN_REFERENCE,
     ImageSavingStrategy.ONLY_GOOD_SCAN,
     ImageSavingStrategy.EAGER -> "wsq"
 }

--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
@@ -42,6 +42,10 @@ import com.simprints.fingerprint.infra.scanner.exceptions.safe.ScannerOperationI
 import com.simprints.fingerprint.infra.scanner.wrapper.ScannerWrapper
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.FingerprintConfiguration
+import com.simprints.infra.config.store.models.Vero2Configuration.ImageSavingStrategy.EAGER
+import com.simprints.infra.config.store.models.Vero2Configuration.ImageSavingStrategy.NEVER
+import com.simprints.infra.config.store.models.Vero2Configuration.ImageSavingStrategy.ONLY_GOOD_SCAN
+import com.simprints.infra.config.store.models.Vero2Configuration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE
 import com.simprints.infra.images.model.Path
 import com.simprints.infra.images.model.SecuredImageRef
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.FINGER_CAPTURE
@@ -176,13 +180,14 @@ internal class FingerprintCaptureViewModel @Inject constructor(
 
     private suspend fun initBioSdk() {
         try {
-            bioSdkWrapper= resolveBioSdkWrapperUseCase()
+            bioSdkWrapper = resolveBioSdkWrapperUseCase()
             bioSdkWrapper.initialize()
         } catch (e: BioSdkException.BioSdkInitializationException) {
             Simber.e(e)
             _invalidLicense.send()
         }
     }
+
     private fun launchReconnect() {
         if (!state.isShowingConnectionScreen) {
             updateState {
@@ -201,12 +206,14 @@ internal class FingerprintCaptureViewModel @Inject constructor(
 
             when (it.currentCaptureState()) {
                 is CaptureState.Scanning,
-                is CaptureState.TransferringImage -> pauseLiveFeedback()
+                is CaptureState.TransferringImage,
+                -> pauseLiveFeedback()
 
                 CaptureState.NotCollected,
                 CaptureState.Skipped,
                 is CaptureState.NotDetected,
-                is CaptureState.Collected -> {
+                is CaptureState.Collected,
+                -> {
                     if (it.isShowingConfirmDialog) stopLiveFeedback()
                     else startLiveFeedback(scannerManager.scanner)
                 }
@@ -265,7 +272,7 @@ internal class FingerprintCaptureViewModel @Inject constructor(
         bioSdkWrapper.scanningTimeoutMs +
             if (isImageTransferRequired()) bioSdkWrapper.imageTransferTimeoutMs else 0
 
-   private fun isImageTransferRequired(): Boolean =
+    private fun isImageTransferRequired(): Boolean =
         bioSdkConfiguration.vero2?.imageSavingStrategy?.isImageTransferRequired() ?: false &&
             scannerManager.scanner.isImageTransferSupported()
 
@@ -372,10 +379,18 @@ internal class FingerprintCaptureViewModel @Inject constructor(
         }
     }
 
-    private fun shouldProceedToImageTransfer(quality: Int) = isImageTransferRequired() &&
-        (quality >= qualityThreshold() ||
-            tooManyBadScans(state.currentCaptureState(), plusBadScan = true) ||
-            bioSdkConfiguration.vero2?.imageSavingStrategy?.isEager() ?: false)
+    private fun shouldProceedToImageTransfer(quality: Int): Boolean {
+        val isGoodScan = quality >= qualityThreshold()
+        val isTooManyBadScans = tooManyBadScans(state.currentCaptureState(), plusBadScan = true)
+
+        val shouldUploadImage = when (bioSdkConfiguration.vero2?.imageSavingStrategy) {
+            NEVER, null -> false
+            EAGER -> true
+            ONLY_GOOD_SCAN -> isGoodScan
+            ONLY_USED_IN_REFERENCE -> isGoodScan || isTooManyBadScans
+        }
+        return isImageTransferRequired() && shouldUploadImage
+    }
 
     private fun proceedToImageTransfer() {
         imageTransferTask?.cancel()
@@ -504,6 +519,7 @@ internal class FingerprintCaptureViewModel @Inject constructor(
                 Simber.e(e)
                 handleNoFingerDetected()
             }
+
             else -> {
                 updateCaptureState { toNotCollected() }
                 Simber.e(e)

--- a/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/extensions/SaveFingerprintImagesStrategyTest.kt
+++ b/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/extensions/SaveFingerprintImagesStrategyTest.kt
@@ -3,6 +3,7 @@ package com.simprints.fingerprint.capture.extensions
 import com.google.common.truth.Truth.assertThat
 import com.simprints.infra.config.store.models.Vero2Configuration.ImageSavingStrategy.EAGER
 import com.simprints.infra.config.store.models.Vero2Configuration.ImageSavingStrategy.NEVER
+import com.simprints.infra.config.store.models.Vero2Configuration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE
 import com.simprints.infra.config.store.models.Vero2Configuration.ImageSavingStrategy.ONLY_GOOD_SCAN
 import org.junit.Test
 
@@ -13,6 +14,7 @@ internal class SaveFingerprintImagesStrategyTest {
         mapOf(
             EAGER to "wsq",
             ONLY_GOOD_SCAN to "wsq",
+            ONLY_USED_IN_REFERENCE to "wsq",
             NEVER to "",
         ).map { (actual, expected) -> assertThat(actual.deduceFileExtension()).isEqualTo(expected) }
     }
@@ -22,6 +24,7 @@ internal class SaveFingerprintImagesStrategyTest {
         mapOf(
             EAGER to true,
             ONLY_GOOD_SCAN to true,
+            ONLY_USED_IN_REFERENCE to true,
             NEVER to false,
         ).map { (actual, expected) -> assertThat(actual.isImageTransferRequired()).isEqualTo(expected) }
     }
@@ -31,6 +34,7 @@ internal class SaveFingerprintImagesStrategyTest {
         mapOf(
             EAGER to true,
             ONLY_GOOD_SCAN to false,
+            ONLY_USED_IN_REFERENCE to false,
             NEVER to false,
         ).map { (actual, expected) -> assertThat(actual.isEager()).isEqualTo(expected) }
     }

--- a/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModelTest.kt
+++ b/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModelTest.kt
@@ -1233,7 +1233,7 @@ class FingerprintCaptureViewModelTest {
     }
 
     private fun withImageTransfer(isEager: Boolean = false) {
-        every { vero2Configuration.imageSavingStrategy } returns if (isEager) ImageSavingStrategy.EAGER else ImageSavingStrategy.ONLY_GOOD_SCAN
+        every { vero2Configuration.imageSavingStrategy } returns if (isEager) ImageSavingStrategy.EAGER else ImageSavingStrategy.ONLY_USED_IN_REFERENCE
         coEvery { saveImageUseCase.invoke(any(), any(), any()) } returns mockk {
             every { relativePath } returns Path(emptyArray())
         }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/models/OldProjectConfig.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/models/OldProjectConfig.kt
@@ -139,7 +139,7 @@ internal data class OldProjectConfig(
                 displayLiveFeedback = fingerprintLiveFeedbackOn.toBoolean(),
                 imageSavingStrategy = when (saveFingerprintImagesStrategy) {
                     "NEVER" -> Vero2Configuration.ImageSavingStrategy.NEVER
-                    "WSQ_15" -> Vero2Configuration.ImageSavingStrategy.ONLY_GOOD_SCAN
+                    "WSQ_15" -> Vero2Configuration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE
                     "WSQ_15_EAGER" -> Vero2Configuration.ImageSavingStrategy.EAGER
                     else -> Vero2Configuration.ImageSavingStrategy.NEVER
                 },

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/models/OldProjectConfig.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/models/OldProjectConfig.kt
@@ -85,7 +85,7 @@ internal data class OldProjectConfig(
                     ?: DEFAULT_FACE_FRAMES_TO_CAPTURE,
                 qualityThreshold = faceQualityThreshold.toInt(),
                 imageSavingStrategy = if (saveFaceImages.toBoolean()) {
-                    FaceConfiguration.ImageSavingStrategy.ONLY_GOOD_SCAN
+                    FaceConfiguration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE
                 } else {
                     FaceConfiguration.ImageSavingStrategy.NEVER
                 },

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/models/FaceConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/models/FaceConfiguration.kt
@@ -14,6 +14,7 @@ internal fun FaceConfiguration.toProto(): ProtoFaceConfiguration =
 internal fun FaceConfiguration.ImageSavingStrategy.toProto(): ProtoFaceConfiguration.ImageSavingStrategy =
     when (this) {
         FaceConfiguration.ImageSavingStrategy.NEVER -> ProtoFaceConfiguration.ImageSavingStrategy.NEVER
+        FaceConfiguration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE -> ProtoFaceConfiguration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE
         FaceConfiguration.ImageSavingStrategy.ONLY_GOOD_SCAN -> ProtoFaceConfiguration.ImageSavingStrategy.ONLY_GOOD_SCAN
     }
 
@@ -28,6 +29,7 @@ internal fun ProtoFaceConfiguration.toDomain(): FaceConfiguration =
 internal fun ProtoFaceConfiguration.ImageSavingStrategy.toDomain(): FaceConfiguration.ImageSavingStrategy =
     when (this) {
         ProtoFaceConfiguration.ImageSavingStrategy.NEVER -> FaceConfiguration.ImageSavingStrategy.NEVER
+        ProtoFaceConfiguration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE -> FaceConfiguration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE
         ProtoFaceConfiguration.ImageSavingStrategy.ONLY_GOOD_SCAN -> FaceConfiguration.ImageSavingStrategy.ONLY_GOOD_SCAN
         ProtoFaceConfiguration.ImageSavingStrategy.UNRECOGNIZED -> throw InvalidProtobufEnumException(
             "invalid image saving strategy $name"

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/models/Vero2Configuration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/models/Vero2Configuration.kt
@@ -16,6 +16,7 @@ internal fun Vero2Configuration.ImageSavingStrategy.toProto(): ProtoVero2Configu
     when (this) {
         Vero2Configuration.ImageSavingStrategy.NEVER -> ProtoVero2Configuration.ImageSavingStrategy.NEVER
         Vero2Configuration.ImageSavingStrategy.ONLY_GOOD_SCAN -> ProtoVero2Configuration.ImageSavingStrategy.ONLY_GOOD_SCAN
+        Vero2Configuration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE -> ProtoVero2Configuration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE
         Vero2Configuration.ImageSavingStrategy.EAGER -> ProtoVero2Configuration.ImageSavingStrategy.EAGER
     }
 
@@ -47,6 +48,7 @@ internal fun ProtoVero2Configuration.ImageSavingStrategy.toDomain(): Vero2Config
     when (this) {
         ProtoVero2Configuration.ImageSavingStrategy.NEVER -> Vero2Configuration.ImageSavingStrategy.NEVER
         ProtoVero2Configuration.ImageSavingStrategy.ONLY_GOOD_SCAN -> Vero2Configuration.ImageSavingStrategy.ONLY_GOOD_SCAN
+        ProtoVero2Configuration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE -> Vero2Configuration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE
         ProtoVero2Configuration.ImageSavingStrategy.EAGER -> Vero2Configuration.ImageSavingStrategy.EAGER
         ProtoVero2Configuration.ImageSavingStrategy.UNRECOGNIZED -> throw InvalidProtobufEnumException(
             "invalid ImageSavingStrategy $name"

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/FaceConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/FaceConfiguration.kt
@@ -9,6 +9,9 @@ data class FaceConfiguration(
 
     enum class ImageSavingStrategy {
         NEVER,
+        ONLY_USED_IN_REFERENCE,
         ONLY_GOOD_SCAN;
+
+        fun shouldSaveImage() = this != NEVER
     }
 }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/Vero2Configuration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/Vero2Configuration.kt
@@ -13,6 +13,7 @@ data class Vero2Configuration(
     enum class ImageSavingStrategy {
         NEVER,
         ONLY_GOOD_SCAN,
+        ONLY_USED_IN_REFERENCE,
         EAGER;
     }
 

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiFaceConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiFaceConfiguration.kt
@@ -22,11 +22,13 @@ internal data class ApiFaceConfiguration(
     @Keep
     enum class ImageSavingStrategy {
         NEVER,
+        ONLY_USED_IN_REFERENCE,
         ONLY_GOOD_SCAN;
 
         fun toDomain(): FaceConfiguration.ImageSavingStrategy =
             when (this) {
                 NEVER -> FaceConfiguration.ImageSavingStrategy.NEVER
+                ONLY_USED_IN_REFERENCE -> FaceConfiguration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE
                 ONLY_GOOD_SCAN -> FaceConfiguration.ImageSavingStrategy.ONLY_GOOD_SCAN
             }
     }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiVero2Configuration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiVero2Configuration.kt
@@ -25,11 +25,13 @@ internal data class ApiVero2Configuration(
     enum class ImageSavingStrategy {
         NEVER,
         ONLY_GOOD_SCAN,
+        ONLY_USED_IN_REFERENCE,
         EAGER;
 
         fun toDomain(): Vero2Configuration.ImageSavingStrategy =
             when (this) {
                 NEVER -> Vero2Configuration.ImageSavingStrategy.NEVER
+                ONLY_USED_IN_REFERENCE -> Vero2Configuration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE
                 ONLY_GOOD_SCAN -> Vero2Configuration.ImageSavingStrategy.ONLY_GOOD_SCAN
                 EAGER -> Vero2Configuration.ImageSavingStrategy.EAGER
             }

--- a/infra/config-store/src/main/proto/project_config.proto
+++ b/infra/config-store/src/main/proto/project_config.proto
@@ -37,6 +37,7 @@ message ProtoFaceConfiguration {
     enum ImageSavingStrategy {
         NEVER = 0;
         ONLY_GOOD_SCAN = 1;
+        ONLY_USED_IN_REFERENCE = 2;
     }
 }
 

--- a/infra/config-store/src/main/proto/project_config.proto
+++ b/infra/config-store/src/main/proto/project_config.proto
@@ -93,6 +93,7 @@ message ProtoVero2Configuration {
         NEVER = 0;
         ONLY_GOOD_SCAN = 1;
         EAGER = 2;
+        ONLY_USED_IN_REFERENCE = 3;
     }
 
     enum CaptureStrategy {

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigSharedPrefsMigrationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigSharedPrefsMigrationTest.kt
@@ -622,7 +622,7 @@ class ProjectConfigSharedPrefsMigrationTest {
         private val PROTO_FACE_CONFIGURATION = ProtoFaceConfiguration.newBuilder()
             .setNbOfImagesToCapture(2)
             .setQualityThreshold(-1)
-            .setImageSavingStrategy(ProtoFaceConfiguration.ImageSavingStrategy.ONLY_GOOD_SCAN)
+            .setImageSavingStrategy(ProtoFaceConfiguration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE)
             .setDecisionPolicy(
                 ProtoDecisionPolicy.newBuilder().setLow(1).setMedium(20).setHigh(100).build()
             )

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/local/models/FaceConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/local/models/FaceConfigurationTest.kt
@@ -18,6 +18,7 @@ class FaceConfigurationTest {
     fun `should map correctly the ImageSavingStrategy enums`() {
         val mapping = mapOf(
             ProtoFaceConfiguration.ImageSavingStrategy.NEVER to FaceConfiguration.ImageSavingStrategy.NEVER,
+            ProtoFaceConfiguration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE to FaceConfiguration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE,
             ProtoFaceConfiguration.ImageSavingStrategy.ONLY_GOOD_SCAN to FaceConfiguration.ImageSavingStrategy.ONLY_GOOD_SCAN,
         )
 

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/local/models/Vero2ConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/local/models/Vero2ConfigurationTest.kt
@@ -19,6 +19,7 @@ class Vero2ConfigurationTest {
         val mapping = mapOf(
             ProtoVero2Configuration.ImageSavingStrategy.NEVER to Vero2Configuration.ImageSavingStrategy.NEVER,
             ProtoVero2Configuration.ImageSavingStrategy.ONLY_GOOD_SCAN to Vero2Configuration.ImageSavingStrategy.ONLY_GOOD_SCAN,
+            ProtoVero2Configuration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE to Vero2Configuration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE,
             ProtoVero2Configuration.ImageSavingStrategy.EAGER to Vero2Configuration.ImageSavingStrategy.EAGER,
         )
 

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiFaceConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiFaceConfigurationTest.kt
@@ -17,11 +17,25 @@ class ApiFaceConfigurationTest {
     fun `should map correctly the ImageSavingStrategy enums`() {
         val mapping = mapOf(
             ApiFaceConfiguration.ImageSavingStrategy.NEVER to FaceConfiguration.ImageSavingStrategy.NEVER,
+            ApiFaceConfiguration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE to FaceConfiguration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE,
             ApiFaceConfiguration.ImageSavingStrategy.ONLY_GOOD_SCAN to FaceConfiguration.ImageSavingStrategy.ONLY_GOOD_SCAN,
         )
 
         mapping.forEach {
             assertThat(it.key.toDomain()).isEqualTo(it.value)
+        }
+    }
+
+    @Test
+    fun `should upload images correctly`() {
+        val mapping = mapOf(
+            FaceConfiguration.ImageSavingStrategy.NEVER to false,
+            FaceConfiguration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE to true,
+            FaceConfiguration.ImageSavingStrategy.ONLY_GOOD_SCAN to true,
+        )
+
+        mapping.forEach {
+            assertThat(it.key.shouldSaveImage()).isEqualTo(it.value)
         }
     }
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiVero2ConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiVero2ConfigurationTest.kt
@@ -18,6 +18,7 @@ class ApiVero2ConfigurationTest {
         val mapping = mapOf(
             ApiVero2Configuration.ImageSavingStrategy.NEVER to Vero2Configuration.ImageSavingStrategy.NEVER,
             ApiVero2Configuration.ImageSavingStrategy.ONLY_GOOD_SCAN to Vero2Configuration.ImageSavingStrategy.ONLY_GOOD_SCAN,
+            ApiVero2Configuration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE to Vero2Configuration.ImageSavingStrategy.ONLY_USED_IN_REFERENCE,
             ApiVero2Configuration.ImageSavingStrategy.EAGER to Vero2Configuration.ImageSavingStrategy.EAGER,
         )
 


### PR DESCRIPTION
Main changes:
* Existing `ONLY_GOOD_SCAN` saving strategy replaced by `ONLY_USED_IN_REFERENCE` since it is how it already works.
* Adding new logic for `ONLY_GOOD_SCAN` to extract only images with quality scores over the threshold.