### PR TITLE
[MS-577] Fetching GUID for verification only when biometricDataSource is Simprints

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCase.kt
@@ -72,7 +72,12 @@ internal class BuildStepsUseCase @Inject constructor(
         is ActionRequest.VerifyActionRequest -> listOf(
             buildSetupStep(),
             buildAgeSelectionStepIfNeeded(action, projectConfiguration),
-            buildFetchGuidStepIfNeeded(action),
+            buildFetchGuidStepIfNeeded(
+                projectId = action.projectId,
+                subjectId = action.verifyGuid,
+                biometricDataSource = action.biometricDataSource,
+                callerPackageName = action.callerPackageName
+            ),
             buildConsentStep(ConsentType.VERIFY),
             buildModalityCaptureAndMatchStepsForVerify(action, projectConfiguration)
         )
@@ -226,26 +231,26 @@ internal class BuildStepsUseCase @Inject constructor(
         )
     )
 
-    private fun buildFetchGuidStepIfNeeded(action: ActionRequest.VerifyActionRequest) =
-        with(action) {
-            val isBiometricDataSourceSimprints =
-                BiometricDataSource.fromString(
-                    value = biometricDataSource,
-                    callerPackageName = callerPackageName,
-                ) == BiometricDataSource.Simprints
-            if (isBiometricDataSourceSimprints) {
-                listOf(
-                    Step(
-                        id = StepId.FETCH_GUID,
-                        navigationActionId = R.id.action_orchestratorFragment_to_fetchSubject,
-                        destinationId = FetchSubjectContract.DESTINATION,
-                        payload = FetchSubjectContract.getArgs(projectId, action.verifyGuid),
-                    )
-                )
-            } else {
-                emptyList()
-            }
-        }
+    private fun buildFetchGuidStepIfNeeded(
+        projectId: String,
+        subjectId: String,
+        biometricDataSource: String,
+        callerPackageName: String
+    ) = when (BiometricDataSource.fromString(
+        value = biometricDataSource,
+        callerPackageName = callerPackageName
+    )) {
+        BiometricDataSource.Simprints -> listOf(
+            Step(
+                id = StepId.FETCH_GUID,
+                navigationActionId = R.id.action_orchestratorFragment_to_fetchSubject,
+                destinationId = FetchSubjectContract.DESTINATION,
+                payload = FetchSubjectContract.getArgs(projectId, subjectId),
+            )
+        )
+
+        is BiometricDataSource.CommCare -> emptyList()
+    }
 
     private fun buildConsentStep(consentType: ConsentType) = listOf(
         Step(

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCaseTest.kt
@@ -369,6 +369,32 @@ class BuildStepsUseCaseTest {
     }
 
     @Test
+    fun `build - verify action - co-sync data source - returns steps without fetch GUID`() {
+        val projectConfiguration = mockCommonProjectConfiguration()
+        val ageGroup = AgeGroup(18, 60)
+        every { secugenSimMatcher.allowedAgeRange } returns ageGroup
+        every { nec.allowedAgeRange } returns ageGroup
+        every { projectConfiguration.face?.rankOne?.allowedAgeRange } returns ageGroup
+
+        val action = mockk<ActionRequest.VerifyActionRequest>(relaxed = true)
+        every { action.getSubjectAgeIfAvailable() } returns 25 // Subject age within the supported range
+        every { action.biometricDataSource } returns "COMMCARE"
+        val steps = useCase.build(action, projectConfiguration)
+
+        assertStepOrder(steps,
+            StepId.SETUP,
+            // no StepId.FETCH_GUID
+            StepId.CONSENT,
+            StepId.FINGERPRINT_CAPTURE,
+            StepId.FINGERPRINT_CAPTURE,
+            StepId.FACE_CAPTURE,
+            StepId.FINGERPRINT_MATCHER,
+            StepId.FINGERPRINT_MATCHER,
+            StepId.FACE_MATCHER
+        )
+    }
+
+    @Test
     fun `build - enrol action - age restriction - subject age not supported - throws SubjectAgeNotSupportedException`() {
         val projectConfiguration = mockCommonProjectConfiguration()
         val ageGroup = AgeGroup(30, 40)


### PR DESCRIPTION
This fixed verification with co-sync, when the biometric data source is the data collection app.
Related fix for identification: https://github.com/Simprints/Android-Simprints-ID/pull/806