### PR TITLE
[MS-697] Ask the user to retry NFC pairing after the tag has left the field

### DIFF
--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/nfcpair/NfcPairViewModel.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/nfcpair/NfcPairViewModel.kt
@@ -1,5 +1,6 @@
 package com.simprints.fingerprint.connect.screens.issues.nfcpair
 
+import android.nfc.TagLostException
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -38,6 +39,10 @@ internal class NfcPairViewModel @Inject constructor(
             _showToastWithStringRes.send(R.string.fingerprint_connect_nfc_pair_toast_try_again)
         } catch (e: IllegalArgumentException) {
             _showToastWithStringRes.send(R.string.fingerprint_connect_nfc_pair_toast_invalid)
+        } catch (e: SecurityException) {
+            _showToastWithStringRes.send(R.string.fingerprint_connect_nfc_pair_toast_try_again)
+        } catch (e: TagLostException) {
+            _showToastWithStringRes.send(R.string.fingerprint_connect_nfc_pair_toast_try_again)
         }
     }
 

--- a/fingerprint/connect/src/test/java/com/simprints/fingerprint/connect/screens/issues/nfcpair/NfcPairViewModelTest.kt
+++ b/fingerprint/connect/src/test/java/com/simprints/fingerprint/connect/screens/issues/nfcpair/NfcPairViewModelTest.kt
@@ -74,6 +74,18 @@ class NfcPairViewModelTest {
         errorObserver.assertEventReceivedWithContent(R.string.fingerprint_connect_nfc_pair_toast_try_again)
     }
 
+    @Test
+    fun `Shows error when tag moved out of field`() {
+        every { nfcManager.readMacAddressDataFromBluetoothEasyPairTag(any()) } returns ADDRESS
+        every { scannerPairingManager.isScannerAddress(any()) } returns true
+        every { scannerPairingManager.startPairingToDevice(any()) } throws SecurityException("Test")
+
+        val errorObserver = viewModel.showToastWithStringRes.testObserver()
+        viewModel.handleNfcTagDetected(mockk())
+
+        errorObserver.assertEventReceivedWithContent(R.string.fingerprint_connect_nfc_pair_toast_try_again)
+    }
+
     companion object {
         private const val ADDRESS = "address"
     }

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/nfc/android/AndroidMifareUltralight.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/nfc/android/AndroidMifareUltralight.kt
@@ -5,7 +5,7 @@ import com.simprints.fingerprint.infra.scanner.nfc.ComponentMifareUltralight
 import java.io.Closeable
 
 internal class AndroidMifareUltralight(
-    val mifare: MifareUltralight
+    private val mifare: MifareUltralight
 ) : ComponentMifareUltralight, Closeable by mifare {
 
     override fun connect() {


### PR DESCRIPTION
Enhance the NFC error handling by catching `TagLostException `and `SecurityException` during NFC operations. Both exceptions can occur when the NFC tag moves out of range or a new tag is detected.