### PR TITLE
[MS-816] Yellow alert screen background dimmed for better text readability

### DIFF
--- a/infra/resources/src/main/res/values/colors.xml
+++ b/infra/resources/src/main/res/values/colors.xml
@@ -13,7 +13,7 @@
 
     <color name="simprints_orange">#FF7C00</color>
     <color name="simprints_orange_dark">#CC6300</color>
-    <color name="simprints_yellow">#ffcc00</color>
+    <color name="simprints_yellow">#bf9900</color>
 
     <color name="simprints_white">#ffffff</color>
     <color name="simprints_off_white">#FFEEEEEE</color>


### PR DESCRIPTION
Brightness level for yellow Alert screen reduced by 25% to ease white text reading. This is the only use of the yellow color in the app.