### PR TITLE
MS-606 Correctly display module list on sync info page

### DIFF
--- a/feature/dashboard/src/main/res/layout/fragment_sync_info.xml
+++ b/feature/dashboard/src/main/res/layout/fragment_sync_info.xml
@@ -2,9 +2,9 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:fillViewport="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
By default, ScrollView collapses content and does not expand when the content changes. This flag ensures that the view always matches screen size.