### PR TITLE
MS-593 Camera permission revokation fix

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
@@ -152,11 +152,13 @@ internal class OrchestratorViewModel @Inject constructor(
             val nextStep = steps.firstOrNull { it.status == StepStatus.NOT_STARTED }
             if (nextStep != null) {
                 nextStep.status = StepStatus.IN_PROGRESS
+                cache.steps = steps
                 _currentStep.send(nextStep)
             } else {
                 // Acquiring location info could take long time, so we should stop location tracker
                 // before returning to the caller app to avoid creating empty sessions.
                 locationStore.cancelLocationCollection()
+                cache.steps = steps
                 buildAppResponse()
             }
         }

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/steps/Step.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/steps/Step.kt
@@ -57,7 +57,7 @@ import java.io.Serializable
     JsonSubTypes.Type(value = AlertResult::class, name = "AlertResult"),
     JsonSubTypes.Type(value = ExitFormResult::class, name = "ExitFormResult"),
     JsonSubTypes.Type(value = ValidateSubjectPoolResult::class, name = "ValidateSubjectPoolResult"),
-    JsonSubTypes.Type(value = SelectSubjectAgeGroupResult::class, name = "SelectSubjectAgeResult"),
+    JsonSubTypes.Type(value = SelectSubjectAgeGroupResult::class, name = "SelectSubjectAgeGroupResult"),
 )
 abstract class SerializableMixin : Serializable
 


### PR DESCRIPTION
* The app process is silently restarted when revoking permission in settings without calling `onCleared()` or any other indication within the view model. 
* This causes the VM recreation when navigating back to SID. Since the `onCleared()` has not been called there is nothing in the steps cache and the flow is forcibly closed on the next `handleResult()`/`doOnNextStep()` call. 
* The only way to be sure that the step cache is being preserved is to save the steps each time the flow proceeds to the next step or returns the final result. 
* Since the step list is always relatively short (less than 10 items) parsing to/from JSON should take a negligible amount of time. This could also make the cache and state restoration more consistent in other scenarios that involve navigating away from SID mid-flow.