### PR TITLE
MS-614 Only call setupMatch after the permission is received

### DIFF
--- a/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchFragment.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchFragment.kt
@@ -47,9 +47,6 @@ internal class MatchFragment : Fragment(R.layout.fragment_matcher) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         observeViewModel()
-        if (!viewModel.isInitialized) {
-            viewModel.setupMatch(args.params)
-        }
     }
 
     override fun onResume() {


### PR DESCRIPTION
* `setupMatch()` calls `count()` on the enrolment record repository which also requires the permission in case of CommCare data source. 