### PR TITLE
Logging current and received session ID values before throwing exception

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/validators/ConfirmIdentityValidator.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/validators/ConfirmIdentityValidator.kt
@@ -3,6 +3,7 @@ package com.simprints.feature.clientapi.mappers.request.validators
 import com.simprints.feature.clientapi.exceptions.InvalidRequestException
 import com.simprints.feature.clientapi.mappers.request.extractors.ConfirmIdentityRequestExtractor
 import com.simprints.feature.clientapi.models.ClientApiError
+import com.simprints.infra.logging.Simber
 
 
 internal class ConfirmIdentityValidator(
@@ -30,9 +31,11 @@ internal class ConfirmIdentityValidator(
     private fun validateSessionId(sessionId: String) {
         if (sessionId.isBlank())
             throw InvalidRequestException("Missing Session ID", ClientApiError.INVALID_SESSION_ID)
-        if (currentSessionId != sessionId)
+        if (currentSessionId != sessionId) {
+            // TODO Remove in 2024.2.1 or when root cause of "Invalid Session ID" error is found
+            Simber.i("Mismatched IDs: '$currentSessionId' != '$sessionId'")
             throw InvalidRequestException("Invalid Session ID", ClientApiError.INVALID_SESSION_ID)
-
+        }
     }
 
     private fun validateSelectedGuid(selectedId: String) {


### PR DESCRIPTION
Since we cannot reproduce the issue from the current logs and the problem descriptions, it could be helpful to see what exact session ID values are being compared. 

If both are valid sessions we would be able to check the session events for extra clues.