### PR TITLE
[MS-226] LiveFeedbackFragment now utilizes different layouts for horizontal and vertical screen orientations

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/models/ScreenOrientation.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/models/ScreenOrientation.kt
@@ -1,0 +1,16 @@
+package com.simprints.face.capture.models
+
+import android.content.res.Configuration
+import android.content.res.Resources
+
+enum class ScreenOrientation {
+    Landscape, Portrait;
+
+    companion object {
+        fun getCurrentOrientation(resources: Resources) =
+            when (resources.configuration.orientation) {
+                Configuration.ORIENTATION_LANDSCAPE -> Landscape
+                else -> Portrait
+            }
+    }
+}

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/FrameProcessor.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/FrameProcessor.kt
@@ -21,7 +21,8 @@ internal class FrameProcessor @Inject constructor(
     private var previewViewHeight: Int = 0
 
     private lateinit var boxOnTheScreen: RectF
-    private var cropRect: Rect? = null
+    var cropRect: Rect? = null
+        private set
 
     /**
      * Init the frame processor

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -24,6 +24,7 @@ import com.simprints.core.tools.extentions.hasPermission
 import com.simprints.face.capture.R
 import com.simprints.face.capture.databinding.FragmentLiveFeedbackBinding
 import com.simprints.face.capture.models.FaceDetection
+import com.simprints.face.capture.models.ScreenOrientation
 import com.simprints.face.capture.screens.FaceCaptureViewModel
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.uibase.navigation.navigateSafely
@@ -74,6 +75,11 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initFragment()
+    }
+
+    override fun onDestroyView() {
+        vm.clearFrameProcessor()
+        super.onDestroyView()
     }
 
     private fun initFragment() {
@@ -133,7 +139,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
 
     override fun onStop() {
         // Shut down our background executor
-        if(::cameraExecutor.isInitialized) {
+        if (::cameraExecutor.isInitialized) {
             cameraExecutor.shutdown()
         }
         super.onStop()
@@ -161,7 +167,10 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
 
     private fun analyze(image: ImageProxy) {
         try {
-            vm.process(image)
+            vm.process(
+                image = image,
+                screenOrientation = ScreenOrientation.getCurrentOrientation(resources)
+            )
         } catch (t: Throwable) {
             Simber.e(t)
             // Image analysis is running in bg thread
@@ -185,7 +194,9 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
 
     private fun renderCapturingStateColors() {
         with(binding) {
-            captureOverlay.drawWhiteTarget()
+            captureOverlay.drawWhiteTarget(
+                screenOrientation = ScreenOrientation.getCurrentOrientation(resources)
+            )
 
             captureTitle.setTextColor(
                 ContextCompat.getColor(requireContext(), IDR.color.simprints_blue_grey)
@@ -198,7 +209,9 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
 
     private fun renderCapturingNotStarted() {
         binding.apply {
-            captureOverlay.drawSemiTransparentTarget()
+            captureOverlay.drawSemiTransparentTarget(
+                screenOrientation = ScreenOrientation.getCurrentOrientation(resources)
+            )
             captureTitle.text = getString(IDR.string.face_capture_preparation_title)
             captureFeedbackTxtTitle.text = getString(IDR.string.face_capture_title_previewing)
         }

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
@@ -11,6 +11,7 @@ import com.simprints.core.tools.extentions.area
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.face.capture.models.FaceDetection
 import com.simprints.face.capture.models.FaceTarget
+import com.simprints.face.capture.models.ScreenOrientation
 import com.simprints.face.capture.models.SymmetricTarget
 import com.simprints.face.capture.usecases.SimpleCaptureEventReporter
 import com.simprints.infra.config.store.ConfigRepository
@@ -55,9 +56,9 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
      *
      * @param image is the camera frame
      */
-    fun process(image: ImageProxy) {
+    fun process(image: ImageProxy, screenOrientation: ScreenOrientation) {
         val captureStartTime = timeHelper.now()
-        val croppedBitmap = frameProcessor.cropRotateFrame(image)
+        val croppedBitmap = frameProcessor.cropRotateFrame(image, screenOrientation)
         val potentialFace = faceDetector.analyze(croppedBitmap)
 
         val faceDetection = getFaceDetectionFromPotentialFace(croppedBitmap, potentialFace)
@@ -91,6 +92,8 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
         this.attemptNumber = attemptNumber
         frameProcessor.init(previewSize, cropRect)
     }
+
+    fun clearFrameProcessor() = frameProcessor.clear()
 
     fun startCapture() {
         capturingState.value = CapturingState.CAPTURING

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/views/CameraTargetOverlay.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/views/CameraTargetOverlay.kt
@@ -1,11 +1,17 @@
 package com.simprints.face.capture.screens.livefeedback.views
 
 import android.content.Context
-import android.graphics.*
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
+import android.graphics.RectF
 import android.util.AttributeSet
 import android.view.View
 import androidx.appcompat.widget.AppCompatImageView
 import com.simprints.core.tools.extentions.dpToPx
+import com.simprints.face.capture.models.ScreenOrientation
 import com.simprints.infra.uibase.annotations.ExcludedFromGeneratedTestCoverageReports
 
 @ExcludedFromGeneratedTestCoverageReports("UI code")
@@ -16,9 +22,29 @@ internal class CameraTargetOverlay(
     companion object {
         private val SEMI_TRANSPARENT_OVERLAY = Color.argb(102, 0, 0, 0)
         private val WHITE_OVERLAY = Color.argb(242, 255, 255, 255)
-        private const val percentFromTop = 0.3f
 
-        fun rectForPlane(width: Int, height: Int, rectSize: Float): RectF {
+        /**
+         * Reference to the guideline's percentage of margin from the top of the screen. Used when
+         * the screen is in the portrait (vertical) mode
+         */
+        private const val percentFromTopPortrait = 0.3f
+
+        /**
+         * Reference to the guideline's percentage of margin from the top of the screen. Used when
+         * the screen is in the landscape (horizontal) mode
+         */
+        private const val percentFromTopLandscape = 0.5f
+
+        fun rectForPlane(
+            width: Int,
+            height: Int,
+            rectSize: Float,
+            screenOrientation: ScreenOrientation
+        ): RectF {
+            val percentFromTop = when (screenOrientation) {
+                ScreenOrientation.Landscape -> percentFromTopLandscape
+                ScreenOrientation.Portrait -> percentFromTopPortrait
+            }
             val top = (height * percentFromTop) - (rectSize / 2)
             val bottom = top + rectSize
 
@@ -59,24 +85,24 @@ internal class CameraTargetOverlay(
         drawingFunc?.invoke(canvas)
     }
 
-    fun drawSemiTransparentTarget() {
+    fun drawSemiTransparentTarget(screenOrientation: ScreenOrientation) {
         drawingFunc = {
             drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR)
             drawColor(SEMI_TRANSPARENT_OVERLAY, PorterDuff.Mode.SRC_OVER)
-            drawTarget()
+            drawTarget(screenOrientation)
         }
     }
 
-    fun drawWhiteTarget() {
+    fun drawWhiteTarget(screenOrientation: ScreenOrientation) {
         drawingFunc = {
             drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR)
             drawColor(WHITE_OVERLAY, PorterDuff.Mode.SRC_OVER)
-            drawTarget()
+            drawTarget(screenOrientation)
         }
     }
 
-    private fun Canvas.drawTarget() {
-        rectInCanvas = rectForPlane(width, height, rectSize)
+    private fun Canvas.drawTarget(screenOrientation: ScreenOrientation) {
+        rectInCanvas = rectForPlane(width, height, rectSize, screenOrientation)
 
         drawOval(rectInCanvas, circlePaint)
         drawOval(rectInCanvas, circleBorderPaint)

--- a/face/capture/src/main/res/layout-land/fragment_live_feedback.xml
+++ b/face/capture/src/main/res/layout-land/fragment_live_feedback.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -24,7 +23,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.3" />
+        app:layout_constraintGuide_percent="0.5" />
 
     <com.simprints.face.capture.screens.livefeedback.views.CameraTargetOverlay
         android:id="@+id/capture_overlay"
@@ -36,7 +35,7 @@
         style="@style/Text.Headline5.White"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
+        android:layout_marginTop="@dimen/margin_default"
         android:text="@string/face_capture_preparation_title"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -55,37 +54,38 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/capture_guide_frame" />
 
-    <CheckedTextView
-        android:id="@+id/capture_feedback_txt_title"
-        style="@style/Text.Headline6.Bold"
+    <LinearLayout
         android:layout_width="wrap_content"
-        android:layout_height="40dp"
-        android:layout_marginTop="190dp"
-        android:background="@drawable/feedback_chip_white"
-        android:textColor="@color/feedback_chip_text"
-        android:drawablePadding="4dp"
-        android:gravity="center"
-        android:paddingStart="12dp"
-        android:paddingTop="4dp"
-        android:paddingEnd="12dp"
-        android:paddingBottom="4dp"
-        android:text="@string/face_capture_title_previewing"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/capture_guide_frame" />
-
-    <TextView
-        android:id="@+id/capture_feedback_txt_explanation"
-        style="@style/Text.Headline5.White"
-        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
         android:gravity="center"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/margin_default"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/capture_feedback_txt_title"
-        tools:text="Move closer" />
+        app:layout_constraintStart_toStartOf="parent">
+
+        <CheckedTextView
+            android:id="@+id/capture_feedback_txt_title"
+            style="@style/Text.Headline6.Bold"
+            android:layout_width="wrap_content"
+            android:layout_height="40dp"
+            android:background="@drawable/feedback_chip_white"
+            android:drawablePadding="4dp"
+            android:gravity="center"
+            android:paddingHorizontal="12dp"
+            android:paddingVertical="4dp"
+            android:text="@string/face_capture_title_previewing"
+            android:textColor="@color/feedback_chip_text" />
+
+        <TextView
+            android:id="@+id/capture_feedback_txt_explanation"
+            style="@style/Text.Headline5.White"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_default"
+            android:gravity="center"
+            tools:text="Move closer" />
+    </LinearLayout>
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/face/capture/src/test/java/com/simprints/face/capture/models/ScreenOrientationTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/models/ScreenOrientationTest.kt
@@ -1,0 +1,42 @@
+package com.simprints.face.capture.models
+
+import android.content.res.Configuration
+import android.content.res.Resources
+import com.google.common.truth.Truth.assertThat
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import org.junit.Before
+import org.junit.Test
+
+
+class ScreenOrientationTest {
+
+    @MockK
+    lateinit var resources: Resources
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxed = true)
+    }
+
+    @Test
+    fun `when the resources are provided, then the correct screen orientation is mapped`() {
+        val orientationMap = mapOf(
+            Configuration.ORIENTATION_LANDSCAPE to ScreenOrientation.Landscape,
+            Configuration.ORIENTATION_PORTRAIT to ScreenOrientation.Portrait
+        )
+        orientationMap.forEach {entry ->
+            val resourceOrientation = entry.key
+            val expectedOrientation = entry.value
+
+            every { resources.configuration } returns mockk {
+                orientation = resourceOrientation
+            }
+            val orientation = ScreenOrientation.getCurrentOrientation(resources)
+            assertThat(orientation).isEqualTo(expectedOrientation)
+        }
+    }
+
+}

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/FrameProcessorTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/FrameProcessorTest.kt
@@ -6,6 +6,7 @@ import android.graphics.RectF
 import android.util.Size
 import androidx.camera.core.ImageProxy
 import com.google.common.truth.Truth.assertThat
+import com.simprints.face.capture.models.ScreenOrientation
 import com.simprints.face.capture.usecases.ImageProxyToBitmapUseCase
 import io.mockk.CapturingSlot
 import io.mockk.MockKAnnotations
@@ -52,7 +53,7 @@ internal class FrameProcessorTest {
 
         frameProcessor.init(Size(screenWidth, screenHeight), boxOnTheScreen)
         // When
-        frameProcessor.cropRotateFrame(image)
+        frameProcessor.cropRotateFrame(image, ScreenOrientation.Portrait)
 
         // Then
         assertThat(cropRectCapture.captured.toString())
@@ -71,7 +72,7 @@ internal class FrameProcessorTest {
 
         frameProcessor.init(Size(screenWidth, screenHeight), boxOnTheScreen)
         // When
-        frameProcessor.cropRotateFrame(image)
+        frameProcessor.cropRotateFrame(image, ScreenOrientation.Portrait)
 
         // Then
         assertThat(cropRectCapture.captured.toString())
@@ -90,7 +91,7 @@ internal class FrameProcessorTest {
 
         frameProcessor.init(Size(screenWidth, screenHeight), boxOnTheScreen)
         // When
-        frameProcessor.cropRotateFrame(image)
+        frameProcessor.cropRotateFrame(image, ScreenOrientation.Portrait)
 
         // Then
         assertThat(cropRectCapture.captured.toString())
@@ -109,7 +110,7 @@ internal class FrameProcessorTest {
 
         frameProcessor.init(Size(screenWidth, screenHeight), boxOnTheScreen)
         // When
-        frameProcessor.cropRotateFrame(image)
+        frameProcessor.cropRotateFrame(image, ScreenOrientation.Portrait)
 
         // Then
         assertThat(cropRectCapture.captured.toString())
@@ -128,7 +129,7 @@ internal class FrameProcessorTest {
 
         frameProcessor.init(Size(screenWidth, screenHeight), boxOnTheScreen)
         // When
-        frameProcessor.cropRotateFrame(image)
+        frameProcessor.cropRotateFrame(image, ScreenOrientation.Portrait)
         // Then throw IllegalArgumentException
 
     }
@@ -145,7 +146,7 @@ internal class FrameProcessorTest {
 
         frameProcessor.init(Size(screenWidth, screenHeight), boxOnTheScreen)
         // When
-        frameProcessor.cropRotateFrame(image)
+        frameProcessor.cropRotateFrame(image, ScreenOrientation.Portrait)
         // Then
         assertThat(cropRectCapture.captured.toString())
             .isEqualTo(Rect(100, 100, 200, 200).toString())
@@ -163,7 +164,7 @@ internal class FrameProcessorTest {
 
         frameProcessor.init(Size(screenWidth, screenHeight), boxOnTheScreen)
         // When
-        frameProcessor.cropRotateFrame(image)
+        frameProcessor.cropRotateFrame(image, ScreenOrientation.Portrait)
         // Then
         assertThat(cropRectCapture.captured.toString())
             .isEqualTo(Rect(100, 100, 200, 200).toString())

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/FrameProcessorTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/FrameProcessorTest.kt
@@ -170,4 +170,23 @@ internal class FrameProcessorTest {
             .isEqualTo(Rect(100, 100, 200, 200).toString())
     }
 
+    @Test
+    fun `when clear is called, cropRect becomes null`() {
+        every { image.width } returns 2000
+        every { image.height } returns 1000
+        every { image.imageInfo.rotationDegrees } returns 90
+
+        val screenWidth = 1000
+        val screenHeight = 500
+
+        frameProcessor.init(Size(screenWidth, screenHeight), boxOnTheScreen)
+        frameProcessor.cropRotateFrame(image, ScreenOrientation.Portrait)
+
+        assertThat(frameProcessor.cropRect).isNotNull()
+
+        frameProcessor.clear()
+
+        assertThat(frameProcessor.cropRect).isNull()
+    }
+
 }

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
@@ -10,21 +10,25 @@ import com.google.common.truth.Truth.assertThat
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.face.capture.models.FaceDetection
+import com.simprints.face.capture.models.ScreenOrientation
 import com.simprints.face.capture.usecases.SimpleCaptureEventReporter
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.facebiosdk.detection.Face
 import com.simprints.infra.facebiosdk.detection.FaceDetector
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import com.simprints.testtools.common.livedata.testObserver
-import io.mockk.*
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.justRun
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.*
 import kotlin.random.Random
 
 @RunWith(RobolectricTestRunner::class)
@@ -61,6 +65,7 @@ internal class LiveFeedbackFragmentViewModelTest {
     lateinit var timeHelper: TimeHelper
 
     private val previewViewSize: Size = Size(100, 100)
+    private val screenOrientation = ScreenOrientation.Portrait
 
     private lateinit var viewModel: LiveFeedbackFragmentViewModel
 
@@ -73,7 +78,7 @@ internal class LiveFeedbackFragmentViewModelTest {
         justRun { frameProcessor.init(any(), any()) }
         justRun { frame.close() }
         justRun { previewFrame.recycle() }
-        every { frameProcessor.cropRotateFrame(frame) } returns previewFrame
+        every { frameProcessor.cropRotateFrame(frame, screenOrientation) } returns previewFrame
 
         viewModel = LiveFeedbackFragmentViewModel(
             frameProcessor,
@@ -89,7 +94,7 @@ internal class LiveFeedbackFragmentViewModelTest {
         coEvery { faceDetector.analyze(previewFrame) } returns getFace()
 
         viewModel.initFrameProcessor(1, 0, rectF, previewViewSize)
-        viewModel.process(frame)
+        viewModel.process(frame, screenOrientation)
 
         val currentDetection = viewModel.currentDetection.testObserver()
         assertThat(currentDetection.observedValues.last()?.status).isEqualTo(FaceDetection.Status.VALID)
@@ -102,9 +107,9 @@ internal class LiveFeedbackFragmentViewModelTest {
         coEvery { faceDetector.analyze(previewFrame) } returns getFace()
 
         viewModel.initFrameProcessor(1, 0, rectF, previewViewSize)
-        viewModel.process(frame)
+        viewModel.process(frame, screenOrientation)
         viewModel.startCapture()
-        viewModel.process(frame)
+        viewModel.process(frame, screenOrientation)
 
         val currentDetection = viewModel.currentDetection.testObserver()
         assertThat(currentDetection.observedValues.last()?.status).isEqualTo(FaceDetection.Status.VALID_CAPTURING)
@@ -120,7 +125,7 @@ internal class LiveFeedbackFragmentViewModelTest {
         val rolledFace: Face = getFace(roll = 45f)
         val noFace = null
 
-        every { frameProcessor.cropRotateFrame(frame) } returns previewFrame
+        every { frameProcessor.cropRotateFrame(frame, screenOrientation) } returns previewFrame
         every { faceDetector.analyze(previewFrame) } returnsMany listOf(
             smallFace,
             bigFace,
@@ -132,11 +137,11 @@ internal class LiveFeedbackFragmentViewModelTest {
         val detections = viewModel.currentDetection.testObserver()
         viewModel.initFrameProcessor(2, 0, rectF, previewViewSize)
 
-        viewModel.process(frame)
-        viewModel.process(frame)
-        viewModel.process(frame)
-        viewModel.process(frame)
-        viewModel.process(frame)
+        viewModel.process(frame, screenOrientation)
+        viewModel.process(frame, screenOrientation)
+        viewModel.process(frame, screenOrientation)
+        viewModel.process(frame, screenOrientation)
+        viewModel.process(frame, screenOrientation)
 
         detections.observedValues.let {
             assertThat(it[0]?.status).isEqualTo(FaceDetection.Status.TOOFAR)
@@ -152,17 +157,17 @@ internal class LiveFeedbackFragmentViewModelTest {
     @Test
     fun `Save all valid captures without fallback image`() = runTest {
         val validFace: Face = getFace()
-        every { frameProcessor.cropRotateFrame(frame) } returns previewFrame
+        every { frameProcessor.cropRotateFrame(frame, screenOrientation) } returns previewFrame
         every { faceDetector.analyze(previewFrame) } returns validFace
         every { timeHelper.now() } returnsMany (0..100L).map { Timestamp(it) }
 
         val currentDetectionObserver = viewModel.currentDetection.testObserver()
         val capturingStateObserver = viewModel.capturingState.testObserver()
         viewModel.initFrameProcessor(2, 0, rectF, previewViewSize)
-        viewModel.process(frame)
+        viewModel.process(frame, screenOrientation)
         viewModel.startCapture()
-        viewModel.process(frame)
-        viewModel.process(frame)
+        viewModel.process(frame, screenOrientation)
+        viewModel.process(frame, screenOrientation)
 
         currentDetectionObserver.observedValues.let {
             assertThat(it[0]?.status).isEqualTo(FaceDetection.Status.VALID)


### PR DESCRIPTION
Due to historical reasons, the preview is formed around the guideline in the layout, whose height is defined as percentage of the screen height. It is hardcoded to 0.3 (30% of sceren height), and it doesn't work for the smaller horizontal dimensions. Thus, the new horizontal layout is introduced, that has a guideline set at the 0.5 (50% of screen height).

![face-capture-1](https://github.com/Simprints/Android-Simprints-ID/assets/129499142/028ac10f-f3c0-4df8-81c4-b13373935f78)
![face-capture-2](https://github.com/Simprints/Android-Simprints-ID/assets/129499142/36cbe6d7-a5b4-421d-94b9-aad718301755)
![face-capture-3](https://github.com/Simprints/Android-Simprints-ID/assets/129499142/d5454b2d-7f2c-4ede-8a4d-d21c7783688f)
![face-capture-4](https://github.com/Simprints/Android-Simprints-ID/assets/129499142/2b7dabe7-6318-4778-9c22-26bdd6d0eeb5)
![image](https://github.com/Simprints/Android-Simprints-ID/assets/129499142/59a77292-7f11-4a84-bc1b-25480e221499)
