### PR TITLE
Revert "Bump android_gradlePlugin_version from 8.6.1 to 8.7.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin_version = "2.0.20"
 kotlin_coroutine_version = "1.9.0"
 ksp_version = "2.0.20-1.0.24"
 
-android_gradlePlugin_version = "8.7.0"
+android_gradlePlugin_version = "8.6.1"
 androidx_version = "1.6.2"
 androidx_core_version = "1.13.1"
 androidx_app_compat_version = "1.7.0"


### PR DESCRIPTION
This reverts commit 29eb051f0ae8a3e95f28945f80b8e32e162f5b9c.

Gradle 8.7 only works on a preview version of AS. 