### PR TITLE
[MS-587] Resolve release compilation errors

### DIFF
--- a/build-logic/proguard-rules.pro
+++ b/build-logic/proguard-rules.pro
@@ -1,4 +1,4 @@
 # Dont warn about the missing files during the obfuscation
 -dontwarn com.simprints.**
-# Do not obfuscate names in simprints package
+# Do not obfuscate the simprints package
 -keep class com.simprints.** { *; }

--- a/build-logic/proguard-rules.pro
+++ b/build-logic/proguard-rules.pro
@@ -1,2 +1,4 @@
 # Dont warn about the missing files during the obfuscation
 -dontwarn com.simprints.**
+# Do not obfuscate names in simprints package
+-keep class com.simprints.** { *; }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin_version = "2.0.0"
 kotlin_coroutine_version = "1.8.1"
 ksp_version = "2.0.0-1.0.23"
 
-android_gradlePlugin_version = "8.5.1"
+android_gradlePlugin_version = "8.3.1"
 androidx_version = "1.6.1"
 androidx_core_version = "1.13.1"
 androidx_app_compat_version = "1.7.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 17 16:28:15 EEST 2024
+#Mon Apr 17 08:02:27 EET 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/id/proguard-rules.pro
+++ b/id/proguard-rules.pro
@@ -58,8 +58,8 @@
 #net.zetetic:android-database-sqlcipher
 -keep class net.sqlcipher.** { *; }
 
-# Do not obfuscate names in out packages`
--keepnames class com.simprints.** { *; }
+# Do not obfuscate names in simprints package
+-keep class com.simprints.** { *; }
 # Keep all marshallable classes as-is
 -keep class com.simprints.** extends java.io.Serializable { *; }
 -keep class com.simprints.** extends android.os.Parcelable { *; }


### PR DESCRIPTION
Due to inconsistencies between AGP, R8, KSP, and Hilt versions, we encountered issues when creating release builds. Over the last two days, I tried many workarounds mentioned in GitHub issues but found it safer to roll back. Downgrading the AGP version to the last known working version (in the release 2024.1.* branch) resolved the problem.

The error trace: 
```
error: ComponentProcessingStep was unable to process 'com.simprints.id.Application_HiltComponents.SingletonC' because 'com.simprints.infra.config.sync.ConfigManager' could not be resolved.

Dependency trace:
    => element (CLASS): com.simprints.infra.sync.config.worker.DeviceConfigDownSyncWorker
    => element (CONSTRUCTOR): DeviceConfigDownSyncWorker(android.content.Context,androidx.work.WorkerParameters,com.simprints.infra.config.sync.ConfigManager,com.simprints.infra.sync.config.usecase.LogoutUseCase,com.simprints.infra.sync.SyncOrchestrator,kotlinx.coroutines.CoroutineDispatcher)
    => type (EXECUTABLE constructor): (android.content.Context,androidx.work.WorkerParameters,com.simprints.infra.config.sync.ConfigManager,com.simprints.infra.sync.config.usecase.LogoutUseCase,com.simprints.infra.sync.SyncOrchestrator,kotlinx.coroutines.CoroutineDispatcher)void
    => type (ERROR parameter type): com.simprints.infra.config.sync.ConfigManager

If type 'com.simprints.infra.config.sync.ConfigManager' is a generated type, check above for compilation errors that may have prevented the type from being generated. Otherwise, ensure that type 'com.simprints.infra.config.sync.ConfigManager' is on your classpath.
1 error
```

