### PR TITLE
[MS-592] Fix for face unable to be captured after app resumes from background

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -61,6 +61,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
     private val binding by viewBinding(FragmentLiveFeedbackBinding::bind)
 
     private lateinit var screenSize: Size
+    private lateinit var targetResolution: Size
 
     private val launchPermissionRequest = registerForActivityResult(
         ActivityResultContracts.RequestPermission(),
@@ -111,7 +112,9 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
         cameraExecutor = Executors.newSingleThreadExecutor()
         // ImageAnalysis
         //Todo choose accurate output image resolution that respects quality,performance and face analysis SDKs https://simprints.atlassian.net/browse/CORE-2569
-        val targetResolution = Size(binding.captureOverlay.width, binding.captureOverlay.height)
+        if (!::targetResolution.isInitialized) {
+            targetResolution = Size(binding.captureOverlay.width, binding.captureOverlay.height)
+        }
         val imageAnalyzer = ImageAnalysis.Builder().setTargetResolution(targetResolution)
             .setOutputImageFormat(OUTPUT_IMAGE_FORMAT_RGBA_8888).build()
         imageAnalyzer.setAnalyzer(cameraExecutor, ::analyze)

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -104,7 +104,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
 
     /** Initialize CameraX, and prepare to bind the camera use cases  */
     private fun setUpCamera() = lifecycleScope.launch {
-        if (::cameraExecutor.isInitialized) {
+        if (::cameraExecutor.isInitialized && !cameraExecutor.isShutdown) {
             return@launch
         }
         // Initialize our background executor
@@ -118,6 +118,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
         // Preview
         val preview = Preview.Builder().setTargetResolution(targetResolution).build()
         val cameraProvider = ProcessCameraProvider.getInstance(requireContext()).await()
+        cameraProvider.unbindAll()
         cameraProvider.bindToLifecycle(
             this@LiveFeedbackFragment, DEFAULT_BACK_CAMERA, preview, imageAnalyzer
         )


### PR DESCRIPTION
Face capture camera viewfinder used to get stuck in its previous state after the app was put into background and then again into foreground.