### PR TITLE
MS-421 Login error message adjusted to also make sense for an Ending project

### DIFF
--- a/infra/resources/src/main/res/values/strings.xml
+++ b/infra/resources/src/main/res/values/strings.xml
@@ -86,7 +86,7 @@
     <string name="login_qr_code_scanning_camera_unavailable_error">A problem occurred while trying to access the camera, please contact your system administrator</string>
     <string name="login_invalid_qr_code_error">The scanned QR code is invalid.</string>
     <string name="login_missing_credentials_error">Missing credentials. Please check the User ID, Project ID, and key, and try again.</string>
-    <string name="login_invalid_credentials_error">Invalid credentials. Please check the Project ID and key</string>
+    <string name="login_invalid_credentials_error">Login error. Please check the project credentials and that the project is active.</string>
     <string name="login_project_id_intent_mismatch_error">Project ID different from that supplied in intent. Please contact your system administrator.</string>
     <string name="login_no_network_error">Currently offline. Please check your internet connection.</string>
     <string name="login_integrity_service_down_error">A problem occurred trying to contact the Integrity Service. Please try again later.</string>


### PR DESCRIPTION
The error is the same for invalid credentials and for Ending project status, but the error message was related only to the former - adjusted.