### PR TITLE
[MS-572] EventDownSyncRequest/EventUpSyncRequest events error type changed to just class name

### DIFF
--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/EventDownSyncTask.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/EventDownSyncTask.kt
@@ -75,7 +75,7 @@ internal class EventDownSyncTask @Inject constructor(
                 .catch {
                     // Track a case when event stream is closed due to a parser error,
                     // but the exception is handled gracefully and channel is closed correctly.
-                    errorType = it.toString()
+                    errorType = it.javaClass.simpleName
                 }
                 .collect {
                     batchOfEventsToProcess.add(it)
@@ -105,7 +105,7 @@ internal class EventDownSyncTask @Inject constructor(
             }
 
             Simber.d(t)
-            errorType = t.toString()
+            errorType = t.javaClass.simpleName
 
             lastOperation = processBatchedEvents(operation, batchOfEventsToProcess, lastOperation)
             emitProgress(lastOperation, count, count)

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
@@ -295,7 +295,7 @@ internal class EventUpSyncTask @Inject constructor(
                 endedAt = timeHelper.now(),
                 requestId = requestId,
                 responseStatus = result?.status,
-                errorType = ex.toString(),
+                errorType = ex.javaClass.simpleName,
             )
         )
     }


### PR DESCRIPTION
The `errorType` in `EventDownSyncRequestEvent` and `EventUpSyncRequestEvent` used to contain the stack trace, which was excessive for logging at the backend.