### PR TITLE
MS-825 Ignore image transfer cancellation exception to avoid breaking user flow

### DIFF
--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
@@ -164,7 +165,7 @@ internal class FingerprintCaptureViewModel @Inject constructor(
 
     private fun start(
         fingerprintsToCapture: List<IFingerIdentifier>,
-        fingerprintSdk: FingerprintConfiguration.BioSdk
+        fingerprintSdk: FingerprintConfiguration.BioSdk,
     ) {
         if (!hasStarted) {
             hasStarted = true
@@ -403,7 +404,11 @@ internal class FingerprintCaptureViewModel @Inject constructor(
         imageTransferTask = viewModelScope.launch {
             try {
                 val acquiredImage = bioSdkWrapper.acquireFingerprintImage()
-                handleImageTransferSuccess(acquiredImage)
+                if (isActive) {
+                    handleImageTransferSuccess(acquiredImage)
+                }
+            } catch (_: CancellationException) {
+                // No-op - This is expected when job is cancelled manually, i.e. by back press
             } catch (ex: Throwable) {
                 handleScannerCommunicationsError(ex)
             }
@@ -665,7 +670,7 @@ internal class FingerprintCaptureViewModel @Inject constructor(
 
     fun handleOnViewCreated(
         fingerprintsToCapture: List<IFingerIdentifier>,
-        fingerprintSdk: FingerprintConfiguration.BioSdk
+        fingerprintSdk: FingerprintConfiguration.BioSdk,
     ) {
         updateState {
             it.copy(


### PR DESCRIPTION
* Cancellation exception is expected when the task is cancelled, so no extra error handling is required - UI is automatically reset to a starting state.