### PR TITLE
MS-755 Split session logging and mutex

### DIFF
--- a/infra/events/src/test/java/com/simprints/infra/events/session/SessionEventRepositoryImplTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/session/SessionEventRepositoryImplTest.kt
@@ -10,8 +10,10 @@ import com.simprints.infra.events.sampledata.createSessionScope
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -190,6 +192,7 @@ internal class SessionEventRepositoryImplTest {
     @Test
     fun `updates cached event on add or update`() = runTest {
         val event = createEventWithSessionId("eventId", "mockId")
+        sessionDataCache.eventScope = mockk { every { id } returns "updatedEventScopeId" }
         sessionDataCache.eventCache[event.id] = event
         coEvery { eventRepository.addOrUpdateEvent(any(), any(), any()) } returns event.apply {
             this.scopeId = "updatedEventScopeId"


### PR DESCRIPTION
* Added non-fatals to see logs around session creation and restoration
* Locked every event cache interaction with mutex to prevent any potential race condition