### PR TITLE
MS-197 Assemble consent text using activity context instead of application

### DIFF
--- a/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/ConsentFragment.kt
+++ b/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/ConsentFragment.kt
@@ -96,8 +96,12 @@ internal class ConsentFragment : Fragment(R.layout.fragment_consent) {
 
     private fun updateUiWithState(state: ConsentViewState) {
         binding.consentLogo.isVisible = state.showLogo
+
+        val generalText = state.consentTextBuilder?.assembleText(requireActivity()).orEmpty()
+        val parentText = state.parentalTextBuilder?.assembleText(requireActivity()).orEmpty()
+
         // setup initial text to general consent
-        binding.consentTextHolderView.text = state.consentText
+        binding.consentTextHolderView.text = generalText
 
         with(binding.consentTabHost) {
             // Fully reset tab state
@@ -105,7 +109,7 @@ internal class ConsentFragment : Fragment(R.layout.fragment_consent) {
             clearOnTabSelectedListeners()
             addTab(newTab().setText(IDR.string.consent_general_title), GENERAL_CONSENT_TAB)
             if (state.showParentalConsent) {
-                addParentalConsentTab(state.consentText, state.parentalConsentText)
+                addParentalConsentTab(generalText, parentText)
             }
             getTabAt(state.selectedTab)?.select()
         }

--- a/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/ConsentViewState.kt
+++ b/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/ConsentViewState.kt
@@ -1,9 +1,12 @@
 package com.simprints.feature.consent.screens.consent
 
+import com.simprints.feature.consent.screens.consent.helpers.GeneralConsentTextHelper
+import com.simprints.feature.consent.screens.consent.helpers.ParentalConsentTextHelper
+
 internal data class ConsentViewState(
     val showLogo: Boolean = true,
-    val consentText: String = "",
     val showParentalConsent: Boolean = false,
-    val parentalConsentText: String = "",
-    val selectedTab: Int = 0
+    val consentTextBuilder: GeneralConsentTextHelper? = null,
+    val parentalTextBuilder: ParentalConsentTextHelper? = null,
+    val selectedTab: Int = 0,
 )

--- a/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/helpers/GeneralConsentTextHelper.kt
+++ b/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/helpers/GeneralConsentTextHelper.kt
@@ -3,41 +3,39 @@ package com.simprints.feature.consent.screens.consent.helpers
 import android.content.Context
 import com.simprints.feature.consent.ConsentType
 import com.simprints.infra.config.store.models.ConsentConfiguration
-import com.simprints.infra.config.store.models.GeneralConfiguration
+import com.simprints.infra.config.store.models.GeneralConfiguration.*
 import com.simprints.infra.resources.R
-import dagger.hilt.android.qualifiers.ApplicationContext
-import javax.inject.Inject
 
-internal class GeneralConsentTextHelper @Inject constructor(
-    @ApplicationContext val context: Context,
+internal data class GeneralConsentTextHelper(
+    private val config: ConsentConfiguration,
+    private val modalities: List<Modality>,
+    private val consentType: ConsentType,
 ) {
     // TODO All the `getString(id).format(arg,arg)` calls should be `getString(id,arg,arg)` one strings are fixed
 
     //First argument in consent text should always be program name, second is modality specific access/use case text
-    fun assembleText(
-        config: ConsentConfiguration,
-        modalities: List<GeneralConfiguration.Modality>,
-        consentType: ConsentType,
-    ) = StringBuilder().apply {
-        val modalityUseCase = getModalitySpecificUseCaseText(modalities)
-        val modalityAccess = getModalitySpecificAccessText(modalities)
+    fun assembleText(context: Context) = StringBuilder().apply {
+        val modalityUseCase = getModalitySpecificUseCaseText(context, modalities)
+        val modalityAccess = getModalitySpecificAccessText(context, modalities)
 
-        filterAppRequestForConsent(consentType, config, modalityUseCase)
-        filterForDataSharingOptions(config, modalityUseCase, modalityAccess)
+        filterAppRequestForConsent(context, consentType, config, modalityUseCase)
+        filterForDataSharingOptions(context, config, modalityUseCase, modalityAccess)
     }.toString()
 
     private fun StringBuilder.filterAppRequestForConsent(
+        context: Context,
         consentType: ConsentType,
         config: ConsentConfiguration,
         modalityUseCase: String,
     ) {
         when (consentType) {
-            ConsentType.ENROL -> appendTextForConsentEnrol(config.generalPrompt, config.programName, modalityUseCase)
-            ConsentType.IDENTIFY, ConsentType.VERIFY -> appendTextForConsentVerifyOrIdentify(config.programName, modalityUseCase)
+            ConsentType.ENROL -> appendTextForConsentEnrol(context, config.generalPrompt, config.programName, modalityUseCase)
+            ConsentType.IDENTIFY, ConsentType.VERIFY -> appendTextForConsentVerifyOrIdentify(context, config.programName, modalityUseCase)
         }
     }
 
     private fun StringBuilder.appendTextForConsentEnrol(
+        context: Context,
         config: ConsentConfiguration.ConsentPromptConfiguration?,
         programName: String,
         modalityUseCase: String,
@@ -53,11 +51,16 @@ internal class GeneralConsentTextHelper @Inject constructor(
         else -> this
     }
 
-    private fun StringBuilder.appendTextForConsentVerifyOrIdentify(programName: String, modalityUseCase: String) = appendSentence(
+    private fun StringBuilder.appendTextForConsentVerifyOrIdentify(
+        context: Context,
+        programName: String,
+        modalityUseCase: String
+    ) = appendSentence(
         context.getString(R.string.consent_id_verify).format(programName, modalityUseCase)
     )
 
     private fun StringBuilder.filterForDataSharingOptions(
+        context: Context,
         config: ConsentConfiguration,
         modalityUseCase: String,
         modalityAccess: String,
@@ -86,33 +89,46 @@ internal class GeneralConsentTextHelper @Inject constructor(
         }
     }
 
-    private fun getModalitySpecificUseCaseText(modalities: List<GeneralConfiguration.Modality>) = if (modalities.size == 1) {
-        getSingleModalitySpecificUseCaseText(modalities)
+    private fun getModalitySpecificUseCaseText(
+        context: Context,
+        modalities: List<Modality>,
+    ) = if (modalities.size == 1) {
+        getSingleModalitySpecificUseCaseText(context, modalities)
     } else {
-        getConcatenatedModalitiesUseCaseText()
+        getConcatenatedModalitiesUseCaseText(context)
     }
 
-    private fun getConcatenatedModalitiesUseCaseText() = "%s %s %s".format(
+    private fun getConcatenatedModalitiesUseCaseText(context: Context) = "%s %s %s".format(
         context.getString(R.string.consent_biometrics_general_fingerprint),
         context.getString(R.string.consent_biometric_concat_modalities),
         context.getString(R.string.consent_biometric_general_face)
     )
 
-    private fun getSingleModalitySpecificUseCaseText(modalities: List<GeneralConfiguration.Modality>) = when (modalities.first()) {
-        GeneralConfiguration.Modality.FACE -> context.getString(R.string.consent_biometric_general_face)
-        GeneralConfiguration.Modality.FINGERPRINT -> context.getString(R.string.consent_biometrics_general_fingerprint)
+    private fun getSingleModalitySpecificUseCaseText(
+        context: Context,
+        modalities: List<Modality>,
+    ) = when (modalities.first()) {
+        Modality.FACE -> context.getString(R.string.consent_biometric_general_face)
+        Modality.FINGERPRINT -> context.getString(R.string.consent_biometrics_general_fingerprint)
     }
 
-    private fun getModalitySpecificAccessText(modalities: List<GeneralConfiguration.Modality>) = if (modalities.size == 1) {
-        getSingleModalityAccessText(modalities)
+    private fun getModalitySpecificAccessText(
+        context: Context,
+        modalities: List<Modality>,
+    ) = if (modalities.size == 1) {
+        getSingleModalityAccessText(context, modalities)
     } else {
-        getConcatenatedModalitiesAccessText()
+        getConcatenatedModalitiesAccessText(context)
     }
 
-    private fun getConcatenatedModalitiesAccessText() = context.getString(R.string.consent_biometrics_access_fingerprint_face)
+    private fun getConcatenatedModalitiesAccessText(context: Context) =
+        context.getString(R.string.consent_biometrics_access_fingerprint_face)
 
-    private fun getSingleModalityAccessText(modalities: List<GeneralConfiguration.Modality>) = when (modalities.first()) {
-        GeneralConfiguration.Modality.FACE -> context.getString(R.string.consent_biometrics_access_face)
-        GeneralConfiguration.Modality.FINGERPRINT -> context.getString(R.string.consent_biometrics_access_fingerprint)
+    private fun getSingleModalityAccessText(
+        context: Context,
+        modalities: List<Modality>,
+    ) = when (modalities.first()) {
+        Modality.FACE -> context.getString(R.string.consent_biometrics_access_face)
+        Modality.FINGERPRINT -> context.getString(R.string.consent_biometrics_access_fingerprint)
     }
 }

--- a/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/helpers/ParentalConsentTextHelper.kt
+++ b/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/helpers/ParentalConsentTextHelper.kt
@@ -5,39 +5,37 @@ import com.simprints.feature.consent.ConsentType
 import com.simprints.infra.config.store.models.ConsentConfiguration
 import com.simprints.infra.config.store.models.GeneralConfiguration.Modality
 import com.simprints.infra.resources.R
-import dagger.hilt.android.qualifiers.ApplicationContext
-import javax.inject.Inject
 
-internal class ParentalConsentTextHelper @Inject constructor(
-    @ApplicationContext val context: Context
+internal data class ParentalConsentTextHelper(
+    private val config: ConsentConfiguration,
+    private val modalities: List<Modality>,
+    private val consentType: ConsentType,
 ) {
     // TODO All the `getString(id).format(arg,arg)` calls should be `getString(id,arg,arg)` one strings are fixed
 
     //First argument in consent text should always be program name, second is modality specific access/use case text
-    fun assembleText(
-        config: ConsentConfiguration,
-        modalities: List<Modality>,
-        consentType: ConsentType,
-    ): String = StringBuilder().apply {
-        val modalityUseCase = getModalitySpecificUseCaseText(modalities)
-        val modalityAccess = getModalitySpecificAccessText(modalities)
+    fun assembleText(context: Context): String = StringBuilder().apply {
+        val modalityUseCase = getModalitySpecificUseCaseText(context, modalities)
+        val modalityAccess = getModalitySpecificAccessText(context, modalities)
 
-        filterAppRequestForParentalConsent(consentType, config, modalityUseCase)
-        extractDataSharingOptions(config, modalityUseCase, modalityAccess)
+        filterAppRequestForParentalConsent(context, consentType, config, modalityUseCase)
+        extractDataSharingOptions(context, config, modalityUseCase, modalityAccess)
     }.toString()
 
     private fun StringBuilder.filterAppRequestForParentalConsent(
+        context: Context,
         consentType: ConsentType,
         config: ConsentConfiguration,
         modalityUseCase: String,
     ) {
         when (consentType) {
-            ConsentType.ENROL -> appendTextForParentalEnrol(config.parentalPrompt, config.programName, modalityUseCase)
-            ConsentType.IDENTIFY, ConsentType.VERIFY -> appendTextForIdentifyOrVerify(config.programName, modalityUseCase)
+            ConsentType.ENROL -> appendTextForParentalEnrol(context, config.parentalPrompt, config.programName, modalityUseCase)
+            ConsentType.IDENTIFY, ConsentType.VERIFY -> appendTextForIdentifyOrVerify(context, config.programName, modalityUseCase)
         }
     }
 
     private fun StringBuilder.appendTextForParentalEnrol(
+        context: Context,
         config: ConsentConfiguration.ConsentPromptConfiguration?,
         programName: String,
         modalityUseCase: String,
@@ -55,11 +53,16 @@ internal class ParentalConsentTextHelper @Inject constructor(
         else -> this
     }
 
-    private fun StringBuilder.appendTextForIdentifyOrVerify(programName: String, modalityUseCase: String) = appendSentence(
+    private fun StringBuilder.appendTextForIdentifyOrVerify(
+        context: Context,
+        programName: String,
+        modalityUseCase: String,
+    ) = appendSentence(
         context.getString(R.string.consent_parental_id_verify).format(programName, modalityUseCase)
     )
 
     private fun StringBuilder.extractDataSharingOptions(
+        context: Context,
         config: ConsentConfiguration,
         modalityUseCase: String,
         modalityAccess: String
@@ -86,33 +89,46 @@ internal class ParentalConsentTextHelper @Inject constructor(
         }
     }
 
-    private fun getModalitySpecificUseCaseText(modalities: List<Modality>) = if (modalities.size == 1) {
-        getSingleModalitySpecificUseCaseText(modalities)
+    private fun getModalitySpecificUseCaseText(
+        context: Context,
+        modalities: List<Modality>,
+    ) = if (modalities.size == 1) {
+        getSingleModalitySpecificUseCaseText(context, modalities)
     } else {
-        getConcatenatedModalitiesUseCaseText()
+        getConcatenatedModalitiesUseCaseText(context)
     }
 
-    private fun getConcatenatedModalitiesUseCaseText() = "%s %s %s".format(
+    private fun getConcatenatedModalitiesUseCaseText(context: Context) = "%s %s %s".format(
         context.getString(R.string.consent_biometrics_parental_fingerprint),
         context.getString(R.string.consent_biometric_concat_modalities),
         context.getString(R.string.consent_biometrics_parental_face)
     )
 
-    private fun getSingleModalitySpecificUseCaseText(modalities: List<Modality>) = when (modalities.first()) {
+    private fun getSingleModalitySpecificUseCaseText(
+        context: Context,
+        modalities: List<Modality>,
+    ) = when (modalities.first()) {
         Modality.FACE -> context.getString(R.string.consent_biometrics_parental_face)
         Modality.FINGERPRINT -> context.getString(R.string.consent_biometrics_parental_fingerprint)
         else -> ""
     }
 
-    private fun getModalitySpecificAccessText(modalities: List<Modality>) = if (modalities.size == 1) {
-        getSingleModalityAccessText(modalities)
+    private fun getModalitySpecificAccessText(
+        context: Context,
+        modalities: List<Modality>,
+    ) = if (modalities.size == 1) {
+        getSingleModalityAccessText(context, modalities)
     } else {
-        getConcatenatedModalitiesAccessText()
+        getConcatenatedModalitiesAccessText(context)
     }
 
-    private fun getConcatenatedModalitiesAccessText() = context.getString(R.string.consent_biometrics_access_fingerprint_face)
+    private fun getConcatenatedModalitiesAccessText(context: Context) =
+        context.getString(R.string.consent_biometrics_access_fingerprint_face)
 
-    private fun getSingleModalityAccessText(modalities: List<Modality>) = when (modalities.first()) {
+    private fun getSingleModalityAccessText(
+        context: Context,
+        modalities: List<Modality>,
+    ) = when (modalities.first()) {
         Modality.FACE -> context.getString(R.string.consent_biometrics_access_face)
         Modality.FINGERPRINT -> context.getString(R.string.consent_biometrics_access_fingerprint)
         else -> ""

--- a/feature/consent/src/test/java/com/simprints/feature/consent/screens/consent/ConsentViewModelTest.kt
+++ b/feature/consent/src/test/java/com/simprints/feature/consent/screens/consent/ConsentViewModelTest.kt
@@ -1,13 +1,11 @@
 package com.simprints.feature.consent.screens.consent
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.*
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.feature.consent.ConsentResult
 import com.simprints.feature.consent.ConsentType
-import com.simprints.feature.consent.screens.consent.helpers.GeneralConsentTextHelper
-import com.simprints.feature.consent.screens.consent.helpers.ParentalConsentTextHelper
 import com.simprints.feature.exitform.ExitFormResult
 import com.simprints.infra.config.store.models.GeneralConfiguration
 import com.simprints.infra.config.store.models.ProjectConfiguration
@@ -23,7 +21,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -44,12 +41,6 @@ class ConsentViewModelTest {
     private lateinit var timeHelper: TimeHelper
 
     @MockK
-    private lateinit var generalConsentTextHelper: GeneralConsentTextHelper
-
-    @MockK
-    private lateinit var parentalConsentTextHelper: ParentalConsentTextHelper
-
-    @MockK
     private lateinit var configManager: ConfigManager
 
     @MockK
@@ -68,17 +59,12 @@ class ConsentViewModelTest {
         MockKAnnotations.init(this, relaxed = true)
         coEvery { configManager.getProjectConfiguration() } returns projectConfig
         every { projectConfig.consent } returns mockk()
-
         every { timeHelper.now() } returns TIMESTAMP
-        every { generalConsentTextHelper.assembleText(any(), any(), any()) } returns GENERAL_CONSENT
-        every { parentalConsentTextHelper.assembleText(any(), any(), any()) } returns PARENTAL_CONSENT
 
         vm = ConsentViewModel(
             timeHelper,
             configManager,
             eventRepository,
-            generalConsentTextHelper,
-            parentalConsentTextHelper,
             CoroutineScope(testCoroutineRule.testCoroutineDispatcher)
         )
     }
@@ -93,13 +79,11 @@ class ConsentViewModelTest {
         val state = vm.viewState.getOrAwaitValue()
 
         coVerify { configManager.getProjectConfiguration() }
-        verify { generalConsentTextHelper.assembleText(any(), eq(defaultModalityList), eq(ConsentType.ENROL)) }
-        verify { parentalConsentTextHelper.assembleText(any(), eq(defaultModalityList), eq(ConsentType.ENROL)) }
 
-        Truth.assertThat(state.showLogo).isEqualTo(false)
-        Truth.assertThat(state.consentText).isEqualTo(GENERAL_CONSENT)
-        Truth.assertThat(state.showParentalConsent).isTrue()
-        Truth.assertThat(state.parentalConsentText).isEqualTo(PARENTAL_CONSENT)
+        assertThat(state.showLogo).isEqualTo(false)
+        assertThat(state.consentTextBuilder).isNotNull()
+        assertThat(state.showParentalConsent).isTrue()
+        assertThat(state.parentalTextBuilder).isNotNull()
     }
 
 
@@ -111,9 +95,8 @@ class ConsentViewModelTest {
         vm.loadConfiguration(ConsentType.ENROL)
         val state = vm.viewState.getOrAwaitValue()
 
-        verify(exactly = 0) { parentalConsentTextHelper.assembleText(any(), any(), any()) }
-        Truth.assertThat(state.showParentalConsent).isFalse()
-        Truth.assertThat(state.parentalConsentText).isEmpty()
+        assertThat(state.showParentalConsent).isFalse()
+        assertThat(state.parentalTextBuilder).isNull()
     }
 
 
@@ -127,7 +110,7 @@ class ConsentViewModelTest {
         vm.loadConfiguration(ConsentType.ENROL)
         val state = vm.viewState.getOrAwaitValue()
 
-        Truth.assertThat(state.selectedTab).isEqualTo(selectedTabIndex)
+        assertThat(state.selectedTab).isEqualTo(selectedTabIndex)
     }
 
     @Test
@@ -138,12 +121,12 @@ class ConsentViewModelTest {
         val event = slot<ConsentEvent>()
         coVerify { eventRepository.addOrUpdateEvent(capture(event)) }
         with(event.captured) {
-            Truth.assertThat(payload.consentType).isEqualTo(ConsentEvent.ConsentPayload.Type.INDIVIDUAL)
-            Truth.assertThat(payload.result).isEqualTo(ConsentEvent.ConsentPayload.Result.ACCEPTED)
+            assertThat(payload.consentType).isEqualTo(ConsentEvent.ConsentPayload.Type.INDIVIDUAL)
+            assertThat(payload.result).isEqualTo(ConsentEvent.ConsentPayload.Result.ACCEPTED)
         }
 
-        Truth.assertThat(result.peekContent()).isInstanceOf(ConsentResult::class.java)
-        Truth.assertThat(vm.showExitForm.value).isNull()
+        assertThat(result.peekContent()).isInstanceOf(ConsentResult::class.java)
+        assertThat(vm.showExitForm.value).isNull()
     }
 
     @Test
@@ -153,8 +136,8 @@ class ConsentViewModelTest {
         val event = slot<ConsentEvent>()
         coVerify { eventRepository.addOrUpdateEvent(capture(event)) }
         with(event.captured) {
-            Truth.assertThat(payload.consentType).isEqualTo(ConsentEvent.ConsentPayload.Type.PARENTAL)
-            Truth.assertThat(payload.result).isEqualTo(ConsentEvent.ConsentPayload.Result.DECLINED)
+            assertThat(payload.consentType).isEqualTo(ConsentEvent.ConsentPayload.Type.PARENTAL)
+            assertThat(payload.result).isEqualTo(ConsentEvent.ConsentPayload.Result.DECLINED)
         }
     }
 
@@ -165,7 +148,7 @@ class ConsentViewModelTest {
         vm.declineClicked(ConsentTab.PARENTAL)
         val result = vm.showExitForm.getOrAwaitValue()
 
-        Truth.assertThat(result.getContentIfNotHandled()?.titleRes).isEqualTo(IDR.string.exit_form_title_face)
+        assertThat(result.getContentIfNotHandled()?.titleRes).isEqualTo(IDR.string.exit_form_title_face)
     }
 
     @Test
@@ -175,7 +158,7 @@ class ConsentViewModelTest {
         vm.declineClicked(ConsentTab.PARENTAL)
         val result = vm.showExitForm.getOrAwaitValue()
 
-        Truth.assertThat(result.getContentIfNotHandled()?.titleRes).isEqualTo(IDR.string.exit_form_title_fingerprinting)
+        assertThat(result.getContentIfNotHandled()?.titleRes).isEqualTo(IDR.string.exit_form_title_fingerprinting)
     }
 
     @Test
@@ -188,7 +171,7 @@ class ConsentViewModelTest {
         vm.declineClicked(ConsentTab.PARENTAL)
         val result = vm.showExitForm.getOrAwaitValue()
 
-        Truth.assertThat(result.getContentIfNotHandled()?.titleRes).isEqualTo(IDR.string.exit_form_title_biometrics)
+        assertThat(result.getContentIfNotHandled()?.titleRes).isEqualTo(IDR.string.exit_form_title_biometrics)
     }
 
     @Test
@@ -196,7 +179,7 @@ class ConsentViewModelTest {
         vm.handleExitFormResponse(ExitFormResult(false))
 
         coVerify(exactly = 0) { eventRepository.removeLocationDataFromCurrentSession() }
-        Truth.assertThat(vm.showExitForm.value).isNull()
+        assertThat(vm.showExitForm.value).isNull()
     }
 
     @Test
@@ -206,12 +189,10 @@ class ConsentViewModelTest {
         val result = vm.returnConsentResult.getOrAwaitValue()
 
         coVerify { eventRepository.removeLocationDataFromCurrentSession() }
-        Truth.assertThat(result.getContentIfNotHandled()).isInstanceOf(ExitFormResult::class.java)
+        assertThat(result.getContentIfNotHandled()).isInstanceOf(ExitFormResult::class.java)
     }
 
     companion object {
         private val TIMESTAMP = Timestamp(1L)
-        private const val GENERAL_CONSENT = "General consent"
-        private const val PARENTAL_CONSENT = "Parental consent"
     }
 }

--- a/feature/consent/src/test/java/com/simprints/feature/consent/screens/consent/helpers/GeneralConsentTextHelperTest.kt
+++ b/feature/consent/src/test/java/com/simprints/feature/consent/screens/consent/helpers/GeneralConsentTextHelperTest.kt
@@ -28,7 +28,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for an enrol only with one modality`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.ENROLMENT_ONLY,
                 dataSharedWithPartner = false,
@@ -38,7 +38,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.ENROL,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_enrol_only)
@@ -49,7 +49,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for an enrol only with two modalities`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.ENROLMENT_ONLY,
                 dataSharedWithPartner = false,
@@ -59,7 +59,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT, GeneralConfiguration.Modality.FACE),
             ConsentType.ENROL,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_enrol_only)
@@ -70,7 +70,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for a standard enrol with one modality`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = false,
@@ -80,7 +80,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FACE),
             ConsentType.ENROL,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_enrol)
@@ -91,7 +91,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for a standard enrol with two modalities`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = false,
@@ -101,7 +101,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT, GeneralConfiguration.Modality.FACE),
             ConsentType.ENROL,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_enrol)
@@ -112,7 +112,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for a verification`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = false,
@@ -122,7 +122,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.VERIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_id_verify)
@@ -133,7 +133,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for an identification with one modality`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(
                 ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
@@ -144,7 +144,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_id_verify)
@@ -155,7 +155,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for an identification with two modalities`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = false,
@@ -165,7 +165,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT, GeneralConfiguration.Modality.FACE),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_id_verify)
@@ -176,7 +176,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the data is not shared with partner for fingerprint`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = false,
@@ -186,7 +186,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_share_data_no)
@@ -198,7 +198,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the data is not shared with partner for face`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = false,
@@ -208,7 +208,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FACE),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_share_data_no)
@@ -220,7 +220,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the data is not shared with partner for face and fingerprint`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = false,
@@ -230,7 +230,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT, GeneralConfiguration.Modality.FACE),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_share_data_no)
@@ -242,7 +242,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the data is shared with partner for fingerprint`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = true,
@@ -252,7 +252,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_share_data_yes)
@@ -263,7 +263,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the data is used for R&D`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = false,
@@ -273,7 +273,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_collect_yes)
@@ -283,7 +283,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should not add the string when the data is not used for R&D`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = false,
@@ -293,7 +293,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_collect_yes)
@@ -303,7 +303,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the privacy right is required`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = false,
@@ -313,7 +313,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_privacy_rights)
@@ -323,7 +323,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should not add the string when the privacy right is not required`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = false,
@@ -333,7 +333,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_privacy_rights)
@@ -343,7 +343,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the confirmation is required`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = false,
@@ -353,7 +353,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_confirmation)
@@ -364,7 +364,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should not add the string when the confirmation is not required`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = false,
@@ -374,7 +374,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_confirmation)
@@ -384,7 +384,7 @@ class GeneralConsentTextHelperTest {
 
     @Test
     fun `should not start a new sentence after a period without a following space`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = true,
@@ -394,14 +394,14 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         assertThat(generalConsentText).doesNotContainMatch("\\.\\w")
     }
 
     @Test
     fun `should not start with a space`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = true,
@@ -411,14 +411,14 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         assertThat(generalConsentText).doesNotContainMatch("^\\s.*")
     }
 
     @Test
     fun `should not contain double spaces`() {
-        val generalConsentText = GeneralConsentTextHelper(context).assembleText(
+        val generalConsentText = GeneralConsentTextHelper(
             configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
                 enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
                 dataSharedWithPartner = true,
@@ -428,7 +428,7 @@ class GeneralConsentTextHelperTest {
             )),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         assertThat(generalConsentText).doesNotContain("  ")
     }

--- a/feature/consent/src/test/java/com/simprints/feature/consent/screens/consent/helpers/ParentalConsentTextHelperTest.kt
+++ b/feature/consent/src/test/java/com/simprints/feature/consent/screens/consent/helpers/ParentalConsentTextHelperTest.kt
@@ -28,17 +28,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for an enrol only with one modality`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.ENROLMENT_ONLY,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.ENROLMENT_ONLY,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.ENROL,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_enrol_only)
@@ -49,17 +51,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for an enrol only with two modalities`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.ENROLMENT_ONLY,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.ENROLMENT_ONLY,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT, GeneralConfiguration.Modality.FACE),
             ConsentType.ENROL,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_enrol_only)
@@ -70,17 +74,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for a standard enrol with one modality`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FACE),
             ConsentType.ENROL,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_enrol)
@@ -91,17 +97,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for a standard enrol with two modalities`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT, GeneralConfiguration.Modality.FACE),
             ConsentType.ENROL,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_enrol)
@@ -112,17 +120,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for a verification`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.VERIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_id_verify)
@@ -133,17 +143,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for an identification with one modality`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_id_verify)
@@ -154,17 +166,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should return the correct consent for an identification with two modalities`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT, GeneralConfiguration.Modality.FACE),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_id_verify)
@@ -175,17 +189,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the data is not shared with partner for fingerprint`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_share_data_no)
@@ -197,17 +213,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the data is not shared with partner for face`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FACE),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_share_data_no)
@@ -219,17 +237,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the data is not shared with partner for face and fingerprint`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT, GeneralConfiguration.Modality.FACE),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_share_data_no)
@@ -241,17 +261,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the data is shared with partner for fingerprint`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = true,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = true,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_share_data_yes)
@@ -262,17 +284,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the data is used for R&D`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = true,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = true,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_collect_yes)
@@ -282,17 +306,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should not add the string when the data is not used for R&D`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_collect_yes)
@@ -302,17 +328,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the privacy right is required`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = true,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = true,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_privacy_rights)
@@ -322,17 +350,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should not add the string when the privacy right is not required`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_privacy_rights)
@@ -342,17 +372,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should add the correct string when the confirmation is required`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = true,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = true,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_confirmation)
@@ -363,17 +395,19 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should not add the string when the confirmation is not required`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = false,
-                dataUsedForRAndD = false,
-                privacyRights = false,
-                confirmation = false,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = false,
+                    dataUsedForRAndD = false,
+                    privacyRights = false,
+                    confirmation = false,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         val expectedString = context
             .getString(R.string.consent_parental_confirmation)
@@ -383,51 +417,57 @@ class ParentalConsentTextHelperTest {
 
     @Test
     fun `should not start a new sentence after a period without a following space`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = true,
-                dataUsedForRAndD = true,
-                privacyRights = true,
-                confirmation = true,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = true,
+                    dataUsedForRAndD = true,
+                    privacyRights = true,
+                    confirmation = true,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         assertThat(parentalConsentText).doesNotContainMatch("\\.\\w")
     }
 
     @Test
     fun `should not start with a space`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = true,
-                dataUsedForRAndD = true,
-                privacyRights = true,
-                confirmation = true,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = true,
+                    dataUsedForRAndD = true,
+                    privacyRights = true,
+                    confirmation = true,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         assertThat(parentalConsentText).doesNotContainMatch("^\\s.*")
     }
 
     @Test
     fun `should not contain double spaces`() {
-        val parentalConsentText = ParentalConsentTextHelper(context).assembleText(
-            configWithPrompt(ConsentConfiguration.ConsentPromptConfiguration(
-                enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
-                dataSharedWithPartner = true,
-                dataUsedForRAndD = true,
-                privacyRights = true,
-                confirmation = true,
-            )),
+        val parentalConsentText = ParentalConsentTextHelper(
+            configWithPrompt(
+                ConsentConfiguration.ConsentPromptConfiguration(
+                    enrolmentVariant = ConsentConfiguration.ConsentEnrolmentVariant.STANDARD,
+                    dataSharedWithPartner = true,
+                    dataUsedForRAndD = true,
+                    privacyRights = true,
+                    confirmation = true,
+                )
+            ),
             listOf(GeneralConfiguration.Modality.FINGERPRINT),
             ConsentType.IDENTIFY,
-        )
+        ).assembleText(context)
 
         assertThat(parentalConsentText).doesNotContain("  ")
     }
@@ -442,4 +482,3 @@ class ParentalConsentTextHelperTest {
         parentalPrompt = prompt,
     )
 }
-


### PR DESCRIPTION
* As per Alex's investigation - When forming the consent text application context was used. The application context is built only on cold start and has English resources loaded regardless of the changed language.
* I flipped the consent text helpers from holding context in the field and receiving data in params to holding configuration in a data class and receiving context as a parameter. The context of the fragment/activity can now be provided when assembling the consent text. 
* The activity context is not stored within the helper and is only used to access the strings so there should be no risk of a memory leak.