### PR TITLE
[MS-778] Switch from tryEmit to emit in FingerprintScanningStatusTracer

### DIFF
--- a/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/screen/ObserveFingerprintScanStatusUseCaseTest.kt
+++ b/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/screen/ObserveFingerprintScanStatusUseCaseTest.kt
@@ -28,7 +28,6 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class ObserveFingerprintScanStatusUseCaseTest {
 
-
     private lateinit var tracker: FingerprintScanningStatusTracker
 
     @RelaxedMockK
@@ -49,7 +48,6 @@ class ObserveFingerprintScanStatusUseCaseTest {
     @MockK
     private lateinit var sharedPreferences: SharedPreferences
 
-
     private lateinit var observeFingerprintScanStatus: ObserveFingerprintScanStatusUseCase
     private val testDispatcher = UnconfinedTestDispatcher()
 
@@ -59,7 +57,7 @@ class ObserveFingerprintScanStatusUseCaseTest {
         mockkStatic(MediaPlayer::class)
         mockkStatic(PreferenceManager::class)
         every { PreferenceManager.getDefaultSharedPreferences(context) } returns sharedPreferences
-        tracker = FingerprintScanningStatusTracker()
+        tracker = FingerprintScanningStatusTracker(testDispatcher)
 
         observeFingerprintScanStatus = ObserveFingerprintScanStatusUseCase(
             tracker, playAudioBeep, configManager, scannerManager, context
@@ -86,7 +84,6 @@ class ObserveFingerprintScanStatusUseCaseTest {
             coVerify { scannerManager.scanner.turnOffSmileLeds() }
 
         }
-
 
     @Test
     fun `playBeep should not be called when scan completes and audio is disabled`() =
@@ -119,39 +116,37 @@ class ObserveFingerprintScanStatusUseCaseTest {
     }
 
     @Test
-    fun `setUiGoodCapture should be called when image quality is good`() =
-        runTest(testDispatcher) {
-            // Given
-            every { sharedPreferences.getBoolean(any(), any()) } returns true
+    fun `setUiGoodCapture should be called when image quality is good`() = runTest(testDispatcher) {
+        // Given
+        every { sharedPreferences.getBoolean(any(), any()) } returns true
 
-            observeFingerprintScanStatus(this.backgroundScope, fingerprintSdk)
-            // Simulate the previous state as ScanCompleted to allow UI change
-            tracker.completeScan()
+        observeFingerprintScanStatus(this.backgroundScope, fingerprintSdk)
+        // Simulate the previous state as ScanCompleted to allow UI change
+        tracker.completeScan()
 
-            // When
-            tracker.setImageQualityCheckingResult(true)
-            observeFingerprintScanStatus.stopObserving()
+        // When
+        tracker.setImageQualityCheckingResult(true)
+        observeFingerprintScanStatus.stopObserving()
 
-            // Then
-            coVerify { scannerManager.scanner.setUiGoodCapture() }
-        }
+        // Then
+        coVerify { scannerManager.scanner.setUiGoodCapture() }
+    }
 
     @Test
-    fun `setUiBadCapture should be called when image quality is bad`() =
-        runTest(testDispatcher) {
-            // Given
-            every { sharedPreferences.getBoolean(any(), any()) } returns true
+    fun `setUiBadCapture should be called when image quality is bad`() = runTest(testDispatcher) {
+        // Given
+        every { sharedPreferences.getBoolean(any(), any()) } returns true
 
-            observeFingerprintScanStatus(this.backgroundScope, fingerprintSdk)
-            // Simulate the previous state as ScanCompleted to allow UI change
-            tracker.completeScan()
+        observeFingerprintScanStatus(this.backgroundScope, fingerprintSdk)
+        // Simulate the previous state as ScanCompleted to allow UI change
+        tracker.completeScan()
 
-            // When
-            tracker.setImageQualityCheckingResult(false)
-            observeFingerprintScanStatus.stopObserving()
-            // Then
-            coVerify { scannerManager.scanner.setUiBadCapture() }
-        }
+        // When
+        tracker.setImageQualityCheckingResult(false)
+        observeFingerprintScanStatus.stopObserving()
+        // Then
+        coVerify { scannerManager.scanner.setUiBadCapture() }
+    }
 
     @Test
     fun `turnFlashingLedsOn should be called when state is Idle and VISUAL_SCAN_FEEDBACK is enabled`() =
@@ -192,6 +187,5 @@ class ObserveFingerprintScanStatusUseCaseTest {
             // Then
             coVerify(exactly = 0) { scannerManager.scanner.turnFlashingOrangeLeds() }
         }
-
 
 }

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintScanningStatusTracker.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintScanningStatusTracker.kt
@@ -1,36 +1,41 @@
 package com.simprints.fingerprint.infra.scanner.capture
 
+import com.simprints.core.DispatcherBG
 import com.simprints.fingerprint.infra.scanner.capture.FingerprintScanState.Idle
 import com.simprints.fingerprint.infra.scanner.capture.FingerprintScanState.ImageQualityChecking.Bad
 import com.simprints.fingerprint.infra.scanner.capture.FingerprintScanState.ImageQualityChecking.Good
 import com.simprints.fingerprint.infra.scanner.capture.FingerprintScanState.ScanCompleted
 import com.simprints.fingerprint.infra.scanner.capture.FingerprintScanState.Scanning
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
 
 @Singleton
-class FingerprintScanningStatusTracker @Inject constructor() {
+class FingerprintScanningStatusTracker @Inject constructor(
+    @DispatcherBG private val dispatcherBG: CoroutineDispatcher
+) {
+    private val coroutineScope = CoroutineScope(dispatcherBG)
     private val _state =
         MutableSharedFlow<FingerprintScanState>(replay = 1, extraBufferCapacity = 1)
     val state: SharedFlow<FingerprintScanState> = _state
 
-    fun startScanning() {
-        _state.tryEmit(Scanning)
-    }
+    fun startScanning() = emitState(Scanning)
 
-    fun completeScan() {
-        _state.tryEmit(ScanCompleted)
-    }
+    fun completeScan() = emitState(ScanCompleted)
 
-    fun setImageQualityCheckingResult(isQualityOk: Boolean) {
-        _state.tryEmit(if (isQualityOk) Good else Bad)
-    }
+    fun setImageQualityCheckingResult(isQualityOk: Boolean) =
+        emitState(if (isQualityOk) Good else Bad)
 
-    fun resetToIdle() {
-    _state.tryEmit(Idle)
+    fun resetToIdle() = emitState(Idle)
+
+    fun emitState(state: FingerprintScanState) {
+        coroutineScope.launch {
+            _state.emit(state)
+        }
     }
 }
-

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintScanningStatusTrackerTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/capture/FingerprintScanningStatusTrackerTest.kt
@@ -3,6 +3,7 @@ package com.simprints.fingerprint.infra.scanner.capture
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -14,7 +15,7 @@ class FingerprintScanningStatusTrackerTest {
 
     @Before
     fun setup() {
-        tracker = FingerprintScanningStatusTracker()
+        tracker = FingerprintScanningStatusTracker(UnconfinedTestDispatcher())
     }
 
     @Test


### PR DESCRIPTION
Changed `tryEmit` to `emit` in to ensure reliable state updates. `tryEmit` may drop updates under high concurrency or backpressure, while `emit` suspends until the emission completes, guaranteeing consistent delivery of state changes.