### PR TITLE
[MS-817] Fix for Jackson-caused unwanted attribute serialization in AgeGroup

### DIFF
--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/cache/OrchestratorCacheTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/cache/OrchestratorCacheTest.kt
@@ -13,6 +13,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
+import com.google.common.truth.Truth.assertThat
 
 class OrchestratorCacheTest {
 
@@ -106,5 +107,16 @@ class OrchestratorCacheTest {
 
         verify(exactly = 1) { prefs.edit().remove("steps") }
         verify(exactly = 1) { prefs.edit().remove("age_group") }
+    }
+
+    @Test
+    fun `AgeGroup is serialized by Jackson without addition of phantom attributes`() {
+        // see Jackson unwanted attribute serialization bug https://stackoverflow.com/questions/69616587/why-does-jackson-add-an-empty-false-into-the-json
+        val realJsonHelper = JsonHelper
+        val originalAgeGroup = AgeGroup(startInclusive = 0, endExclusive = 1)
+
+        val json = realJsonHelper.toJson(originalAgeGroup)
+
+        assertThat(json).isEqualTo("{\"startInclusive\":0,\"endExclusive\":1}")
     }
 }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/AgeGroup.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/AgeGroup.kt
@@ -1,6 +1,7 @@
 package com.simprints.infra.config.store.models
 
 import androidx.annotation.Keep
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.io.Serializable
 
@@ -9,6 +10,7 @@ data class AgeGroup(
     @JsonProperty("startInclusive") val startInclusive: Int,
     @JsonProperty("endExclusive") val endExclusive: Int?,
 ) : Serializable {
+    @JsonIgnore // prevents Jackson isEmpty unwanted serialization bug, see https://stackoverflow.com/questions/69616587/why-does-jackson-add-an-empty-false-into-the-json
     fun isEmpty() = startInclusive == 0 && (endExclusive == null || endExclusive == 0)
 
     fun includes(age: Int): Boolean {


### PR DESCRIPTION
`AgeGroup` has an `isEmpty` method, which was unexpectedly serialized by Jackson, and is now explicitly excluded from serialization.

See https://stackoverflow.com/questions/69616587/why-does-jackson-add-an-empty-false-into-the-json

Credits to @BurningAXE for finding the root cause.