### PR TITLE
MS-471 Matching default lowest confidence value decreased to minimum possible

### DIFF
--- a/feature/matcher/src/main/java/com/simprints/matcher/usecases/MatchResultSet.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/usecases/MatchResultSet.kt
@@ -7,7 +7,7 @@ internal class MatchResultSet<T : MatchResultItem>(
     private val maxSize: Int = MAX_RESULTS,
 ) {
 
-    private var lowestConfidence: Float = Float.MIN_VALUE
+    private var lowestConfidence: Float = 0f
 
     private val treeSet = TreeSet { o1: T, o2: T ->
         // Reverse order for descending sort


### PR DESCRIPTION
Matching algorithm provides a non-negative value, but the minimum lowest confidence value to compare it with was above 0. Adjusted to 0.