### PR TITLE
MS-765 Hide ID pool validation behind a flag

### DIFF
--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCaseTest.kt
@@ -13,6 +13,7 @@ import com.simprints.infra.config.store.models.FingerprintConfiguration.BioSdk.N
 import com.simprints.infra.config.store.models.FingerprintConfiguration.BioSdk.SECUGEN_SIM_MATCHER
 import com.simprints.infra.config.store.models.GeneralConfiguration.Modality
 import com.simprints.infra.config.store.models.ProjectConfiguration
+import com.simprints.infra.config.store.models.experimental
 import com.simprints.infra.orchestration.data.ActionRequest
 import io.mockk.MockKAnnotations
 import io.mockk.every
@@ -139,6 +140,28 @@ class BuildStepsUseCaseTest {
 
         assertStepOrder(steps,
             StepId.SETUP,
+            StepId.CONSENT,
+            StepId.FINGERPRINT_CAPTURE,
+            StepId.FINGERPRINT_CAPTURE,
+            StepId.FACE_CAPTURE,
+            StepId.FINGERPRINT_MATCHER,
+            StepId.FINGERPRINT_MATCHER,
+            StepId.FACE_MATCHER
+        )
+    }
+
+    @Test
+    fun `build - identify action - no age restriction - id pool validation - returns expected steps`() {
+        val projectConfiguration = mockCommonProjectConfiguration()
+
+        val action = mockk<ActionRequest.IdentifyActionRequest>(relaxed = true)
+        every { action.getSubjectAgeIfAvailable() } returns null
+        every { projectConfiguration.experimental().idPoolValidationEnabled } returns true
+
+        val steps = useCase.build(action, projectConfiguration)
+
+        assertStepOrder(steps,
+            StepId.SETUP,
             StepId.VALIDATE_ID_POOL,
             StepId.CONSENT,
             StepId.FINGERPRINT_CAPTURE,
@@ -235,7 +258,6 @@ class BuildStepsUseCaseTest {
 
         assertStepOrder(steps,
             StepId.SETUP,
-            StepId.VALIDATE_ID_POOL,
             StepId.SELECT_SUBJECT_AGE,
             StepId.CONSENT
         )
@@ -325,7 +347,6 @@ class BuildStepsUseCaseTest {
 
         assertStepOrder(steps,
             StepId.SETUP,
-            StepId.VALIDATE_ID_POOL,
             StepId.CONSENT,
             StepId.FINGERPRINT_CAPTURE,
             StepId.FINGERPRINT_CAPTURE,

--- a/infra/auth-logic/src/test/java/com/simprints/infra/authlogic/authenticator/ProjectAuthenticatorTest.kt
+++ b/infra/auth-logic/src/test/java/com/simprints/infra/authlogic/authenticator/ProjectAuthenticatorTest.kt
@@ -173,6 +173,7 @@ class ProjectAuthenticatorTest {
             mockk(),
             mockk(),
             mockk(),
+            mockk(),
         )
         coEvery { configManager.getPrivacyNotice(any(), any()) } returns emptyFlow()
 

--- a/infra/auth-logic/src/test/java/com/simprints/infra/authlogic/authenticator/SignerManagerTest.kt
+++ b/infra/auth-logic/src/test/java/com/simprints/infra/authlogic/authenticator/SignerManagerTest.kt
@@ -231,8 +231,9 @@ internal class SignerManagerTest {
                             tokenizationKeys = emptyMap()
                         ),
                         ProjectConfiguration(
-                            DEFAULT_PROJECT_ID, "", mockk(), mockk(), mockk(), mockk(), mockk(), mockk()
-                        )
+                            DEFAULT_PROJECT_ID, "", mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), null,
+                        ),
+
                     )
                 )
             } else {

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/ConfigLocalDataSourceImpl.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/ConfigLocalDataSourceImpl.kt
@@ -197,6 +197,7 @@ internal class ConfigLocalDataSourceImpl @Inject constructor(
                         maxAge = DEFAULT_DOWN_SYNC_MAX_AGE,
                     ),
                 ),
+                custom = null,
             ).toProto()
         val defaultDeviceConfiguration: ProtoDeviceConfiguration = DeviceConfiguration(
             language = "",

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/models/OldProjectConfig.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/models/OldProjectConfig.kt
@@ -72,6 +72,7 @@ internal data class OldProjectConfig(
             consent = consentConfiguration(),
             identification = identificationConfiguration(),
             synchronization = synchronizationConfiguration(),
+            custom = null,
         )
 
     private fun generalConfiguration(): GeneralConfiguration =

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
@@ -8,4 +8,12 @@ data class ExperimentalProjectConfiguration(
     private val customConfig: Map<String, Any>?,
 ) {
 
+    val idPoolValidationEnabled: Boolean
+        get() = customConfig?.get(ENABLE_ID_POOL_VALIDATION)
+            ?.let { it as? Boolean }
+            .let { it == true }
+
+    companion object {
+        internal const val ENABLE_ID_POOL_VALIDATION = "validateIdentificationPool"
+    }
 }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
@@ -1,0 +1,11 @@
+package com.simprints.infra.config.store.models
+
+/**
+ * Thin wrapper around custom project configuration to keep all the experimental
+ * feature definitions in a single place and make calls explicit and type-safe.
+ */
+data class ExperimentalProjectConfiguration(
+    private val customConfig: Map<String, Any>?,
+) {
+
+}

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ProjectConfiguration.kt
@@ -9,6 +9,7 @@ data class ProjectConfiguration(
     val consent: ConsentConfiguration,
     val identification: IdentificationConfiguration,
     val synchronization: SynchronizationConfiguration,
+    val custom: Map<String, Any>?,
 )
 
 fun ProjectConfiguration.canCoSyncAllData(): Boolean =
@@ -72,3 +73,5 @@ fun ProjectConfiguration.sortedUniqueAgeGroups(): List<AgeGroup> {
 }
 
 fun ProjectConfiguration.isAgeRestricted() = allowedAgeRanges().any { !it.isEmpty()}
+
+fun ProjectConfiguration.experimental(): ExperimentalProjectConfiguration = ExperimentalProjectConfiguration(custom)

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiProjectConfiguration.kt
@@ -13,6 +13,7 @@ internal data class ApiProjectConfiguration(
     val consent: ApiConsentConfiguration,
     val identification: ApiIdentificationConfiguration,
     val synchronization: ApiSynchronizationConfiguration,
+    val custom: Map<String, Any>?,
 ) {
 
     fun toDomain(): ProjectConfiguration = ProjectConfiguration(
@@ -24,5 +25,6 @@ internal data class ApiProjectConfiguration(
         consent.toDomain(),
         identification.toDomain(),
         synchronization.toDomain(),
+        custom,
     )
 }

--- a/infra/config-store/src/main/proto/project_config.proto
+++ b/infra/config-store/src/main/proto/project_config.proto
@@ -12,6 +12,7 @@ message ProtoProjectConfiguration {
     ProtoIdentificationConfiguration identification = 6;
     ProtoSynchronizationConfiguration synchronization = 7;
     string updated_at = 8;
+    optional string customJson = 9;
 }
 
 message ProtoGeneralConfiguration {

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/local/ConfigLocalDataSourceImplTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/local/ConfigLocalDataSourceImplTest.kt
@@ -170,7 +170,8 @@ class ConfigLocalDataSourceImplTest {
                 null,
                 consentConfiguration,
                 identificationConfiguration,
-                synchronizationConfiguration
+                synchronizationConfiguration,
+                null
             )
 
             configLocalDataSourceImpl.saveProjectConfiguration(projectConfigurationToSave)

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/local/models/ProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/local/models/ProjectConfigurationTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.simprints.infra.config.store.testtools.projectConfiguration
 import com.simprints.infra.config.store.testtools.protoProjectConfiguration
 import org.junit.Test
+import java.io.InputStream
 
 class ProjectConfigurationTest {
 
@@ -11,5 +12,21 @@ class ProjectConfigurationTest {
     fun `should map correctly the model`() {
         assertThat(protoProjectConfiguration.toDomain()).isEqualTo(projectConfiguration)
         assertThat(projectConfiguration.toProto()).isEqualTo(protoProjectConfiguration)
+    }
+
+    @Test
+    fun `should ignore broken custom config model`() {
+        assertThat(protoProjectConfiguration.let {
+            it.toBuilder().setCustomJson("{").build()
+        }.toDomain()).isEqualTo(
+            projectConfiguration.copy(custom = null)
+        )
+
+        assertThat(
+            // custom map contains class that Jackson cannot convert to string
+            projectConfiguration.copy(custom = mapOf("test" to InputStream.nullInputStream())).toProto()
+        ).isEqualTo(
+            protoProjectConfiguration.let { it.toBuilder().clearCustomJson().build() }
+        )
     }
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
@@ -1,0 +1,25 @@
+package com.simprints.infra.config.store.models
+
+import com.google.common.truth.Truth.assertThat
+import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.ENABLE_ID_POOL_VALIDATION
+import kotlin.test.Test
+
+internal class ExperimentalProjectConfigurationTest {
+
+    @Test
+    fun `check pool validation flag correctly`() {
+        mapOf<Map<String, Any>, Boolean>(
+            // Value not present
+            emptyMap<String, Any>() to false,
+            // Value not boolean
+            mapOf(ENABLE_ID_POOL_VALIDATION to 1) to false,
+            // Value present and FALSE
+            mapOf(ENABLE_ID_POOL_VALIDATION to false) to false,
+            // Value present and TRUE
+            mapOf(ENABLE_ID_POOL_VALIDATION to true) to true,
+        ).forEach { (config, result) ->
+            assertThat(ExperimentalProjectConfiguration(config).idPoolValidationEnabled).isEqualTo(result)
+        }
+    }
+
+}

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiProjectConfigurationTest.kt
@@ -22,7 +22,8 @@ class ApiProjectConfigurationTest {
             null,
             apiConsentConfiguration,
             apiIdentificationConfiguration,
-            apiSynchronizationConfiguration
+            apiSynchronizationConfiguration,
+            customKeyMap,
         )
         val projectConfiguration = ProjectConfiguration(
             "projectId",
@@ -32,7 +33,8 @@ class ApiProjectConfigurationTest {
             null,
             consentConfiguration,
             identificationConfiguration,
-            synchronizationConfiguration
+            synchronizationConfiguration,
+            customKeyMap,
         )
 
         assertThat(apiProjectConfiguration.toDomain()).isEqualTo(projectConfiguration)

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/testtools/Models.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/testtools/Models.kt
@@ -342,6 +342,14 @@ internal val protoSynchronizationConfiguration = ProtoSynchronizationConfigurati
     )
     .build()
 
+internal val customKeyMap: Map<String, Any>? = mapOf(
+    "key1" to 7,
+    "key2" to 4.2,
+    "key3" to false,
+    "key4" to "test"
+)
+internal const val protoCustomKeyMapJson = "{\"key1\":7,\"key2\":4.2,\"key3\":false,\"key4\":\"test\"}"
+
 internal val apiProjectConfiguration = ApiProjectConfiguration(
     "projectId",
     "updatedAt",
@@ -350,7 +358,8 @@ internal val apiProjectConfiguration = ApiProjectConfiguration(
     apiFingerprintConfiguration,
     apiConsentConfiguration,
     apiIdentificationConfiguration,
-    apiSynchronizationConfiguration
+    apiSynchronizationConfiguration,
+    customKeyMap,
 )
 
 internal val projectConfiguration = ProjectConfiguration(
@@ -361,7 +370,8 @@ internal val projectConfiguration = ProjectConfiguration(
     fingerprintConfiguration,
     consentConfiguration,
     identificationConfiguration,
-    synchronizationConfiguration
+    synchronizationConfiguration,
+    customKeyMap,
 )
 
 internal val protoProjectConfiguration = ProtoProjectConfiguration.newBuilder()
@@ -373,6 +383,7 @@ internal val protoProjectConfiguration = ProtoProjectConfiguration.newBuilder()
     .setConsent(protoConsentConfiguration)
     .setIdentification(protoIdentificationConfiguration)
     .setSynchronization(protoSynchronizationConfiguration)
+    .setCustomJson(protoCustomKeyMapJson)
     .build()
 
 

--- a/infra/sync/src/test/java/com/simprints/infra/sync/config/testtools/Models.kt
+++ b/infra/sync/src/test/java/com/simprints/infra/sync/config/testtools/Models.kt
@@ -117,7 +117,8 @@ internal val projectConfiguration = ProjectConfiguration(
     fingerprintConfiguration,
     consentConfiguration,
     identificationConfiguration,
-    synchronizationConfiguration
+    synchronizationConfiguration,
+    null,
 )
 
 internal const val tokenizationJson =


### PR DESCRIPTION
* Added a mechanism to handle dynamic custom/experimental config safely and explicitly.
* A custom configuration was added to validate ID pool only when required.