### PR TITLE
[MS-468] Adding a separate horizontal fragment_confirmation.xml layout, so that the face capture screen elements won't overlap each other

### DIFF
--- a/face/capture/src/main/res/layout-land/fragment_confirmation.xml
+++ b/face/capture/src/main/res/layout-land/fragment_confirmation.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/simprints_blue">
+
+    <TextView
+        android:id="@+id/face_confirm_title"
+        style="@style/Text.Headline6.White"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_default"
+        android:text="@string/face_capture_confirmation_title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <de.hdodenhof.circleimageview.CircleImageView
+        android:id="@+id/confirmation_img"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/container_buttons"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/face_confirm_title"
+        tools:src="@tools:sample/avatars" />
+
+    <LinearLayout
+        android:id="@+id/container_buttons"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/recapture_btn"
+            style="@style/Widget.Simprints.Button.White"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginEnd="8dp"
+            android:layout_weight="1"
+            android:text="@string/face_capture_recapture_button" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/confirmation_btn"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginStart="8dp"
+            android:layout_weight="1"
+            android:text="@string/face_capture_finish_button" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/face/capture/src/main/res/layout-land/fragment_confirmation.xml
+++ b/face/capture/src/main/res/layout-land/fragment_confirmation.xml
@@ -21,6 +21,8 @@
         android:id="@+id/confirmation_img"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        app:layout_constraintHeight_max="300dp"
+        app:layout_constraintWidth_max="300dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintBottom_toTopOf="@+id/container_buttons"
         app:layout_constraintDimensionRatio="1:1"

--- a/face/capture/src/main/res/layout/fragment_confirmation.xml
+++ b/face/capture/src/main/res/layout/fragment_confirmation.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/simprints_blue">
@@ -23,7 +24,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@tools:sample/avatars" />
 
     <TextView
         android:id="@+id/confirmation_txt"


### PR DESCRIPTION
The `Face has been successfully captured` was intentionally removed from the horizontal layout to provide more space for the image.

**Phone view**
![image](https://github.com/Simprints/Android-Simprints-ID/assets/129499142/f14c2d31-2eab-4820-8e7d-7d8913544cdf)
![image](https://github.com/Simprints/Android-Simprints-ID/assets/129499142/f75b47f4-f8dd-4862-9a57-b9e9a149bcc4)

**Tablet view**
![image](https://github.com/Simprints/Android-Simprints-ID/assets/129499142/0ba51fec-5c7b-4368-aeb3-fc689b0307cc)

