### PR TITLE
MS-199 co-sync data permission

### DIFF
--- a/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchViewModel.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchViewModel.kt
@@ -30,6 +30,8 @@ internal class MatchViewModel @Inject constructor(
     private val timeHelper: TimeHelper,
 ) : ViewModel() {
 
+    var shouldCheckPermission: Boolean = true
+
     val matchState: LiveData<MatchState>
         get() = _matchState
     private val _matchState = MutableLiveData<MatchState>(MatchState.NotStarted)
@@ -71,10 +73,12 @@ internal class MatchViewModel @Inject constructor(
         // wait a bit for the user to see the results
         delay(matchingEndWaitTimeInMillis)
 
-        _matchResponse.send(when {
-            isFaceMatch -> FaceMatchResult(sortedResults)
-            else -> FingerprintMatchResult(sortedResults)
-        })
+        _matchResponse.send(
+            when {
+                isFaceMatch -> FaceMatchResult(sortedResults)
+                else -> FingerprintMatchResult(sortedResults)
+            }
+        )
     }
 
     private fun setMatchState(candidatesMatched: Int, results: List<MatchResultItem>) {
@@ -84,31 +88,42 @@ internal class MatchViewModel @Inject constructor(
         val fairMatches =
             results.count { fairMatchThreshold <= it.confidence && it.confidence < goodMatchThreshold }
 
-        _matchState.postValue(MatchState.Finished(
-            candidatesMatched,
-            results.size,
-            veryGoodMatches,
-            goodMatches,
-            fairMatches
-        ))
+        _matchState.postValue(
+            MatchState.Finished(
+                candidatesMatched,
+                results.size,
+                veryGoodMatches,
+                goodMatches,
+                fairMatches
+            )
+        )
+    }
+
+    fun noPermission(neverAskAgain: Boolean) {
+        _matchState.postValue(MatchState.NoPermission(shouldOpenSettings = neverAskAgain))
     }
 
     sealed class MatchState {
         data object NotStarted : MatchState()
         data object LoadingCandidates : MatchState()
         data object Matching : MatchState()
+        data class NoPermission(
+            val shouldOpenSettings: Boolean,
+        ) : MatchState()
+
         data class Finished(
             val candidatesMatched: Int,
             val returnSize: Int,
             val veryGoodMatches: Int,
             val goodMatches: Int,
-            val fairMatches: Int
+            val fairMatches: Int,
         ) : MatchState()
     }
 
     // TODO This configuration should be provided by SDK or project configuration
     //   https://simprints.atlassian.net/browse/CORE-2923
     companion object {
+
         private const val veryGoodMatchThreshold = 50.0
         private const val goodMatchThreshold = 35.0
         private const val fairMatchThreshold = 20.0

--- a/feature/matcher/src/main/res/layout/fragment_matcher.xml
+++ b/feature/matcher/src/main/res/layout/fragment_matcher.xml
@@ -7,7 +7,7 @@
     android:padding="@dimen/margin_large">
 
     <TextView
-        android:id="@+id/face_match_please_wait"
+        android:id="@+id/face_match_message"
         style="@style/Text.Subtitle2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -31,7 +31,7 @@
         app:layout_constraintBottom_toTopOf="@+id/face_match_tv_matchingProgressStatus1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/face_match_please_wait"
+        app:layout_constraintTop_toBottomOf="@id/face_match_message"
         tools:progress="50" />
 
     <TextView
@@ -96,5 +96,17 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/face_match_tv_matchingResultStatus2"
         tools:text="10 matches" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/face_match_permission_request_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/matcher_grant_permission_action"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/face_match_tv_matchingResultStatus3"
+        tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/matcher/src/test/java/com/simprints/matcher/screen/MatchViewModelTest.kt
+++ b/feature/matcher/src/test/java/com/simprints/matcher/screen/MatchViewModelTest.kt
@@ -76,6 +76,13 @@ internal class MatchViewModelTest {
     }
 
     @Test
+    fun `Handles no permission call`() = runTest {
+        val states = viewModel.matchState.test()
+        viewModel.noPermission(true)
+        assertThat(states.value()).isEqualTo(MatchViewModel.MatchState.NoPermission(true))
+    }
+
+    @Test
     fun `Handle face match request correctly`() = runTest {
         val responseItems = listOf(
             FaceMatchResult.Item("1", 90f),

--- a/infra/core/src/main/java/com/simprints/core/tools/extentions/Context.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extentions/Context.ext.kt
@@ -2,7 +2,9 @@ package com.simprints.core.tools.extentions
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.provider.Settings
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
 
@@ -19,3 +21,10 @@ val Context.packageVersionName: String
     } catch (e: PackageManager.NameNotFoundException) {
         "Version Name Not Found"
     }
+
+@ExcludedFromGeneratedTestCoverageReports("UI code")
+val Context.applicationSettingsIntent: Intent
+    get() = Intent(
+        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+        Uri.parse("package:$packageName")
+    )

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/commcare/CommCareIdentityDataSource.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/commcare/CommCareIdentityDataSource.kt
@@ -33,6 +33,7 @@ internal class CommCareIdentityDataSource @Inject constructor(
     companion object {
         val CASE_METADATA_URI: Uri = Uri.parse("content://org.commcare.dalvik.case/casedb/case")
         val CASE_DATA_URI: Uri = Uri.parse("content://org.commcare.dalvik.case/casedb/data")
+        const val PERMISSION_NAME = "org.commcare.dalvik.provider.cases.read"
         const val COLUMN_CASE_ID = "case_id"
         const val COLUMN_DATUM_ID = "datum_id"
         const val COLUMN_VALUE = "value"

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/domain/models/BiometricDataSource.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/domain/models/BiometricDataSource.kt
@@ -1,13 +1,21 @@
 package com.simprints.infra.enrolment.records.store.domain.models
 
+import com.simprints.infra.enrolment.records.store.commcare.CommCareIdentityDataSource
+
 enum class BiometricDataSource {
     SIMPRINTS,
     COMMCARE;
 
     companion object {
+
         fun fromString(value: String) = when (value.uppercase()) {
             "COMMCARE" -> COMMCARE
             else -> SIMPRINTS
+        }
+
+        fun BiometricDataSource.permissionName(): String? = when (this) {
+            COMMCARE -> CommCareIdentityDataSource.PERMISSION_NAME
+            else -> null
         }
     }
 }

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/domain/models/BiometricDataSourceTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/domain/models/BiometricDataSourceTest.kt
@@ -1,5 +1,6 @@
 import com.google.common.truth.Truth.assertThat
 import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
+import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource.Companion.permissionName
 import org.junit.Test
 
 class BiometricDataSourceTest {
@@ -20,5 +21,11 @@ class BiometricDataSourceTest {
     fun `should return SIMPRINTS when value is unknown`() {
         val result = BiometricDataSource.fromString("UNKNOWN")
         assertThat(result).isEqualTo(BiometricDataSource.SIMPRINTS)
+    }
+
+    @Test
+    fun `should return correct permission name for data sources`() {
+        assertThat(BiometricDataSource.SIMPRINTS.permissionName()).isNull()
+        assertThat(BiometricDataSource.COMMCARE.permissionName()).isNotEmpty()
     }
 }

--- a/infra/resources/src/main/res/values/strings.xml
+++ b/infra/resources/src/main/res/values/strings.xml
@@ -120,6 +120,8 @@
         <item quantity="one">%d match</item>
         <item quantity="other">%d matches</item>
     </plurals>
+    <string name="matcher_missing_access_permission">Permission is required to access data provided by the Data Collector application</string>
+    <string name="matcher_grant_permission_action">Grant permission</string>
 
     <!-- Orchestrator -->
     <string name="orchestrator_generic_error_title">Error occurred</string>


### PR DESCRIPTION
Notable changes:
* If the data source defines a custom permission it is checked at the start of the matching step. This may work for any future co-sync data sources.
* If permission is not granted, the user is forced to do a simplified "grant permission" flow on the matching step landing screen.
* "Grant permission" wording has been chosen to accommodate both possible request flows - just the dialogue and settings (when never ask again is selected). Although from my testing it seems that a single "Deny" would automatically set the "Never ask again" state.


https://github.com/Simprints/Android-Simprints-ID/assets/2182889/376d4805-a63a-4e66-b393-7edfdb7fa1ba

https://github.com/Simprints/Android-Simprints-ID/assets/2182889/c08d8191-ce10-4137-9e97-c171fb8b51a6


