### PR TITLE
Refresh full project configuration when requested

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsViewModel.kt
@@ -57,6 +57,7 @@ internal class SettingsViewModel @Inject constructor(
     }
 
     fun scheduleConfigUpdate() {
+        syncOrchestrator.startProjectSync()
         syncOrchestrator.startDeviceSync()
     }
 }

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/SettingsViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/SettingsViewModelTest.kt
@@ -87,6 +87,7 @@ class SettingsViewModelTest {
     fun `trigger device sync when called`() {
         viewModel.scheduleConfigUpdate()
 
+        verify { syncOrchestrator.startProjectSync() }
         verify { syncOrchestrator.startDeviceSync() }
     }
 

--- a/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestrator.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestrator.kt
@@ -5,6 +5,7 @@ interface SyncOrchestrator {
     suspend fun scheduleBackgroundWork()
     suspend fun cancelBackgroundWork()
 
+    fun startProjectSync()
     fun startDeviceSync()
 
     fun rescheduleEventSync()

--- a/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestratorImpl.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestratorImpl.kt
@@ -91,6 +91,10 @@ internal class SyncOrchestratorImpl @Inject constructor(
         stopEventSync()
     }
 
+    override fun startProjectSync() {
+        workManager.startWorker<ProjectConfigDownSyncWorker>(SyncConstants.PROJECT_SYNC_WORK_NAME)
+    }
+
     override fun startDeviceSync() {
         workManager.startWorker<DeviceConfigDownSyncWorker>(SyncConstants.DEVICE_SYNC_WORK_NAME_ONE_TIME)
     }


### PR DESCRIPTION
* It only update the device state (compromised or not), which is not the intended use of the button.
* I noticed this while implementing MS-802, but it is not directly related to the task itself.