### PR TITLE
MS-784 Removing redundant data refreshes

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
@@ -41,7 +41,6 @@ internal class SyncInfoFragment : Fragment(R.layout.fragment_sync_info) {
         binding.selectedModulesView.adapter = moduleCountAdapter
         setupClickListeners()
         observeUI()
-        viewModel.refreshInformation()
 
         findNavController().handleResult<LoginResult>(
             viewLifecycleOwner,

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
@@ -26,7 +26,6 @@ import com.simprints.infra.events.event.domain.models.EventType
 import com.simprints.infra.eventsync.EventSyncManager
 import com.simprints.infra.eventsync.status.models.DownSyncCounts
 import com.simprints.infra.eventsync.status.models.EventSyncState
-import com.simprints.infra.eventsync.status.models.EventSyncWorkerState
 import com.simprints.infra.images.ImageRepository
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.ConnectivityTracker
@@ -49,7 +48,7 @@ internal class SyncInfoViewModel @Inject constructor(
     private val eventSyncManager: EventSyncManager,
     private val syncOrchestrator: SyncOrchestrator,
     private val tokenizationProcessor: TokenizationProcessor,
-    private val recentUserActivityManager: RecentUserActivityManager
+    private val recentUserActivityManager: RecentUserActivityManager,
 ) : ViewModel() {
 
     val recordsInLocal: LiveData<Int?>
@@ -150,9 +149,7 @@ internal class SyncInfoViewModel @Inject constructor(
      */
     fun fetchSyncInformationIfNeeded(eventSyncState: EventSyncState) {
         if (eventSyncState != lastKnownEventSyncState) {
-            val workers = eventSyncState.downSyncWorkersInfo + eventSyncState.upSyncWorkersInfo
-            val unfinishedWorkers = workers.filter { it.state != EventSyncWorkerState.Succeeded }
-            if (unfinishedWorkers.isEmpty()) {
+            if (eventSyncState.isSyncCompleted() && eventSyncState.isSyncReporterCompleted()) {
                 load()
             }
 


### PR DESCRIPTION
* Removed pre-emptive refresh call on the view creation - it gets called on the first state update anyway.
* Tighten the sync completion check to prevent unnecessary calls. 