### PR TITLE
SM-782 Sync card crash fix

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncViewModel.kt
@@ -100,8 +100,14 @@ internal class SyncViewModel @Inject constructor(
         _signOutEventLiveData.addSource(_syncCardLiveData) { cardState ->
             viewModelScope.launch {
                 val isSyncComplete = cardState is SyncComplete
-                val isProjectEnding =
+                val isProjectEnding = try {
                     configManager.getProject(authStore.signedInProjectId).state == ProjectState.PROJECT_ENDING
+                } catch (e: Throwable) {
+                    // When the device is compromised the project data will be deleted and
+                    // attempting to access project state with result in exception.
+                    // For user it is essentially the same as project ending.
+                    true
+                }
 
                 if (isSyncComplete && isProjectEnding) {
                     viewModelScope.launch {


### PR DESCRIPTION
* If SID is open during project/device configuration sync on a compromised device, the project state may be requested after everything has been deleted. 
* To avoid large config manager and auth repo rework we can just consider the "non-reachable" project state as the project ending and force log out.