### PR TITLE
Fix deadlocks in session cache access

### DIFF
--- a/infra/events/src/main/java/com/simprints/infra/events/session/SessionEventRepositoryImpl.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/session/SessionEventRepositoryImpl.kt
@@ -20,7 +20,69 @@ internal class SessionEventRepositoryImpl @Inject constructor(
 
     private val eventsLock = Mutex()
 
-    override suspend fun createSession(): EventScope = eventsLock.withLock {
+    override suspend fun createSession(): EventScope = withLockedContext {
+        createSessionInternal()
+    }
+
+    override suspend fun saveSessionScope(eventScope: EventScope) = withLockedContext {
+        saveSessionScopeInternal(eventScope)
+    }
+
+    override suspend fun hasOpenSession(): Boolean = withLockedContext {
+        val session = sessionDataCache.eventScope ?: localSessionScope()
+        session != null
+    }
+
+    override suspend fun getCurrentSessionScope(): EventScope = withLockedContext {
+        getCurrentScopeInternal()
+    }
+
+    override suspend fun removeLocationDataFromCurrentSession() = withLockedContext {
+        val sessionScope = getCurrentScopeInternal()
+        if (sessionScope.payload.location != null) {
+            val updatedSessionScope = sessionScope.copy(
+                payload = sessionScope.payload.copy(location = null)
+            )
+            saveSessionScopeInternal(updatedSessionScope)
+        }
+    }
+
+    override suspend fun getEventsInCurrentSession(): List<Event> = withLockedContext {
+        val sessionId = getCurrentScopeInternal().id
+
+        if (sessionDataCache.eventCache.isEmpty()) {
+            loadEventsIntoCache(sessionId)
+        }
+        sessionDataCache.eventCache.values.toList()
+    }
+
+    override suspend fun addOrUpdateEvent(event: Event) = withLockedContext {
+        val currentEvents = sessionDataCache.eventCache.values.toList()
+        val savedEvent = eventRepository.addOrUpdateEvent(
+            getCurrentScopeInternal(),
+            event,
+            currentEvents,
+        )
+        sessionDataCache.eventCache[savedEvent.id] = savedEvent
+    }
+
+    override suspend fun closeCurrentSession(reason: EventScopeEndCause?) = withLockedContext {
+        eventRepository.closeEventScope(getCurrentScopeInternal(), reason)
+        sessionDataCache.eventCache.clear()
+        sessionDataCache.eventScope = null
+    }
+
+    /**
+     * Scope for internal extension functions that must be called within locked context.
+     */
+    private object LockedContext
+
+    private suspend inline fun <T> withLockedContext(
+        crossinline block: suspend LockedContext.() -> T,
+    ) = eventsLock.withLock { LockedContext.block() }
+
+
+    private suspend fun LockedContext.createSessionInternal(): EventScope {
         closeAllSessions(EventScopeEndCause.NEW_SESSION)
         return eventRepository.createEventScope(EventScopeType.SESSION).also { sessionScope ->
             sessionDataCache.eventScope = sessionScope
@@ -28,26 +90,14 @@ internal class SessionEventRepositoryImpl @Inject constructor(
         }
     }
 
-    /**
-     * If the session is closing for normal reasons (i.e. came to a normal end), then it should be `null`.
-     */
-    private suspend fun closeAllSessions(reason: EventScopeEndCause?) {
-        eventRepository.closeAllOpenScopes(EventScopeType.SESSION, reason)
-    }
-
-    override suspend fun saveSessionScope(eventScope: EventScope) = eventsLock.withLock {
+    private suspend fun LockedContext.saveSessionScopeInternal(eventScope: EventScope) {
         if (eventScope.id == sessionDataCache.eventScope?.id) {
             sessionDataCache.eventScope = eventScope
         }
         eventRepository.saveEventScope(eventScope)
     }
 
-    override suspend fun hasOpenSession(): Boolean {
-        val session = sessionDataCache.eventScope ?: localSessionScope()
-        return session != null
-    }
-
-    override suspend fun getCurrentSessionScope(): EventScope {
+    private suspend fun LockedContext.getCurrentScopeInternal(): EventScope {
         val cachedScope = sessionDataCache.eventScope
         if (cachedScope != null) return cachedScope
 
@@ -58,60 +108,26 @@ internal class SessionEventRepositoryImpl @Inject constructor(
         }
 
         Simber.w("Creating new session DB")
-        return createSession()
+        return createSessionInternal()
     }
 
-    override suspend fun removeLocationDataFromCurrentSession() {
-        val sessionScope = getCurrentSessionScope()
-        if (sessionScope.payload.location != null) {
-            val updatedSessionScope = sessionScope.copy(
-                payload = sessionScope.payload.copy(location = null)
-            )
-            saveSessionScope(updatedSessionScope)
-        }
-    }
-
-    override suspend fun getEventsInCurrentSession(): List<Event> {
-        val sessionId = getCurrentSessionScope().id
-        return eventsLock.withLock {
-            if (sessionDataCache.eventCache.isEmpty()) {
-                loadEventsIntoCache(sessionId)
-            }
-            sessionDataCache.eventCache.values.toList()
-        }
-    }
-
-    override suspend fun addOrUpdateEvent(event: Event) = eventsLock.withLock {
-        val currentEvents = sessionDataCache.eventCache.values.toList()
-        val savedEvent = eventRepository.addOrUpdateEvent(
-            getCurrentSessionScope(),
-            event,
-            currentEvents
-        )
-        sessionDataCache.eventCache[savedEvent.id] = savedEvent
-    }
-
-    private suspend fun localSessionScope() = eventRepository
+    private suspend fun LockedContext.localSessionScope() = eventRepository
         .getOpenEventScopes(EventScopeType.SESSION)
         .firstOrNull()
         ?.also { session ->
-            eventsLock.withLock {
-                sessionDataCache.eventScope = session
-                loadEventsIntoCache(session.id)
-            }
+            sessionDataCache.eventScope = session
+            loadEventsIntoCache(session.id)
         }
 
-    private suspend fun loadEventsIntoCache(sessionId: String) {
+    private suspend fun LockedContext.loadEventsIntoCache(sessionId: String) {
         sessionDataCache.eventCache.clear()
-        eventRepository.getEventsFromScope(sessionId)
-            .forEach { sessionDataCache.eventCache[it.id] = it }
+        eventRepository.getEventsFromScope(sessionId).forEach { sessionDataCache.eventCache[it.id] = it }
     }
 
-    override suspend fun closeCurrentSession(reason: EventScopeEndCause?) = eventsLock.withLock {
-        val session = getCurrentSessionScope()
-        eventRepository.closeEventScope(session, reason)
-
-        sessionDataCache.eventScope = null
-        sessionDataCache.eventCache.clear()
+    /**
+     * If the session is closing for normal reasons (i.e. came to a normal end), then it should be `null`.
+     */
+    private suspend fun LockedContext.closeAllSessions(reason: EventScopeEndCause?) {
+        eventRepository.closeAllOpenScopes(EventScopeType.SESSION, reason)
     }
 }


### PR DESCRIPTION
* Ensured that locked data is not accessed from within the already locked code block by explicitly separating synchronised and unsynchronised methods.
* Added an empty method scope to explicitly mark methods that should be called from locked context.