### PR TITLE
Fix enrol last enrolment records after additional capture

### DIFF
--- a/feature/enrol-last-biometric/src/main/java/com/simprints/feature/enrollast/screen/EnrolLastBiometricViewModel.kt
+++ b/feature/enrol-last-biometric/src/main/java/com/simprints/feature/enrollast/screen/EnrolLastBiometricViewModel.kt
@@ -92,6 +92,7 @@ internal class EnrolLastBiometricViewModel @Inject constructor(
 
         val personCreationEvent = eventRepository.getEventsInCurrentSession()
             .filterIsInstance<PersonCreationEvent>()
+            .sortedByDescending { it.payload.createdAt }
             .first()
 
         eventRepository.addOrUpdateEvent(EnrolmentEventV2(

--- a/feature/enrol-last-biometric/src/test/java/com/simprints/feature/enrollast/screen/EnrolLastBiometricViewModelTest.kt
+++ b/feature/enrol-last-biometric/src/test/java/com/simprints/feature/enrollast/screen/EnrolLastBiometricViewModelTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.jraska.livedata.test
 import com.simprints.core.domain.tokenization.asTokenizableRaw
 import com.simprints.core.tools.time.TimeHelper
+import com.simprints.core.tools.time.Timestamp
 import com.simprints.feature.enrollast.EnrolLastBiometricParams
 import com.simprints.feature.enrollast.EnrolLastBiometricStepResult
 import com.simprints.feature.enrollast.screen.usecase.BuildSubjectUseCase
@@ -14,7 +15,9 @@ import com.simprints.infra.config.sync.ConfigManager
 import com.simprints.infra.enrolment.records.store.EnrolmentRecordRepository
 import com.simprints.infra.enrolment.records.store.domain.models.Subject
 import com.simprints.infra.events.SessionEventRepository
+import com.simprints.infra.events.event.domain.models.EnrolmentEventV2
 import com.simprints.infra.events.event.domain.models.PersonCreationEvent
+import com.simprints.infra.events.event.domain.models.PersonCreationEvent.PersonCreationPayload
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -186,6 +189,33 @@ internal class EnrolLastBiometricViewModelTest {
         val result =
             viewModel.finish.test().value().getContentIfNotHandled() as EnrolLastState.Failed
         assertThat(result.errorType).isEqualTo(EnrolLastState.ErrorType.GENERAL_ERROR)
+    }
+
+    @Test
+    fun `Uses latest PersonCreationEvent for Enrolment event`() = runTest {
+        val personCreationEvent1 = mockk<PersonCreationEvent> {
+            every { id } returns "personCreationEventId1"
+            every { payload } returns mockk<PersonCreationPayload> {
+                every { createdAt } returns Timestamp(1)
+            }
+        }
+        val personCreationId2 = "personCreationEventId2"
+        val personCreationEvent2 = mockk<PersonCreationEvent> {
+            every { id } returns personCreationId2
+            every { payload } returns mockk<PersonCreationPayload> {
+                every { createdAt } returns Timestamp(2)
+            }
+        }
+        coEvery { eventRepository.getEventsInCurrentSession() } returns listOf(
+            personCreationEvent1,
+            personCreationEvent2
+        )
+
+        viewModel.enrolBiometric(createParams(listOf()))
+
+        coVerify { eventRepository.addOrUpdateEvent(
+            match { it is EnrolmentEventV2 && it.payload.personCreationEventId == personCreationId2 }
+        ) }
     }
 
     private fun createParams(steps: List<EnrolLastBiometricStepResult>) = EnrolLastBiometricParams(

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/CreatePersonEventUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/CreatePersonEventUseCase.kt
@@ -21,6 +21,7 @@ internal class CreatePersonEventUseCase @Inject constructor(
         val sessionEvents = eventRepository.getEventsInCurrentSession()
         val previousPersonCreationEvent = sessionEvents
             .filterIsInstance<PersonCreationEvent>()
+            .sortedByDescending { it.payload.createdAt }
             .firstOrNull()
 
         val faceCaptures = extractFaceCaptures(results)

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/EnrolSubjectUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/EnrolSubjectUseCase.kt
@@ -17,7 +17,9 @@ internal class EnrolSubjectUseCase @Inject constructor(
 
     suspend operator fun invoke(subject: Subject) {
         val personCreationEvent = eventRepository.getEventsInCurrentSession()
-            .filterIsInstance<PersonCreationEvent>().first()
+            .filterIsInstance<PersonCreationEvent>()
+            .sortedByDescending { it.payload.createdAt }
+            .first()
 
         eventRepository.addOrUpdateEvent(EnrolmentEventV2(
             timeHelper.now(),


### PR DESCRIPTION
There were two issues:
1. Events in the event cache are not ordered and getting the latest PersonCreation event was not guaranteed
2. In cases where Enrol Last has to capture a missing biometric, the new capture steps were not added to the params and consequently missing from the local enrolment record