### PR TITLE
MS-472 Android 15 compatibility check

### DIFF
--- a/build-logic/convention/src/main/kotlin/common/SdkVersions.kt
+++ b/build-logic/convention/src/main/kotlin/common/SdkVersions.kt
@@ -5,7 +5,7 @@ import org.gradle.api.JavaVersion
 object SdkVersions {
 
     const val MIN = 23
-    const val TARGET = 34
+    const val TARGET = 35
 
     val JAVA_TARGET = JavaVersion.VERSION_17
 }

--- a/feature/orchestrator/src/main/res/layout/activity_orchestrator.xml
+++ b/feature/orchestrator/src/main/res/layout/activity_orchestrator.xml
@@ -2,7 +2,8 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/orchestrationHost"

--- a/id/src/main/AndroidManifest.xml
+++ b/id/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
 
         <service
             android:name=".services.sync.events.down.EventDownSyncResetService"
-            android:foregroundServiceType="dataSync"
+            android:foregroundServiceType="shortService|dataSync"
             android:exported="false" />
 
         <service

--- a/infra/core/src/main/java/com/simprints/core/tools/extentions/Context.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extentions/Context.ext.kt
@@ -15,7 +15,7 @@ val Context.deviceHardwareId: String
 @ExcludedFromGeneratedTestCoverageReports("UI code")
 val Context.packageVersionName: String
     get() = try {
-        packageManager.getPackageInfo(packageName, 0).versionName
+        packageManager.getPackageInfo(packageName, 0).versionName ?: ""
     } catch (e: PackageManager.NameNotFoundException) {
         "Version Name Not Found"
     }


### PR DESCRIPTION
Notable changes:
* Increased target API to 35 (required updating some breaking changes in API)
* Added `onTimeout()` override to the only service we have to comply with the new requirement. The type of the reset service was also changed from `dataSync` to `shortSerivice` to avoid the new restrictions on sync services.