### PR TITLE
Add proguard rules to fix down sync

### DIFF
--- a/id/proguard-rules.pro
+++ b/id/proguard-rules.pro
@@ -63,3 +63,6 @@
 # Keep all marshallable classes as-is
 -keep class com.simprints.** extends java.io.Serializable { *; }
 -keep class com.simprints.** extends android.os.Parcelable { *; }
+
+-keep class retrofit2.** { *; }
+-keep interface retrofit2.** { *; }


### PR DESCRIPTION
Retrofit added rules to support for R8 full mode in version 2.10, which is why we didn't encounter any issues while testing version 2024.1.0. We downgraded to version 2.9 to resolve the Jackson issue, so we had to manually add the rules.




