### PR TITLE
[MS-576] 'Validate ID pool' step is added only when the biometric data source is "Simprints"

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCase.kt
@@ -54,7 +54,11 @@ internal class BuildStepsUseCase @Inject constructor(
 
             listOf(
                 buildSetupStep(),
-                buildValidateIdPoolStep(subjectQuery),
+                buildValidateIdPoolStep(
+                    subjectQuery = subjectQuery,
+                    biometricDataSource = action.biometricDataSource,
+                    callerPackageName = action.callerPackageName
+                ),
                 buildAgeSelectionStepIfNeeded(action, projectConfiguration),
                 buildConsentStep(ConsentType.IDENTIFY),
                 buildModalityCaptureAndMatchStepsForIdentify(
@@ -240,14 +244,25 @@ internal class BuildStepsUseCase @Inject constructor(
         )
     )
 
-    private fun buildValidateIdPoolStep(subjectQuery: SubjectQuery) = listOf(
-        Step(
-            id = StepId.VALIDATE_ID_POOL,
-            navigationActionId = R.id.action_orchestratorFragment_to_validateSubjectPool,
-            destinationId = ValidateSubjectPoolContract.DESTINATION,
-            payload = ValidateSubjectPoolContract.getArgs(subjectQuery),
+    private fun buildValidateIdPoolStep(
+        subjectQuery: SubjectQuery,
+        biometricDataSource: String,
+        callerPackageName: String
+    ) = when (BiometricDataSource.fromString(
+        value = biometricDataSource,
+        callerPackageName = callerPackageName
+    )) {
+        BiometricDataSource.Simprints -> listOf(
+            Step(
+                id = StepId.VALIDATE_ID_POOL,
+                navigationActionId = R.id.action_orchestratorFragment_to_validateSubjectPool,
+                destinationId = ValidateSubjectPoolContract.DESTINATION,
+                payload = ValidateSubjectPoolContract.getArgs(subjectQuery),
+            )
         )
-    )
+
+        is BiometricDataSource.CommCare -> emptyList()
+    }
 
     private fun buildModalityCaptureSteps(
         projectConfiguration: ProjectConfiguration,

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCaseTest.kt
@@ -343,6 +343,32 @@ class BuildStepsUseCaseTest {
     }
 
     @Test
+    fun `build - identify action - CoSync data source - returns steps without validate ID pool`() {
+        val projectConfiguration = mockCommonProjectConfiguration()
+        val ageGroup = AgeGroup(18, 60)
+        every { secugenSimMatcher.allowedAgeRange } returns ageGroup
+        every { nec.allowedAgeRange } returns ageGroup
+        every { projectConfiguration.face?.rankOne?.allowedAgeRange } returns ageGroup
+
+        val action = mockk<ActionRequest.IdentifyActionRequest>(relaxed = true) {
+            every { getSubjectAgeIfAvailable() } returns 25
+            every { biometricDataSource } returns "COMMCARE"
+        }
+        val steps = useCase.build(action, projectConfiguration)
+
+        assertStepOrder(steps,
+            StepId.SETUP,
+            StepId.CONSENT,
+            StepId.FINGERPRINT_CAPTURE,
+            StepId.FINGERPRINT_CAPTURE,
+            StepId.FACE_CAPTURE,
+            StepId.FINGERPRINT_MATCHER,
+            StepId.FINGERPRINT_MATCHER,
+            StepId.FACE_MATCHER
+        )
+    }
+
+    @Test
     fun `build - verify action - age restriction - subject age within range - returns expected steps`() {
         val projectConfiguration = mockCommonProjectConfiguration()
         val ageGroup = AgeGroup(18, 60)


### PR DESCRIPTION
'Validate ID Pool' step is only added if the `biometricDataSource` intent flag is resolved to `BiometricDataSource.Simprints`