### PR TITLE
Close session on confirm response

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/ClientApiViewModel.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/ClientApiViewModel.kt
@@ -135,6 +135,7 @@ class ClientApiViewModel @Inject internal constructor(
     ) = viewModelScope.launch {
         val currentSessionId = getCurrentSessionId()
         simpleEventReporter.addCompletionCheckEvent(flowCompleted = true)
+        simpleEventReporter.closeCurrentSessionNormally()
 
         deleteSessionEventsIfNeeded(currentSessionId)
 

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/ClientApiViewModelTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/ClientApiViewModelTest.kt
@@ -169,6 +169,7 @@ internal class ClientApiViewModelTest {
 
         coVerify {
             simpleEventReporter.addCompletionCheckEvent(eq(true))
+            simpleEventReporter.closeCurrentSessionNormally()
             deleteSessionEventsIfNeeded(any())
         }
         verify { resultMapper.invoke(withArg { it is ActionResponse.ConfirmActionResponse }) }


### PR DESCRIPTION
Minor upkeep change that should not affect app behavior. This ensures that sessions that finish with confirmation intent have the correct end cause ("WORKFLOW_ENDED" instead of "NEW_SESSION").