### PR TITLE
[MS-537] The 'expiration' field in the 'License' class is now nullable to reflect the BFSID API

### DIFF
--- a/infra/license/src/main/java/com/simprints/infra/license/LicenseUtils.kt
+++ b/infra/license/src/main/java/com/simprints/infra/license/LicenseUtils.kt
@@ -9,7 +9,7 @@ import java.util.TimeZone
 
 
 private fun License.isExpired(): Boolean {
-    if (expiration.isEmpty()) return false
+    if (expiration.isNullOrEmpty()) return false
 
     val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
     format.timeZone = TimeZone.getTimeZone("UTC")

--- a/infra/license/src/main/java/com/simprints/infra/license/local/LicenseLocalDataSourceImpl.kt
+++ b/infra/license/src/main/java/com/simprints/infra/license/local/LicenseLocalDataSourceImpl.kt
@@ -57,7 +57,7 @@ internal class LicenseLocalDataSourceImpl @Inject constructor(
         withContext(dispatcherIo) {
             createDirectoryIfNonExistent(licenseDirectoryPath)
             saveLicenseData(vendor, license.data)
-            saveExpirationDate(vendor, license.expiration)
+            license.expiration?.let { saveExpirationDate(vendor, it) }
         }
 
     private fun saveLicenseData(vendor: Vendor, licenseData: String) {

--- a/infra/license/src/main/java/com/simprints/infra/license/remote/ApiLicense.kt
+++ b/infra/license/src/main/java/com/simprints/infra/license/remote/ApiLicense.kt
@@ -13,7 +13,7 @@ internal data class ApiLicense(val licenses: Map<Vendor, License> = emptyMap()) 
 }
 
 @Keep
-data class License(val expiration: String, val data: String)
+data class License(val expiration: String?, val data: String)
 
 /**
  * BFSID returns an error in the following format:

--- a/infra/license/src/test/java/com/simprints/infra/license/LicenseUtilsTest.kt
+++ b/infra/license/src/test/java/com/simprints/infra/license/LicenseUtilsTest.kt
@@ -12,19 +12,22 @@ class LicenseUtilsTest {
         val nullLicense: License? = null
         assertThat(nullLicense.determineLicenseStatus()).isEqualTo(LicenseStatus.MISSING)
 
-        val expiredLicense = License("2022-01-01T00:00:00Z", "data")
+        val expiredLicense = License(expiration = "2022-01-01T00:00:00Z", data = "data")
         assertThat(expiredLicense.determineLicenseStatus()).isEqualTo(LicenseStatus.EXPIRED)
 
-        val invalidLicense = License("2223-01-01T00:00:00Z", "")
+        val invalidLicense = License(expiration = "2223-01-01T00:00:00Z", data = "")
         assertThat(invalidLicense.determineLicenseStatus()).isEqualTo(LicenseStatus.INVALID)
 
-        val validLicense = License("2123-01-01T00:00:00Z", "data")
+        val validLicense = License(expiration = "2123-01-01T00:00:00Z", data = "data")
         assertThat(validLicense.determineLicenseStatus()).isEqualTo(LicenseStatus.VALID)
 
-        val validLicenseWithEmptyExpiration = License("", "data")
+        val validLicenseWithEmptyExpiration = License(expiration = "", data = "data")
         assertThat(validLicenseWithEmptyExpiration.determineLicenseStatus()).isEqualTo(LicenseStatus.VALID)
 
-        val validLicenseWithBadExpirationDate = License("bad date", "data")
+        val validLicenseWithNullExpiration = License(expiration = null, data = "data")
+        assertThat(validLicenseWithNullExpiration.determineLicenseStatus()).isEqualTo(LicenseStatus.VALID)
+
+        val validLicenseWithBadExpirationDate = License(expiration = "bad date", data = "data")
         assertThat(validLicenseWithBadExpirationDate.determineLicenseStatus()).isEqualTo(
             LicenseStatus.VALID
         )


### PR DESCRIPTION
The `BFSID` might return the face SDK license response with no `expiration` field:
```
{
  "VENDOR": {
    "vendor": "VENDOR",
    "data": "{...}"
}
```

Reflecting this in the `License` class so that the parsing won't fail

