### PR TITLE
MS-199 support different package names

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/builders/EnrolRequestBuilder.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/builders/EnrolRequestBuilder.kt
@@ -41,6 +41,7 @@ internal class EnrolRequestBuilder(
         projectId = extractor.getProjectId(),
         userId = extractor.getUserId().asTokenizableRaw(),
         biometricDataSource = extractor.getBiometricDataSource(),
+        callerPackageName = extractor.getCallerPackageName(),
         metadata = extractor.getMetadata(),
         moduleId = extractor.getModuleId().asTokenizableRaw(),
         unknownExtras = extractor.getUnknownExtras()

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/builders/IdentifyRequestBuilder.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/builders/IdentifyRequestBuilder.kt
@@ -44,6 +44,7 @@ internal class IdentifyRequestBuilder(
         userId = extractor.getUserId().asTokenizableRaw(),
         moduleId = extractor.getModuleId().asTokenizableRaw(),
         biometricDataSource = extractor.getBiometricDataSource(),
+        callerPackageName = extractor.getCallerPackageName(),
         metadata = extractor.getMetadata(),
         unknownExtras = extractor.getUnknownExtras()
     )

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/builders/VerifyRequestBuilder.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/builders/VerifyRequestBuilder.kt
@@ -43,6 +43,7 @@ internal class VerifyRequestBuilder(
         userId = extractor.getUserId().asTokenizableRaw(),
         moduleId = extractor.getModuleId().asTokenizableRaw(),
         biometricDataSource = extractor.getBiometricDataSource(),
+        callerPackageName = extractor.getCallerPackageName(),
         metadata = extractor.getMetadata(),
         verifyGuid = extractor.getVerifyGuid(),
         unknownExtras = extractor.getUnknownExtras()

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/extractors/ActionRequestExtractor.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/extractors/ActionRequestExtractor.kt
@@ -2,6 +2,7 @@ package com.simprints.feature.clientapi.mappers.request.extractors
 
 import android.content.Intent
 import com.simprints.feature.clientapi.extensions.extractString
+import com.simprints.feature.clientapi.models.ClientApiConstants
 import com.simprints.libsimprints.Constants
 
 
@@ -23,6 +24,8 @@ internal abstract class ActionRequestExtractor(private val extras: Map<String, A
     open fun getModuleId(): String = extras.extractString(Constants.SIMPRINTS_MODULE_ID)
     
     open fun getBiometricDataSource(): String = extras.extractString(Constants.SIMPRINTS_BIOMETRIC_DATA_SOURCE)
+
+    open fun getCallerPackageName(): String = extras.extractString(ClientApiConstants.CALLER_PACKAGE_NAME)
 
     open fun getMetadata(): String = extras.extractString(Constants.SIMPRINTS_METADATA)
 

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/models/Constants.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/models/Constants.kt
@@ -1,5 +1,10 @@
 package com.simprints.feature.clientapi.models
 
+ object ClientApiConstants {
+
+    const val CALLER_PACKAGE_NAME = "callerPackageName"
+}
+
 internal object OdkConstants {
 
     const val PACKAGE_NAME = "com.simprints.simodkadapter"

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/request/requestFactories/EnrolActionFactory.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/request/requestFactories/EnrolActionFactory.kt
@@ -24,6 +24,7 @@ internal object EnrolActionFactory : RequestActionFactory() {
         metadata = MOCK_METADATA,
         moduleId = MOCK_MODULE_ID.asTokenizableRaw(),
         biometricDataSource = MOCK_BIOMETRIC_DATA_SOURCE,
+        callerPackageName = MOCK_CALLER_PACKAGE_NAME,
         unknownExtras = emptyMap()
     )
 

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/request/requestFactories/IdentifyRequestActionFactory.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/request/requestFactories/IdentifyRequestActionFactory.kt
@@ -24,6 +24,7 @@ internal object IdentifyRequestActionFactory : RequestActionFactory() {
         userId = MOCK_USER_ID.asTokenizableRaw(),
         metadata = MOCK_METADATA,
         biometricDataSource = MOCK_BIOMETRIC_DATA_SOURCE,
+        callerPackageName = MOCK_CALLER_PACKAGE_NAME,
         unknownExtras = emptyMap()
     )
 

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/request/requestFactories/RequestActionFactory.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/request/requestFactories/RequestActionFactory.kt
@@ -19,6 +19,7 @@ internal abstract class RequestActionFactory {
         const val MOCK_SESSION_ID = "ddf01a3c-3081-4d3e-b872-538731517cb9"
         const val MOCK_SELECTED_GUID = "5390ef82-9c1f-40a9-b833-2e97ab369208"
         const val MOCK_BIOMETRIC_DATA_SOURCE = ""
+        const val MOCK_CALLER_PACKAGE_NAME = "com.test.caller.package"
     }
 
     abstract fun getIdentifier(): ActionRequestIdentifier
@@ -37,6 +38,7 @@ internal abstract class RequestActionFactory {
         every { mockExtractor.getModuleId() } returns MOCK_MODULE_ID
         every { mockExtractor.getMetadata() } returns MOCK_METADATA
         every { mockExtractor.getBiometricDataSource() } returns MOCK_BIOMETRIC_DATA_SOURCE
+        every { mockExtractor.getCallerPackageName() } returns MOCK_CALLER_PACKAGE_NAME
         every { mockExtractor.getUnknownExtras() } returns emptyMap()
     }
 

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/request/requestFactories/VerifyActionFactory.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/request/requestFactories/VerifyActionFactory.kt
@@ -26,6 +26,7 @@ internal object VerifyActionFactory : RequestActionFactory() {
         metadata = MOCK_METADATA,
         verifyGuid = MOCK_VERIFY_GUID,
         biometricDataSource = MOCK_BIOMETRIC_DATA_SOURCE,
+        callerPackageName = MOCK_CALLER_PACKAGE_NAME,
         unknownExtras = emptyMap()
     )
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/debug/DebugFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/debug/DebugFragment.kt
@@ -16,6 +16,9 @@ import com.simprints.feature.dashboard.databinding.FragmentDebugBinding
 import com.simprints.infra.authstore.AuthStore
 import com.simprints.infra.config.sync.ConfigManager
 import com.simprints.infra.enrolment.records.store.EnrolmentRecordRepository
+import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
+import com.simprints.infra.enrolment.records.store.domain.models.SubjectQuery
+import com.simprints.infra.enrolment.records.store.local.EnrolmentRecordLocalDataSource
 import com.simprints.infra.events.EventRepository
 import com.simprints.infra.eventsync.EventSyncManager
 import com.simprints.infra.eventsync.status.models.EventSyncWorkerState
@@ -47,7 +50,7 @@ internal class DebugFragment : Fragment(R.layout.fragment_debug) {
     lateinit var eventRepository: EventRepository
 
     @Inject
-    lateinit var enrolmentRecordRepository: EnrolmentRecordRepository
+    lateinit var enrolmentRecordRepository: EnrolmentRecordLocalDataSource
 
     @Inject
     @DispatcherIO

--- a/feature/login-check/src/test/java/com/simprints/feature/logincheck/usecases/ActionFactory.kt
+++ b/feature/login-check/src/test/java/com/simprints/feature/logincheck/usecases/ActionFactory.kt
@@ -19,6 +19,7 @@ internal object ActionFactory {
         moduleId = MOCK_MODULE_ID,
         unknownExtras = extras,
         biometricDataSource = MOCK_BIOMETRIC_DATA_SOURCE,
+        callerPackageName = "",
         metadata = "",
     )
 

--- a/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchFragment.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchFragment.kt
@@ -15,7 +15,6 @@ import com.simprints.core.livedata.LiveDataEventWithContentObserver
 import com.simprints.core.tools.extentions.hasPermission
 import com.simprints.core.tools.extentions.permissionFromResult
 import com.simprints.core.tools.extentions.applicationSettingsIntent
-import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource.Companion.permissionName
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import com.simprints.matcher.R

--- a/feature/matcher/src/main/java/com/simprints/matcher/usecases/FaceMatcherUseCase.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/usecases/FaceMatcherUseCase.kt
@@ -59,7 +59,7 @@ internal class FaceMatcherUseCase @Inject constructor(
     private suspend fun getCandidates(
         query: SubjectQuery,
         range: IntRange,
-        dataSource: BiometricDataSource = BiometricDataSource.SIMPRINTS,
+        dataSource: BiometricDataSource = BiometricDataSource.Simprints,
     ) = enrolmentRecordRepository
         .loadFaceIdentities(query, range, dataSource)
         .map {

--- a/feature/matcher/src/main/java/com/simprints/matcher/usecases/FingerprintMatcherUseCase.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/usecases/FingerprintMatcherUseCase.kt
@@ -73,7 +73,7 @@ internal class FingerprintMatcherUseCase @Inject constructor(
     private suspend fun getCandidates(
         query: SubjectQuery,
         range: IntRange,
-        dataSource: BiometricDataSource = BiometricDataSource.SIMPRINTS,
+        dataSource: BiometricDataSource = BiometricDataSource.Simprints,
     ) = enrolmentRecordRepository
         .loadFingerprintIdentities(query, range, dataSource)
         .map {

--- a/feature/matcher/src/test/java/com/simprints/matcher/screen/MatchViewModelTest.kt
+++ b/feature/matcher/src/test/java/com/simprints/matcher/screen/MatchViewModelTest.kt
@@ -105,7 +105,7 @@ internal class MatchViewModelTest {
             probeFaceSamples = listOf(getFaceSample()),
             flowType = FlowType.ENROL,
             queryForCandidates = mockk {},
-            biometricDataSource = BiometricDataSource.SIMPRINTS,
+            biometricDataSource = BiometricDataSource.Simprints,
         ))
         advanceUntilIdle()
 
@@ -147,7 +147,7 @@ internal class MatchViewModelTest {
             probeFingerprintSamples = listOf(getFingerprintSample()),
             flowType = FlowType.ENROL,
             queryForCandidates = mockk {},
-            biometricDataSource = BiometricDataSource.SIMPRINTS,
+            biometricDataSource = BiometricDataSource.Simprints,
         ))
         advanceUntilIdle()
 

--- a/feature/matcher/src/test/java/com/simprints/matcher/usecases/FaceMatcherUseCaseTest.kt
+++ b/feature/matcher/src/test/java/com/simprints/matcher/usecases/FaceMatcherUseCaseTest.kt
@@ -59,7 +59,7 @@ internal class FaceMatcherUseCaseTest {
             MatchParams(
                 flowType = FlowType.VERIFY,
                 queryForCandidates = SubjectQuery(),
-                biometricDataSource = BiometricDataSource.SIMPRINTS,
+                biometricDataSource = BiometricDataSource.Simprints,
             ),
         )
 
@@ -77,7 +77,7 @@ internal class FaceMatcherUseCaseTest {
                 ),
                 flowType = FlowType.VERIFY,
                 queryForCandidates = SubjectQuery(),
-                biometricDataSource = BiometricDataSource.SIMPRINTS,
+                biometricDataSource = BiometricDataSource.Simprints,
             ),
         )
 
@@ -106,7 +106,7 @@ internal class FaceMatcherUseCaseTest {
                 ),
                 flowType = FlowType.VERIFY,
                 queryForCandidates = SubjectQuery(),
-                biometricDataSource = BiometricDataSource.SIMPRINTS,
+                biometricDataSource = BiometricDataSource.Simprints,
             ),
             onLoadingCandidates = { onLoadingCalled = true },
         )

--- a/feature/matcher/src/test/java/com/simprints/matcher/usecases/FingerprintMatcherUseCaseTest.kt
+++ b/feature/matcher/src/test/java/com/simprints/matcher/usecases/FingerprintMatcherUseCaseTest.kt
@@ -81,7 +81,7 @@ internal class FingerprintMatcherUseCaseTest {
             MatchParams(
                 flowType = FlowType.VERIFY,
                 queryForCandidates = SubjectQuery(),
-                biometricDataSource = BiometricDataSource.SIMPRINTS,
+                biometricDataSource = BiometricDataSource.Simprints,
             ),
         )
 
@@ -105,7 +105,7 @@ internal class FingerprintMatcherUseCaseTest {
                 ),
                 flowType = FlowType.VERIFY,
                 queryForCandidates = SubjectQuery(),
-                biometricDataSource = BiometricDataSource.SIMPRINTS,
+                biometricDataSource = BiometricDataSource.Simprints,
             ),
         )
 
@@ -154,7 +154,7 @@ internal class FingerprintMatcherUseCaseTest {
                 ),
                 flowType = FlowType.VERIFY,
                 queryForCandidates = SubjectQuery(),
-                biometricDataSource = BiometricDataSource.SIMPRINTS,
+                biometricDataSource = BiometricDataSource.Simprints,
             ),
             onLoadingCandidates = { onLoadingCalled = true },
         )

--- a/feature/matcher/src/test/java/com/simprints/matcher/usecases/SaveMatchEventUseCaseTest.kt
+++ b/feature/matcher/src/test/java/com/simprints/matcher/usecases/SaveMatchEventUseCaseTest.kt
@@ -65,7 +65,7 @@ class SaveMatchEventUseCaseTest {
                 flowType = FlowType.VERIFY,
                 queryForCandidates = SubjectQuery(subjectId = "subjectId"),
                 probeFaceSamples = listOf(MatchParams.FaceSample("faceId", byteArrayOf(1, 2, 3))),
-                biometricDataSource = BiometricDataSource.SIMPRINTS,
+                biometricDataSource = BiometricDataSource.Simprints,
             ),
             2,
             "faceMatcherName",
@@ -104,7 +104,7 @@ class SaveMatchEventUseCaseTest {
                         byteArrayOf(1, 2, 3)
                     )
                 ),
-                biometricDataSource = BiometricDataSource.SIMPRINTS,
+                biometricDataSource = BiometricDataSource.Simprints,
             ),
             2,
             "faceMatcherName",
@@ -138,7 +138,7 @@ class SaveMatchEventUseCaseTest {
                 emptyList(),
                 FlowType.IDENTIFY,
                 SubjectQuery(),
-                biometricDataSource = BiometricDataSource.SIMPRINTS,
+                biometricDataSource = BiometricDataSource.Simprints,
             ),
             2,
             "faceMatcherName",
@@ -169,7 +169,7 @@ class SaveMatchEventUseCaseTest {
             MatchParams(
                 flowType = FlowType.IDENTIFY,
                 queryForCandidates = SubjectQuery(attendantId = "userId"),
-                biometricDataSource = BiometricDataSource.SIMPRINTS,
+                biometricDataSource = BiometricDataSource.Simprints,
             ),
             0,
             "faceMatcherName",
@@ -192,7 +192,7 @@ class SaveMatchEventUseCaseTest {
             MatchParams(
                 flowType = FlowType.IDENTIFY,
                 queryForCandidates = SubjectQuery(moduleId = "moduleId"),
-                biometricDataSource = BiometricDataSource.SIMPRINTS,
+                biometricDataSource = BiometricDataSource.Simprints,
             ),
             0,
             "faceMatcherName",
@@ -216,7 +216,7 @@ class SaveMatchEventUseCaseTest {
                 emptyList(),
                 flowType = FlowType.IDENTIFY,
                 queryForCandidates = SubjectQuery(),
-                biometricDataSource = BiometricDataSource.SIMPRINTS,
+                biometricDataSource = BiometricDataSource.Simprints,
             ),
             0,
             "faceMatcherName",

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorActivity.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.core.os.bundleOf
 import androidx.navigation.findNavController
 import com.simprints.core.tools.activity.BaseActivity
+import com.simprints.feature.clientapi.models.ClientApiConstants
 import com.simprints.feature.orchestrator.databinding.ActivityOrchestratorBinding
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.orchestration.data.results.AppResult
@@ -42,6 +43,10 @@ internal class OrchestratorActivity : BaseActivity() {
         if (activityTracker.isMain(activity = this)) {
             val action = intent.action.orEmpty()
             val extras = intent.extras ?: bundleOf()
+
+            // Some co-sync functionality depends on the exact package name of the caller app,
+            // e.g. to switch content providers of debug and release variants of the caller app
+            extras.putString(ClientApiConstants.CALLER_PACKAGE_NAME, callingPackage)
 
             findNavController(R.id.orchestrationHost).setGraph(
                 R.navigation.graph_orchestration,

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCase.kt
@@ -46,7 +46,10 @@ internal class BuildStepsUseCase @Inject constructor(
                     projectConfiguration,
                     FlowType.ENROL,
                     buildMatcherSubjectQuery(projectConfiguration, action),
-                    BiometricDataSource.fromString(action.biometricDataSource),
+                    BiometricDataSource.fromString(
+                        action.biometricDataSource,
+                        action.callerPackageName
+                    ),
                 )
             } else emptyList(),
         )
@@ -62,7 +65,10 @@ internal class BuildStepsUseCase @Inject constructor(
                 projectConfiguration,
                 FlowType.IDENTIFY,
                 buildMatcherSubjectQuery(projectConfiguration, action),
-                BiometricDataSource.fromString(action.biometricDataSource),
+                BiometricDataSource.fromString(
+                    action.biometricDataSource,
+                    action.callerPackageName
+                ),
             )
         )
 
@@ -78,7 +84,10 @@ internal class BuildStepsUseCase @Inject constructor(
                 projectConfiguration,
                 FlowType.VERIFY,
                 SubjectQuery(subjectId = action.verifyGuid),
-                BiometricDataSource.fromString(action.biometricDataSource),
+                BiometricDataSource.fromString(
+                    action.biometricDataSource,
+                    action.callerPackageName
+                ),
             )
         )
 
@@ -114,8 +123,8 @@ internal class BuildStepsUseCase @Inject constructor(
 
 
     private fun buildModalityCaptureSteps(
-      projectConfiguration: ProjectConfiguration,
-      flowType: FlowType,
+        projectConfiguration: ProjectConfiguration,
+        flowType: FlowType,
     ) = projectConfiguration.general.modalities.map {
         when (it) {
             Modality.FINGERPRINT -> {
@@ -144,10 +153,10 @@ internal class BuildStepsUseCase @Inject constructor(
     }
 
     private fun buildModalityMatcherSteps(
-      projectConfiguration: ProjectConfiguration,
-      flowType: FlowType,
-      subjectQuery: SubjectQuery,
-      biometricDataSource: BiometricDataSource,
+        projectConfiguration: ProjectConfiguration,
+        flowType: FlowType,
+        subjectQuery: SubjectQuery,
+        biometricDataSource: BiometricDataSource,
     ) = projectConfiguration.general.modalities.map {
         Step(
             id = when (it) {

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/OrchestratorViewModelTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/OrchestratorViewModelTest.kt
@@ -189,7 +189,7 @@ internal class OrchestratorViewModelTest {
             createMockStep(StepId.FACE_MATCHER, MatchStepStubPayload.asBundle(
                 FlowType.VERIFY,
                 SubjectQuery(),
-                BiometricDataSource.SIMPRINTS)),
+                BiometricDataSource.Simprints)),
         )
         every { mapRefusalOrErrorResult(any()) } returns null
         every { shouldCreatePerson(any(), any(), any()) } returns false
@@ -209,7 +209,7 @@ internal class OrchestratorViewModelTest {
             createMockStep(StepId.FINGERPRINT_MATCHER, MatchStepStubPayload.asBundle(
                 FlowType.VERIFY,
                 SubjectQuery(),
-                BiometricDataSource.SIMPRINTS)),
+                BiometricDataSource.Simprints)),
         )
         every { mapRefusalOrErrorResult(any()) } returns null
         every { shouldCreatePerson(any(), any(), any()) } returns false

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/ShouldCreatePersonUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/ShouldCreatePersonUseCaseTest.kt
@@ -165,6 +165,7 @@ class ShouldCreatePersonUseCaseTest {
         userId = "".asTokenizableRaw(),
         moduleId = "".asTokenizableRaw(),
         biometricDataSource = "",
+        callerPackageName = "",
         metadata = "",
         unknownExtras = emptyMap(),
     )

--- a/infra/enrolment-records-store/src/main/AndroidManifest.xml
+++ b/infra/enrolment-records-store/src/main/AndroidManifest.xml
@@ -2,5 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="org.commcare.dalvik.provider.cases.read" />
+    <uses-permission android:name="org.commcare.dalvik.debug.provider.cases.read" />
 
 </manifest>

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepository.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepository.kt
@@ -13,20 +13,20 @@ interface EnrolmentRecordRepository : EnrolmentRecordLocalDataSource {
     suspend fun uploadRecords(subjectIds: List<String>)
     suspend fun tokenizeExistingRecords(project: Project)
 
-    suspend fun count(
-        query: SubjectQuery = SubjectQuery(),
-        dataSource: BiometricDataSource = BiometricDataSource.SIMPRINTS
+    override suspend fun count(
+        query: SubjectQuery,
+        dataSource: BiometricDataSource,
     ): Int
 
-    suspend fun loadFingerprintIdentities(
+    override  suspend fun loadFingerprintIdentities(
         query: SubjectQuery,
         range: IntRange,
-        dataSource: BiometricDataSource = BiometricDataSource.SIMPRINTS
+        dataSource: BiometricDataSource,
     ): List<FingerprintIdentity>
 
-    suspend fun loadFaceIdentities(
+    override  suspend fun loadFaceIdentities(
         query: SubjectQuery,
         range: IntRange,
-        dataSource: BiometricDataSource = BiometricDataSource.SIMPRINTS
+        dataSource: BiometricDataSource,
     ): List<FaceIdentity>
 }

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImpl.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImpl.kt
@@ -28,7 +28,7 @@ internal class EnrolmentRecordRepositoryImpl(
     private val tokenizationProcessor: TokenizationProcessor,
     private val dispatcher: CoroutineDispatcher,
     private val batchSize: Int,
-) : EnrolmentRecordRepository, EnrolmentRecordLocalDataSource by localDataSource  {
+) : EnrolmentRecordRepository, EnrolmentRecordLocalDataSource by localDataSource {
 
     @Inject
     constructor(
@@ -116,25 +116,27 @@ internal class EnrolmentRecordRepositoryImpl(
         )
     }
 
-    override suspend fun count(query: SubjectQuery, dataSource: BiometricDataSource): Int =
-        fromIdentityDataSource(dataSource).count(query)
+    override suspend fun count(
+        query: SubjectQuery,
+        dataSource: BiometricDataSource,
+    ): Int = fromIdentityDataSource(dataSource).count(query, dataSource)
 
     override suspend fun loadFingerprintIdentities(
         query: SubjectQuery,
         range: IntRange,
-        dataSource: BiometricDataSource
+        dataSource: BiometricDataSource,
     ): List<FingerprintIdentity> =
-        fromIdentityDataSource(dataSource).loadFingerprintIdentities(query, range)
+        fromIdentityDataSource(dataSource).loadFingerprintIdentities(query, range, dataSource)
 
     override suspend fun loadFaceIdentities(
         query: SubjectQuery,
         range: IntRange,
-        dataSource: BiometricDataSource
+        dataSource: BiometricDataSource,
     ): List<FaceIdentity> =
-        fromIdentityDataSource(dataSource).loadFaceIdentities(query, range)
+        fromIdentityDataSource(dataSource).loadFaceIdentities(query, range, dataSource)
 
     private fun fromIdentityDataSource(dataSource: BiometricDataSource) = when (dataSource) {
-        BiometricDataSource.SIMPRINTS -> localDataSource
-        BiometricDataSource.COMMCARE -> commCareDataSource
+        is BiometricDataSource.Simprints -> localDataSource
+        is BiometricDataSource.CommCare -> commCareDataSource
     }
 }

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/IdentityDataSource.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/IdentityDataSource.kt
@@ -1,12 +1,26 @@
 package com.simprints.infra.enrolment.records.store
 
+import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
 import com.simprints.infra.enrolment.records.store.domain.models.FaceIdentity
 import com.simprints.infra.enrolment.records.store.domain.models.FingerprintIdentity
 import com.simprints.infra.enrolment.records.store.domain.models.SubjectQuery
 
 interface IdentityDataSource {
 
-    suspend fun count(query: SubjectQuery = SubjectQuery()): Int
-    suspend fun loadFingerprintIdentities(query: SubjectQuery, range: IntRange): List<FingerprintIdentity>
-    suspend fun loadFaceIdentities(query: SubjectQuery, range: IntRange): List<FaceIdentity>
+    suspend fun count(
+        query: SubjectQuery = SubjectQuery(),
+        dataSource: BiometricDataSource = BiometricDataSource.Simprints,
+    ): Int
+
+    suspend fun loadFingerprintIdentities(
+        query: SubjectQuery,
+        range: IntRange,
+        dataSource: BiometricDataSource = BiometricDataSource.Simprints,
+    ): List<FingerprintIdentity>
+
+    suspend fun loadFaceIdentities(
+        query: SubjectQuery,
+        range: IntRange,
+        dataSource: BiometricDataSource = BiometricDataSource.Simprints,
+    ): List<FaceIdentity>
 }

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/commcare/CommCareIdentityDataSource.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/commcare/CommCareIdentityDataSource.kt
@@ -12,6 +12,7 @@ import com.simprints.core.domain.tokenization.serialization.TokenizationClassNam
 import com.simprints.core.tools.json.JsonHelper
 import com.simprints.core.tools.utils.EncodingUtils
 import com.simprints.infra.enrolment.records.store.IdentityDataSource
+import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
 import com.simprints.infra.enrolment.records.store.domain.models.FaceIdentity
 import com.simprints.infra.enrolment.records.store.domain.models.FingerprintIdentity
 import com.simprints.infra.enrolment.records.store.domain.models.SubjectQuery
@@ -31,69 +32,58 @@ internal class CommCareIdentityDataSource @Inject constructor(
 ) : IdentityDataSource {
 
     companion object {
-        val CASE_METADATA_URI: Uri = Uri.parse("content://org.commcare.dalvik.case/casedb/case")
-        val CASE_DATA_URI: Uri = Uri.parse("content://org.commcare.dalvik.case/casedb/data")
-        const val PERMISSION_NAME = "org.commcare.dalvik.provider.cases.read"
+
         const val COLUMN_CASE_ID = "case_id"
         const val COLUMN_DATUM_ID = "datum_id"
         const val COLUMN_VALUE = "value"
     }
 
+    private fun getCaseMetadataUri(packageName: String): Uri =
+        Uri.parse("content://$packageName.case/casedb/case")
+
+    private fun getCaseDataUri(packageName: String): Uri =
+        Uri.parse("content://$packageName.case/casedb/data")
+
     override suspend fun loadFingerprintIdentities(
         query: SubjectQuery,
         range: IntRange,
-    ): List<FingerprintIdentity> = loadEnrolmentRecordCreationEvents(range)
+        dataSource: BiometricDataSource,
+    ): List<FingerprintIdentity> = loadEnrolmentRecordCreationEvents(range, dataSource.callerPackageName())
         .filter { erce -> erce.payload.biometricReferences.any { it is FingerprintReference } }
         .map {
-        FingerprintIdentity(
-            it.payload.subjectId,
-            it.payload.biometricReferences.filterIsInstance<FingerprintReference>()
-            .flatMap { fingerprintReference ->
-                fingerprintReference.templates.map { fingerprintTemplate ->
-                    FingerprintSample(
-                        fingerIdentifier = fingerprintTemplate.finger,
-                        templateQualityScore = fingerprintTemplate.quality,
-                        template = encoder.base64ToBytes(fingerprintTemplate.template),
-                        format = fingerprintReference.format,
-                    )
-                }
-            }
-        )
-    }
+            FingerprintIdentity(
+                it.payload.subjectId,
+                it.payload.biometricReferences.filterIsInstance<FingerprintReference>()
+                    .flatMap { fingerprintReference ->
+                        fingerprintReference.templates.map { fingerprintTemplate ->
+                            FingerprintSample(
+                                fingerIdentifier = fingerprintTemplate.finger,
+                                templateQualityScore = fingerprintTemplate.quality,
+                                template = encoder.base64ToBytes(fingerprintTemplate.template),
+                                format = fingerprintReference.format,
+                            )
+                        }
+                    }
+            )
+        }
 
-    override suspend fun loadFaceIdentities(
-        query: SubjectQuery,
+    private fun loadEnrolmentRecordCreationEvents(
         range: IntRange,
-    ): List<FaceIdentity> = loadEnrolmentRecordCreationEvents(range)
-        .filter { erce -> erce.payload.biometricReferences.any { it is FaceReference } }
-        .map {
-        FaceIdentity(
-            it.payload.subjectId,
-            it.payload.biometricReferences.filterIsInstance<FaceReference>()
-            .flatMap { faceReference ->
-                faceReference.templates.map { faceTemplate ->
-                    FaceSample(
-                        template = encoder.base64ToBytes(faceTemplate.template),
-                        format = faceReference.format,
-                    )
-                }
-            }
-        )
-    }
-
-    private fun loadEnrolmentRecordCreationEvents(range: IntRange): List<EnrolmentRecordCreationEvent> {
+        callerPackageName: String,
+    ): List<EnrolmentRecordCreationEvent> {
         val enrolmentRecordCreationEvents: MutableList<EnrolmentRecordCreationEvent> = mutableListOf()
 
         try {
-            context.contentResolver.query(CASE_METADATA_URI, null, null, null, null)?.use { caseMetadataCursor ->
-                if (caseMetadataCursor.moveToPosition(range.first)) {
-                    do {
-                        caseMetadataCursor.getString(caseMetadataCursor.getColumnIndexOrThrow(COLUMN_CASE_ID))?.let { caseId ->
-                            enrolmentRecordCreationEvents.addAll(loadEnrolmentRecordCreationEvents(caseId))
-                        }
-                    } while (caseMetadataCursor.moveToNext() && caseMetadataCursor.position < range.last)
+            context.contentResolver.query(
+                getCaseMetadataUri(callerPackageName), null, null, null, null)?.use { caseMetadataCursor ->
+                    if (caseMetadataCursor.moveToPosition(range.first)) {
+                        do {
+                            caseMetadataCursor.getString(caseMetadataCursor.getColumnIndexOrThrow(COLUMN_CASE_ID))?.let { caseId ->
+                                enrolmentRecordCreationEvents.addAll(loadEnrolmentRecordCreationEvents(caseId, callerPackageName))
+                            }
+                        } while (caseMetadataCursor.moveToNext() && caseMetadataCursor.position < range.last)
+                    }
                 }
-            }
         } catch (e: Exception) {
             Simber.e("Error while querying CommCare", e)
         }
@@ -101,22 +91,49 @@ internal class CommCareIdentityDataSource @Inject constructor(
         return enrolmentRecordCreationEvents
     }
 
-    private fun loadEnrolmentRecordCreationEvents(caseId: String): List<EnrolmentRecordCreationEvent> {
-        val caseEnrolmentRecordCreationEvents: MutableList<EnrolmentRecordCreationEvent> = mutableListOf()
+    override suspend fun loadFaceIdentities(
+        query: SubjectQuery,
+        range: IntRange,
+        dataSource: BiometricDataSource,
+    ): List<FaceIdentity> = loadEnrolmentRecordCreationEvents(range, dataSource.callerPackageName())
+        .filter { erce -> erce.payload.biometricReferences.any { it is FaceReference } }
+        .map {
+            FaceIdentity(
+                it.payload.subjectId,
+                it.payload.biometricReferences.filterIsInstance<FaceReference>()
+                    .flatMap { faceReference ->
+                        faceReference.templates.map { faceTemplate ->
+                            FaceSample(
+                                template = encoder.base64ToBytes(faceTemplate.template),
+                                format = faceReference.format,
+                            )
+                        }
+                    }
+            )
+        }
+
+    private fun loadEnrolmentRecordCreationEvents(
+        caseId: String,
+        callerPackageName: String,
+    ): List<EnrolmentRecordCreationEvent> {
+        val caseEnrolmentRecordCreationEvents: MutableList<EnrolmentRecordCreationEvent> =
+            mutableListOf()
 
         //Access Case Data Listing for the caseId
-        val caseDataUri = CASE_DATA_URI.buildUpon().appendPath(caseId).build()
+        val caseDataUri = getCaseDataUri(callerPackageName).buildUpon().appendPath(caseId).build()
         context.contentResolver.query(caseDataUri, null, null, null, null)?.use { caseDataCursor ->
             var subjectActions = ""
             while (caseDataCursor.moveToNext()) {
-                val key = caseDataCursor.getString(caseDataCursor.getColumnIndexOrThrow(COLUMN_DATUM_ID))
+                val key =
+                    caseDataCursor.getString(caseDataCursor.getColumnIndexOrThrow(COLUMN_DATUM_ID))
                 if (key == SIMPRINTS_COSYNC_SUBJECT_ACTIONS) {
-                    subjectActions = caseDataCursor.getString(caseDataCursor.getColumnIndexOrThrow(COLUMN_VALUE))
+                    subjectActions =
+                        caseDataCursor.getString(caseDataCursor.getColumnIndexOrThrow(COLUMN_VALUE))
                     break
                 }
             }
 
-            val coSyncEnrolmentRecordEvents =  subjectActions.takeIf(String::isNotEmpty)?.let {
+            val coSyncEnrolmentRecordEvents = subjectActions.takeIf(String::isNotEmpty)?.let {
                 try {
                     val coSyncSerializationModule = SimpleModule().apply {
                         addSerializer(
@@ -149,11 +166,14 @@ internal class CommCareIdentityDataSource @Inject constructor(
         return caseEnrolmentRecordCreationEvents
     }
 
-    override suspend fun count(query: SubjectQuery): Int {
+    override suspend fun count(
+        query: SubjectQuery,
+        dataSource: BiometricDataSource,
+    ): Int {
         var count = 0
-        context.contentResolver.query(CASE_METADATA_URI, null, null, null, null)?.use { caseMetadataCursor ->
-            count = caseMetadataCursor.count
-        }
+        context.contentResolver
+            .query(getCaseMetadataUri(dataSource.callerPackageName()), null, null, null, null)
+            ?.use { caseMetadataCursor -> count = caseMetadataCursor.count }
 
         return count
     }

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/domain/models/BiometricDataSource.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/domain/models/BiometricDataSource.kt
@@ -1,10 +1,26 @@
 package com.simprints.infra.enrolment.records.store.domain.models
 
-import com.simprints.infra.enrolment.records.store.commcare.CommCareIdentityDataSource
+import android.os.Parcelable
+import androidx.annotation.Keep
+import kotlinx.parcelize.Parcelize
 
-enum class BiometricDataSource {
-    SIMPRINTS,
-    COMMCARE;
+@Keep
+sealed class BiometricDataSource: Parcelable {
+
+    open fun callerPackageName(): String = ""
+    open fun permissionName(): String? = null
+
+    @Parcelize
+    data object Simprints : BiometricDataSource(), Parcelable
+
+    @Parcelize
+    data class CommCare(
+        private val callerPackageName: String,
+    ) : BiometricDataSource(), Parcelable {
+
+        override fun callerPackageName() = callerPackageName
+        override fun permissionName() = "$callerPackageName.provider.cases.read"
+    }
 
     companion object {
 
@@ -12,13 +28,9 @@ enum class BiometricDataSource {
             value: String,
             callerPackageName: String,
         ) = when (value.uppercase()) {
-            "COMMCARE" -> COMMCARE
-            else -> SIMPRINTS
+            "COMMCARE" -> CommCare(callerPackageName)
+            else -> Simprints
         }
 
-        fun BiometricDataSource.permissionName(): String? = when (this) {
-            COMMCARE -> CommCareIdentityDataSource.PERMISSION_NAME
-            else -> null
-        }
     }
 }

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/domain/models/BiometricDataSource.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/domain/models/BiometricDataSource.kt
@@ -8,7 +8,10 @@ enum class BiometricDataSource {
 
     companion object {
 
-        fun fromString(value: String) = when (value.uppercase()) {
+        fun fromString(
+            value: String,
+            callerPackageName: String,
+        ) = when (value.uppercase()) {
             "COMMCARE" -> COMMCARE
             else -> SIMPRINTS
         }

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImpl.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.simprints.infra.enrolment.records.store.local
 
+import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
 import com.simprints.infra.enrolment.records.store.domain.models.FaceIdentity
 import com.simprints.infra.enrolment.records.store.domain.models.FingerprintIdentity
 import com.simprints.infra.enrolment.records.store.domain.models.Subject
@@ -45,6 +46,7 @@ internal class EnrolmentRecordLocalDataSourceImpl @Inject constructor(
     override suspend fun loadFingerprintIdentities(
         query: SubjectQuery,
         range: IntRange,
+        dataSource: BiometricDataSource,
     ): List<FingerprintIdentity> = realmWrapper.readRealm { realm ->
         realm.query(DbSubject::class)
             .buildRealmQueryForSubject(query)
@@ -60,6 +62,7 @@ internal class EnrolmentRecordLocalDataSourceImpl @Inject constructor(
     override suspend fun loadFaceIdentities(
         query: SubjectQuery,
         range: IntRange,
+        dataSource: BiometricDataSource,
     ): List<FaceIdentity> = realmWrapper.readRealm { realm ->
         realm.query(DbSubject::class)
             .buildRealmQueryForSubject(query)
@@ -86,7 +89,10 @@ internal class EnrolmentRecordLocalDataSourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun count(query: SubjectQuery): Int = realmWrapper.readRealm { realm ->
+    override suspend fun count(
+        query: SubjectQuery,
+        dataSource: BiometricDataSource,
+    ): Int = realmWrapper.readRealm { realm ->
         realm.query(DbSubject::class)
             .buildRealmQueryForSubject(query)
             .count()

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImplTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImplTest.kt
@@ -257,7 +257,7 @@ class EnrolmentRecordRepositoryImplTest {
         val expectedSubjectQuery = SubjectQuery()
         coEvery { localDataSource.count(expectedSubjectQuery) } returns 5
 
-        val count = repository.count(query = expectedSubjectQuery, dataSource = BiometricDataSource.SIMPRINTS)
+        val count = repository.count(query = expectedSubjectQuery, dataSource = BiometricDataSource.Simprints)
 
         assert(count == 5)
         coVerify(exactly = 1) { localDataSource.count(expectedSubjectQuery) }
@@ -266,12 +266,12 @@ class EnrolmentRecordRepositoryImplTest {
     @Test
     fun `should return the correct count of subjects when dataSource is CommCare`() = runTest {
         val expectedSubjectQuery = SubjectQuery()
-        coEvery { commCareDataSource.count(expectedSubjectQuery) } returns 5
+        coEvery { commCareDataSource.count(expectedSubjectQuery, any()) } returns 5
 
-        val count = repository.count(query = expectedSubjectQuery, dataSource = BiometricDataSource.COMMCARE)
+        val count = repository.count(query = expectedSubjectQuery, dataSource = BiometricDataSource.CommCare(""))
 
         assert(count == 5)
-        coVerify(exactly = 1) { commCareDataSource.count(expectedSubjectQuery) }
+        coVerify(exactly = 1) { commCareDataSource.count(expectedSubjectQuery, any()) }
     }
 
     @Test
@@ -284,11 +284,11 @@ class EnrolmentRecordRepositoryImplTest {
         val fingerprintIdentities = repository.loadFingerprintIdentities(
             query = expectedSubjectQuery,
             range = expectedRange,
-            dataSource = BiometricDataSource.SIMPRINTS
+            dataSource = BiometricDataSource.Simprints
         )
 
         assert(fingerprintIdentities == expectedFingerprintIdentities)
-        coVerify(exactly = 1) { localDataSource.loadFingerprintIdentities(expectedSubjectQuery, expectedRange) }
+        coVerify(exactly = 1) { localDataSource.loadFingerprintIdentities(expectedSubjectQuery, expectedRange, any()) }
     }
 
     @Test
@@ -301,11 +301,11 @@ class EnrolmentRecordRepositoryImplTest {
         val fingerprintIdentities = repository.loadFingerprintIdentities(
             query = expectedSubjectQuery,
             range = expectedRange,
-            dataSource = BiometricDataSource.COMMCARE
+            dataSource = BiometricDataSource.CommCare("")
         )
 
         assert(fingerprintIdentities == expectedFingerprintIdentities)
-        coVerify(exactly = 1) { commCareDataSource.loadFingerprintIdentities(expectedSubjectQuery, expectedRange) }
+        coVerify(exactly = 1) { commCareDataSource.loadFingerprintIdentities(expectedSubjectQuery, expectedRange, any()) }
     }
 
     @Test
@@ -318,7 +318,7 @@ class EnrolmentRecordRepositoryImplTest {
         val faceIdentities = repository.loadFaceIdentities(
             query = expectedSubjectQuery,
             range = expectedRange,
-            dataSource = BiometricDataSource.SIMPRINTS
+            dataSource = BiometricDataSource.Simprints
         )
 
         assert(faceIdentities == expectedFaceIdentities)
@@ -335,10 +335,10 @@ class EnrolmentRecordRepositoryImplTest {
         val faceIdentities = repository.loadFaceIdentities(
             query = expectedSubjectQuery,
             range = expectedRange,
-            dataSource = BiometricDataSource.COMMCARE
+            dataSource = BiometricDataSource.CommCare("")
         )
 
         assert(faceIdentities == expectedFaceIdentities)
-        coVerify(exactly = 1) { commCareDataSource.loadFaceIdentities(expectedSubjectQuery, expectedRange) }
+        coVerify(exactly = 1) { commCareDataSource.loadFaceIdentities(expectedSubjectQuery, expectedRange, any()) }
     }
 }

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/commcare/CommCareIdentityDataSourceTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/commcare/CommCareIdentityDataSourceTest.kt
@@ -15,18 +15,8 @@ import com.simprints.infra.enrolment.records.store.domain.models.FaceIdentity
 import com.simprints.infra.enrolment.records.store.domain.models.FingerprintIdentity
 import com.simprints.infra.enrolment.records.store.domain.models.SubjectQuery
 import com.simprints.infra.logging.Simber
-import io.mockk.MockKAnnotations
-import io.mockk.Runs
-import io.mockk.clearAllMocks
-import io.mockk.coVerify
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.just
-import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
-import io.mockk.unmockkStatic
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.test.runTest
@@ -127,6 +117,11 @@ class CommCareIdentityDataSourceTest {
         MockKAnnotations.init(this)
 
         every { context.contentResolver } returns mockContentResolver
+
+        every { Uri.parse(any()) } answers {
+            val uriPath =  it.invocation.args[0] as String
+            if (uriPath.endsWith("case")) mockMetadataUri else mockDataUri
+        }
 
         mockMetadataCursor = mockk(relaxed = true)
         mockDataCursor = mockk(relaxed = true)

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/domain/models/BiometricDataSourceTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/domain/models/BiometricDataSourceTest.kt
@@ -1,31 +1,30 @@
 import com.google.common.truth.Truth.assertThat
 import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
-import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource.Companion.permissionName
 import org.junit.Test
 
 class BiometricDataSourceTest {
 
     @Test
     fun `should return SIMPRINTS when value is not SIMPRINTS`() {
-        val result = BiometricDataSource.fromString("SIMPRINTS")
-        assertThat(result).isEqualTo(BiometricDataSource.SIMPRINTS)
+        val result = BiometricDataSource.fromString("SIMPRINTS", "")
+        assertThat(result).isEqualTo(BiometricDataSource.Simprints)
     }
 
     @Test
     fun `should return COMMCARE when value is COMMCARE`() {
-        val result = BiometricDataSource.fromString("COMMCARE")
-        assertThat(result).isEqualTo(BiometricDataSource.COMMCARE)
+        val result = BiometricDataSource.fromString("COMMCARE", "caller")
+        assertThat(result).isEqualTo(BiometricDataSource.CommCare("caller"))
     }
 
     @Test
     fun `should return SIMPRINTS when value is unknown`() {
-        val result = BiometricDataSource.fromString("UNKNOWN")
-        assertThat(result).isEqualTo(BiometricDataSource.SIMPRINTS)
+        val result = BiometricDataSource.fromString("UNKNOWN", "caller")
+        assertThat(result).isEqualTo(BiometricDataSource.Simprints)
     }
 
     @Test
     fun `should return correct permission name for data sources`() {
-        assertThat(BiometricDataSource.SIMPRINTS.permissionName()).isNull()
-        assertThat(BiometricDataSource.COMMCARE.permissionName()).isNotEmpty()
+        assertThat(BiometricDataSource.Simprints.permissionName()).isNull()
+        assertThat(BiometricDataSource.CommCare("caller").permissionName()).isNotEmpty()
     }
 }

--- a/infra/orchestrator-data/src/main/java/com/simprints/infra/orchestration/data/ActionRequest.kt
+++ b/infra/orchestrator-data/src/main/java/com/simprints/infra/orchestration/data/ActionRequest.kt
@@ -32,6 +32,7 @@ sealed class ActionRequest(
         override val userId: TokenizableString,
         override val moduleId: TokenizableString,
         val biometricDataSource: String,
+        val callerPackageName: String,
         val metadata: String,
         override val unknownExtras: Map<String, Any?>,
     ) : ActionRequest(actionIdentifier, projectId, userId, unknownExtras), FlowAction
@@ -43,6 +44,7 @@ sealed class ActionRequest(
         override val userId: TokenizableString,
         override val moduleId: TokenizableString,
         val biometricDataSource: String,
+        val callerPackageName: String,
         val metadata: String,
         override val unknownExtras: Map<String, Any?>,
     ) : ActionRequest(actionIdentifier, projectId, userId, unknownExtras), FlowAction
@@ -54,6 +56,7 @@ sealed class ActionRequest(
         override val userId: TokenizableString,
         override val moduleId: TokenizableString,
         val biometricDataSource: String,
+        val callerPackageName: String,
         val metadata: String,
         val verifyGuid: String,
         override val unknownExtras: Map<String, Any?>,


### PR DESCRIPTION
Notable changes:
* Adding the caller app package name to the action metadata in the orchestration flows.
* Based on the caller package name adjust the exact permission name and content provider URIs to reflect the exact caller package name.