### PR TITLE
[MS-605] The event cache is cleared every time a new session scope is created

### DIFF
--- a/infra/events/src/main/java/com/simprints/infra/events/session/SessionEventRepositoryImpl.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/session/SessionEventRepositoryImpl.kt
@@ -19,6 +19,7 @@ internal class SessionEventRepositoryImpl @Inject constructor(
         closeAllSessions(EventScopeEndCause.NEW_SESSION)
         return eventRepository.createEventScope(EventScopeType.SESSION).also { sessionScope ->
             sessionDataCache.eventScope = sessionScope
+            sessionDataCache.eventCache.clear()
         }
     }
 
@@ -81,9 +82,9 @@ internal class SessionEventRepositoryImpl @Inject constructor(
             ?.also { session -> loadEventsIntoCache(session.id) }
 
     private suspend fun loadEventsIntoCache(sessionId: String) {
-        eventRepository.getEventsFromScope(sessionId).forEach {
-            sessionDataCache.eventCache[it.id] = it
-        }
+        sessionDataCache.eventCache.clear()
+        eventRepository.getEventsFromScope(sessionId)
+            .forEach { sessionDataCache.eventCache[it.id] = it }
     }
 
     override suspend fun closeCurrentSession(reason: EventScopeEndCause?) {

--- a/infra/events/src/test/java/com/simprints/infra/events/session/SessionEventRepositoryImplTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/session/SessionEventRepositoryImplTest.kt
@@ -48,6 +48,17 @@ internal class SessionEventRepositoryImplTest {
     }
 
     @Test
+    fun `when create session is called, then the event cache is cleared`() = runTest {
+        coEvery { eventRepository.createEventScope(any()) } returns mockk()
+        sessionDataCache.eventCache["test"] = mockk()
+
+        sessionEventRepository.createSession()
+
+        coVerify { eventRepository.createEventScope(EventScopeType.SESSION) }
+        assertThat(sessionDataCache.eventCache).isEmpty()
+    }
+
+    @Test
     fun `closes existing sessions when creating new session`() = runTest {
         coEvery { eventRepository.createEventScope(any()) } returns createSessionScope("mockId")
 
@@ -112,10 +123,12 @@ internal class SessionEventRepositoryImplTest {
     @Test
     fun `return current scope from db if no cache`() = runTest {
         coEvery { eventRepository.getOpenEventScopes(any()) } returns listOf(createSessionScope("mockId"))
+        sessionDataCache.eventCache["test"] = mockk()
 
         val loadedSession = sessionEventRepository.getCurrentSessionScope()
 
         assertThat(loadedSession.id).isEqualTo("mockId")
+        assertThat(sessionDataCache.eventCache).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
A similar PR already exists https://github.com/Simprints/Android-Simprints-ID/pull/845, but it targeted an incorrect branch.
Targeting the correct branch with this PR