### PR TITLE
[MS-612] Removing the 'fitsSystemWindows' attribute so that there is no extra white space when the toolbar is hidden

### DIFF
--- a/fingerprint/capture/src/main/res/layout/fragment_fingerprint_capture.xml
+++ b/fingerprint/capture/src/main/res/layout/fragment_fingerprint_capture.xml
@@ -3,8 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:keepScreenOn="true"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:layout_height="match_parent">
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Once the toolbar was hidden after the `FingerprintCaptureFragment` has finished its execution, a small extra white space remained at the top of the screen.
![image](https://github.com/user-attachments/assets/4c474838-da04-4b2f-ac98-be86045c93f7)

This is now fixed:
![image](https://github.com/user-attachments/assets/97dfc7e3-303d-4be8-9ebc-74feacc673cd)
![image](https://github.com/user-attachments/assets/1ce8db0a-4801-4258-8a4c-ff0d305042ee)
![image](https://github.com/user-attachments/assets/7f679354-e554-447b-804e-d501eadc8202)

