### PR TITLE
[MS-451] Splash screen rotation no longer leads to a freeze of the orchestration flow

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorFragment.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorFragment.kt
@@ -77,7 +77,7 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (savedInstanceState != null) {
-            orchestratorVm.requestProcessed = savedInstanceState.getBoolean(KEY_REQUEST_PROCESSED)
+            orchestratorVm.isRequestProcessed = savedInstanceState.getBoolean(KEY_REQUEST_PROCESSED)
             savedInstanceState.getString(KEY_ACTION_REQUEST)
                 ?.run(orchestratorVm::setActionRequestFromJson)
             orchestratorVm.restoreStepsIfNeeded()
@@ -87,7 +87,6 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        orchestratorVm.isActivityRestored = savedInstanceState != null
 
         observeLoginCheckVm()
         observeClientApiVm()
@@ -230,7 +229,7 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putBoolean(KEY_REQUEST_PROCESSED, orchestratorVm.requestProcessed)
+        outState.putBoolean(KEY_REQUEST_PROCESSED, orchestratorVm.isRequestProcessed)
         // [MS-405] Saving the action request in the bundle, since ViewModels don't survive the
         // process death. ActionRequest is important in mapping the correct SID response, hence it
         // is important for it to be able to survive both configuration changes and process death.
@@ -240,15 +239,15 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
     override fun onResume() {
         super.onResume()
 
-        if (!orchestratorVm.isActivityRestored && !orchestratorVm.requestProcessed) {
+        if (!orchestratorVm.isRequestProcessed) {
             if (loginCheckVm.isDeviceSafe()) {
-                orchestratorVm.requestProcessed = true
                 lifecycleScope.launch {
                     val actionRequest =
                         clientApiVm.handleIntent(args.requestAction, args.requestParams)
                     if (actionRequest != null) {
                         loginCheckVm.validateSignInAndProceed(actionRequest)
                     }
+                    orchestratorVm.isRequestProcessed = true
                 }
             }
         }

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
@@ -52,8 +52,7 @@ internal class OrchestratorViewModel @Inject constructor(
     private val updateDailyActivity: UpdateDailyActivityUseCase,
 ) : ViewModel() {
 
-    var isActivityRestored = false
-    var requestProcessed = false
+    var isRequestProcessed = false
     private var modalities = emptySet<GeneralConfiguration.Modality>()
     private var steps = emptyList<Step>()
     private var actionRequest: ActionRequest? = null


### PR DESCRIPTION
When the device is rotated on the splash screen, it no longer leads to the flow disruption. 
https://github.com/Simprints/Android-Simprints-ID/assets/129499142/c2f32836-0367-482b-8d2b-812cda9a64f7

