### PR TITLE
[MS-732] Fix ProGuard issue causing release build failure with Hilt modules

### DIFF
--- a/build-logic/proguard-rules.pro
+++ b/build-logic/proguard-rules.pro
@@ -2,3 +2,24 @@
 -dontwarn com.simprints.**
 # Do not obfuscate the simprints package
 -keep class com.simprints.** { *; }
+# Hilt
+-keep class dagger.hilt.** { *; }
+-keep class javax.inject.** { *; }
+-keep class dagger.** { *; }
+
+# Prevent ProGuard from removing @Module, @Inject, @Binds, etc.
+-keep class **Module { *; }
+-keep class **Inject { *; }
+-keep class **Provides { *; }
+-keep class **Binds { *; }
+-keep class **Hilt_** { *; }
+
+# Keep generated Hilt components
+-keep class * implements dagger.hilt.internal.GeneratedComponent { *; }
+
+# Keep classes annotated with @InstallIn to prevent them from being removed
+-keep @dagger.hilt.InstallIn class * { *; }
+
+# Keep Hilt components and related Dagger generated code
+-keep class * extends dagger.hilt.internal.GeneratedComponentManager { *; }
+-keep class * extends dagger.hilt.internal.GeneratedComponent { *; }

--- a/id/proguard-rules.pro
+++ b/id/proguard-rules.pro
@@ -66,3 +66,25 @@
 
 -keep class retrofit2.** { *; }
 -keep interface retrofit2.** { *; }
+
+# Hilt
+-keep class dagger.hilt.** { *; }
+-keep class javax.inject.** { *; }
+-keep class dagger.** { *; }
+
+# Prevent ProGuard from removing @Module, @Inject, @Binds, etc.
+-keep class **Module { *; }
+-keep class **Inject { *; }
+-keep class **Provides { *; }
+-keep class **Binds { *; }
+-keep class **Hilt_** { *; }
+
+# Keep generated Hilt components
+-keep class * implements dagger.hilt.internal.GeneratedComponent { *; }
+
+# Keep classes annotated with @InstallIn to prevent them from being removed
+-keep @dagger.hilt.InstallIn class * { *; }
+
+# Keep Hilt components and related Dagger generated code
+-keep class * extends dagger.hilt.internal.GeneratedComponentManager { *; }
+-keep class * extends dagger.hilt.internal.GeneratedComponent { *; }


### PR DESCRIPTION

This PR fixes the release build failure during ProGuard/R8 minification caused by Hilt-generated classes being stripped. The issue is unrelated to KSP, so I will revert the previous [PR ](https://github.com/Simprints/Android-Simprints-ID/pull/914)addressing KSP.
