### PR TITLE
MS-554 Use more permissive method to parse maxAge duration

### DIFF
--- a/feature/validate-subject-pool/src/main/java/com/simprints/feature/validatepool/usecase/ShouldSuggestSyncUseCase.kt
+++ b/feature/validate-subject-pool/src/main/java/com/simprints/feature/validatepool/usecase/ShouldSuggestSyncUseCase.kt
@@ -19,7 +19,7 @@ internal class ShouldSuggestSyncUseCase @Inject constructor(
                 .synchronization
                 .down
                 .maxAge
-                .let(Duration.Companion::parseIsoString)
+                .let(Duration.Companion::parse)
                 .inWholeMilliseconds
 
             timeHelper.msBetweenNowAndTime(it.time) > thresholdMs

--- a/feature/validate-subject-pool/src/test/java/com/simprints/feature/validatepool/usecase/ShouldSuggestSyncUseCaseTest.kt
+++ b/feature/validate-subject-pool/src/test/java/com/simprints/feature/validatepool/usecase/ShouldSuggestSyncUseCaseTest.kt
@@ -51,6 +51,17 @@ class ShouldSuggestSyncUseCaseTest {
     }
 
     @Test
+    fun `returns true if not synced recently with non ISO max age`() = runTest {
+        coEvery { syncManager.getLastSyncTime() } returns Date()
+        coEvery { timeHelper.msBetweenNowAndTime(any()) } returns WEEK_MS
+        coEvery {
+            configRepository.getProjectConfiguration().synchronization.down.maxAge
+        } returns "24h0m0s"
+
+        assertThat(usecase()).isTrue()
+    }
+
+    @Test
     fun `returns false if synced recently`() = runTest {
         coEvery { syncManager.getLastSyncTime() } returns Date()
         coEvery { timeHelper.msBetweenNowAndTime(any()) } returns HOUR_MS


### PR DESCRIPTION
Should be able to parse both "ISO" and "24h0m0s" format.