### PR TITLE
MS-278 Handle alert navigation only once on invalid licence

### DIFF
--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureFragment.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureFragment.kt
@@ -113,7 +113,7 @@ internal class FingerprintCaptureFragment : Fragment(R.layout.fragment_fingerpri
     }
 
     private fun observeBioSdkInit() {
-        vm.invalidLicense.observe(viewLifecycleOwner) {
+        vm.invalidLicense.observe(viewLifecycleOwner, LiveDataEventObserver {
             findNavController().navigateSafely(
                 this,
                 R.id.action_fingerprintCaptureFragment_to_graphAlert,
@@ -127,7 +127,7 @@ internal class FingerprintCaptureFragment : Fragment(R.layout.fragment_fingerpri
                     eventType = AlertScreenEventType.LICENSE_INVALID
                 }.toArgs()
             )
-        }
+        })
     }
 
     private fun openRefusal() {


### PR DESCRIPTION
If the SDK licence is invalid the event live data is provided, but since it is not handled correctly, the user is stuck in a loop. Using the correct observer prevents repeated calls.