### PR TITLE
[MS-824] Move image quality tracking to occur after image transfer

### DIFF
--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
@@ -372,11 +372,12 @@ internal class FingerprintCaptureViewModel @Inject constructor(
             qualityThreshold = qualityThreshold()
         )
         _vibrate.send()
-        tracker.setImageQualityCheckingResult(scanResult.qualityScore >= qualityThreshold())
+
         if (shouldProceedToImageTransfer(scanResult.qualityScore)) {
             updateCaptureState { it.toTransferringImage(scanResult) }
             proceedToImageTransfer()
         } else {
+            tracker.setImageQualityCheckingResult(scanResult.qualityScore >= qualityThreshold())
             updateCaptureState { it.toCollected(scanResult) }
             handleCaptureFinished()
         }
@@ -410,7 +411,11 @@ internal class FingerprintCaptureViewModel @Inject constructor(
 
     private fun handleImageTransferSuccess(acquireFingerprintImageResponse: AcquireFingerprintImageResponse) {
         _vibrate.send()
-        updateCaptureState { it.toCollected(acquireFingerprintImageResponse.imageBytes) }
+        updateCaptureState {
+            it.toCollected(acquireFingerprintImageResponse.imageBytes).also { captureState ->
+                tracker.setImageQualityCheckingResult(captureState.scanResult.qualityScore >= qualityThreshold())
+            }
+        }
         handleCaptureFinished()
     }
 


### PR DESCRIPTION
The image quality tracking logic has been moved to execute after the image transfer is complete. This change addresses an issue where SID attempted to update the LEDs (green/red) during the image transfer process, causing conflicts.

As a result, the LEDs will now indicate quality (green/red) only after the transfer is finished. This is an acceptable trade-off since SID already provides clear signals to inform the user when to remove their finger, as well as when the scanner is idle or actively scanning.