### PR TITLE
[MS-591] Fix for incorrect subject pool sync behavior after device rotation

### DIFF
--- a/feature/validate-subject-pool/src/main/java/com/simprints/feature/validatepool/screen/ValidateSubjectPoolViewModel.kt
+++ b/feature/validate-subject-pool/src/main/java/com/simprints/feature/validatepool/screen/ValidateSubjectPoolViewModel.kt
@@ -26,8 +26,12 @@ internal class ValidateSubjectPoolViewModel @Inject constructor(
     val state: LiveData<LiveDataEventWithContent<ValidateSubjectPoolState>>
         get() = _state
     private var _state = MutableLiveData<LiveDataEventWithContent<ValidateSubjectPoolState>>()
+    private var isSyncing: Boolean = false
 
     fun checkIdentificationPool(subjectQuery: SubjectQuery) = viewModelScope.launch {
+        if (isSyncing) {
+            return@launch
+        }
         _state.send(ValidateSubjectPoolState.Validating)
 
         val validationState = when {
@@ -43,7 +47,9 @@ internal class ValidateSubjectPoolViewModel @Inject constructor(
 
     fun syncAndRetry(subjectQuery: SubjectQuery) = viewModelScope.launch {
         _state.send(ValidateSubjectPoolState.SyncInProgress)
+        isSyncing = true
         runBlockingSync()
+        isSyncing = false
         checkIdentificationPool(subjectQuery)
     }
 


### PR DESCRIPTION
When running identification right after login and syncing candidates pool on request of the validation step, device rotation was causing incorrect sync state.