### PR TITLE
MS-804 Troubleshooting event scope log

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/StubFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/StubFragment.kt
@@ -1,7 +1,0 @@
-package com.simprints.feature.dashboard.settings.troubleshooting
-
-import androidx.fragment.app.Fragment
-import com.simprints.feature.dashboard.R
-
-// TODO remove once few tab fragments are implemented
-class StubFragment : Fragment(R.layout.fragment_troubleshooting_stub)

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/TroubleshootingPagerAdapter.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/TroubleshootingPagerAdapter.kt
@@ -3,6 +3,7 @@ package com.simprints.feature.dashboard.settings.troubleshooting
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.simprints.feature.dashboard.settings.troubleshooting.events.EventScopeLogFragment
 import com.simprints.feature.dashboard.settings.troubleshooting.overview.OverviewFragment
 import com.simprints.infra.uibase.annotations.ExcludedFromGeneratedTestCoverageReports
 
@@ -20,10 +21,7 @@ internal class TroubleshootingPagerAdapter(
         val factory: () -> Fragment,
     ) {
 
-        // TODO Replace stub fragments with proper ones
         Overview("Overview", { OverviewFragment() }),
-        Events("Events", { StubFragment() }),
-        Workers("Worker log", { StubFragment() }),
-        ;
+        Events("Event scopes", { EventScopeLogFragment() }),
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/adapter/TroubleshootingItemViewData.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/adapter/TroubleshootingItemViewData.kt
@@ -1,0 +1,8 @@
+package com.simprints.feature.dashboard.settings.troubleshooting.adapter
+
+data class TroubleshootingItemViewData(
+    val title: String,
+    val subtitle: String = "",
+    val body: String = "",
+    val navigationId: String? = null,
+)

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/adapter/TroubleshootingListAdapter.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/adapter/TroubleshootingListAdapter.kt
@@ -2,10 +2,12 @@ package com.simprints.feature.dashboard.settings.troubleshooting.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
 import com.simprints.feature.dashboard.databinding.ItemTroubleshootingListBinding
+import com.simprints.infra.uibase.system.Clipboard
 
 
 @ExcludedFromGeneratedTestCoverageReports("UI classes are not unit tested")
@@ -31,14 +33,20 @@ internal class TroubleshootingListAdapter(
         private val binding: ItemTroubleshootingListBinding
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(event: TroubleshootingItemViewData) {
-            binding.troubleshootingItemTitle.text = event.title
-            binding.troubleshootingItemSubtitle.text = event.subtitle
-            binding.troubleshootingItemBody.text = event.body
+        fun bind(item: TroubleshootingItemViewData) {
+            binding.troubleshootingItemTitle.text = item.title
+            binding.troubleshootingItemSubtitle.text = item.subtitle
+            binding.troubleshootingItemBody.text = item.body
 
-            binding.troubleshootingItemButton.isVisible = event.navigationId != null
+            binding.troubleshootingItemButton.isVisible = item.navigationId != null
             binding.troubleshootingItemButton.setOnClickListener {
-                event.navigationId?.let(onMoreClick)
+                item.navigationId?.let(onMoreClick)
+            }
+
+            binding.troubleshootingItemCopy.setOnClickListener {
+                val context = binding.root.context
+                Clipboard.copyToClipboard(context, "${item.title}\n${item.subtitle}\n${item.body}")
+                Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/adapter/TroubleshootingListAdapter.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/adapter/TroubleshootingListAdapter.kt
@@ -1,0 +1,45 @@
+package com.simprints.feature.dashboard.settings.troubleshooting.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
+import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
+import com.simprints.feature.dashboard.databinding.ItemTroubleshootingListBinding
+
+
+@ExcludedFromGeneratedTestCoverageReports("UI classes are not unit tested")
+internal class TroubleshootingListAdapter(
+    private val items: List<TroubleshootingItemViewData>,
+    private val onMoreClick: (String) -> Unit = {},
+) : RecyclerView.Adapter<TroubleshootingListAdapter.ViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val layoutInflater = LayoutInflater.from(parent.context)
+        val binding = ItemTroubleshootingListBinding.inflate(layoutInflater, parent, false)
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    @ExcludedFromGeneratedTestCoverageReports("UI classes are not unit tested")
+    inner class ViewHolder(
+        private val binding: ItemTroubleshootingListBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(event: TroubleshootingItemViewData) {
+            binding.troubleshootingItemTitle.text = event.title
+            binding.troubleshootingItemSubtitle.text = event.subtitle
+            binding.troubleshootingItemBody.text = event.body
+
+            binding.troubleshootingItemButton.isVisible = event.navigationId != null
+            binding.troubleshootingItemButton.setOnClickListener {
+                event.navigationId?.let(onMoreClick)
+            }
+        }
+    }
+}

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/events/EventLogFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/events/EventLogFragment.kt
@@ -1,0 +1,38 @@
+package com.simprints.feature.dashboard.settings.troubleshooting.events
+
+import android.os.Bundle
+import android.view.View
+import androidx.core.view.isGone
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.simprints.feature.dashboard.R
+import com.simprints.feature.dashboard.databinding.FragmentTroubleshootingStandaloneListBinding
+import com.simprints.feature.dashboard.settings.troubleshooting.adapter.TroubleshootingListAdapter
+import com.simprints.infra.uibase.viewbinding.viewBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+internal class EventLogFragment : Fragment(R.layout.fragment_troubleshooting_standalone_list) {
+
+    private val args by navArgs<EventLogFragmentArgs>()
+
+    private val viewModel by viewModels<EventsLogViewModel>()
+    private val binding by viewBinding(FragmentTroubleshootingStandaloneListBinding::bind)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.troubleshootingToolbar.title = args.scopeId
+        binding.troubleshootingToolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
+
+        viewModel.events.observe(viewLifecycleOwner) {
+            binding.troubleshootingListProgress.isGone = it.isNotEmpty()
+            binding.troubleshootingList.adapter = TroubleshootingListAdapter(it)
+        }
+        viewModel.collectEvents(args.scopeId)
+    }
+}

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/events/EventScopeLogFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/events/EventScopeLogFragment.kt
@@ -1,0 +1,39 @@
+package com.simprints.feature.dashboard.settings.troubleshooting.events
+
+import android.os.Bundle
+import android.view.View
+import androidx.core.view.isGone
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.simprints.feature.dashboard.R
+import com.simprints.feature.dashboard.databinding.FragmentTroubleshootingListBinding
+import com.simprints.feature.dashboard.settings.troubleshooting.TroubleshootingFragmentDirections
+import com.simprints.feature.dashboard.settings.troubleshooting.adapter.TroubleshootingListAdapter
+import com.simprints.infra.uibase.viewbinding.viewBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+internal class EventScopeLogFragment : Fragment(R.layout.fragment_troubleshooting_list) {
+
+    private val viewModel by viewModels<EventsLogViewModel>()
+    private val binding by viewBinding(FragmentTroubleshootingListBinding::bind)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewModel.scopes.observe(viewLifecycleOwner) {
+            binding.troubleshootingListProgress.isGone = it.isNotEmpty()
+            binding.troubleshootingList.adapter =
+                TroubleshootingListAdapter(it) { openEventsList(it) }
+        }
+        viewModel.collectEventScopes()
+    }
+
+    private fun openEventsList(scopeId: String) {
+        findNavController().navigate(
+            TroubleshootingFragmentDirections
+                .actionTroubleshootingFragmentToTroubleshootingEventLogFragment(scopeId)
+        )
+    }
+}

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/events/EventsLogViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/events/EventsLogViewModel.kt
@@ -1,0 +1,72 @@
+package com.simprints.feature.dashboard.settings.troubleshooting.events
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.simprints.feature.dashboard.settings.troubleshooting.adapter.TroubleshootingItemViewData
+import com.simprints.infra.events.EventRepository
+import com.simprints.infra.events.event.domain.models.Event
+import com.simprints.infra.events.event.domain.models.scope.EventScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import java.util.Date
+import javax.inject.Inject
+
+@HiltViewModel
+internal class EventsLogViewModel @Inject constructor(
+    private val eventRepository: EventRepository,
+) : ViewModel() {
+
+    private val _scopes = MutableLiveData<List<TroubleshootingItemViewData>>(emptyList())
+    val scopes: LiveData<List<TroubleshootingItemViewData>>
+        get() = _scopes
+
+    private val _events = MutableLiveData<List<TroubleshootingItemViewData>>(emptyList())
+    val events: LiveData<List<TroubleshootingItemViewData>>
+        get() = _events
+
+    fun collectEventScopes() {
+        viewModelScope.launch {
+            eventRepository.getAllScopes()
+                .map { scope -> formatScopeViewData(scope) }
+                .ifEmpty { listOf(TroubleshootingItemViewData(title = "No event scopes found")) }
+                .let { _scopes.postValue(it) }
+        }
+    }
+
+    fun collectEvents(scopeId: String) {
+        viewModelScope.launch {
+            eventRepository.getEventsFromScope(scopeId)
+                .map { event -> formatEventViewData(event) }
+                .reversed()
+                .ifEmpty { listOf(TroubleshootingItemViewData(title = "No events found")) }
+                .let { _events.postValue(it) }
+        }
+    }
+
+    private fun formatScopeViewData(scope: EventScope): TroubleshootingItemViewData =
+        TroubleshootingItemViewData(
+            title = scope.id,
+            subtitle = formatTimestampSubtitle(scope.createdAt.ms, scope.endedAt?.ms),
+            body = """
+                    Type: ${scope.type} | End cause: ${scope.payload.endCause}
+                    ${scope.payload.language} | ${scope.payload.sidVersion} | Lib: ${scope.payload.libSimprintsVersion}
+                    Configuration ID: ${scope.payload.projectConfigurationId}
+                    """.trimIndent(),
+            navigationId = scope.id,
+        )
+
+    private fun formatEventViewData(event: Event): TroubleshootingItemViewData =
+        TroubleshootingItemViewData(
+            title = event.type.name,
+            subtitle = formatTimestampSubtitle(
+                event.payload.createdAt.ms,
+                event.payload.endedAt?.ms
+            ),
+        )
+
+    private fun formatTimestampSubtitle(startMs: Long, endMs: Long? = null): String =
+        "Started: ${Date(startMs)}" + endMs?.let { "\nEnded: ${Date(it)}" }.orEmpty()
+
+}

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/events/EventsLogViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/troubleshooting/events/EventsLogViewModel.kt
@@ -64,6 +64,7 @@ internal class EventsLogViewModel @Inject constructor(
                 event.payload.createdAt.ms,
                 event.payload.endedAt?.ms
             ),
+            body = "ID: ${event.id}\n" + event.payload.toSafeString(),
         )
 
     private fun formatTimestampSubtitle(startMs: Long, endMs: Long? = null): String =

--- a/feature/dashboard/src/main/res/layout/fragment_troubleshooting_list.xml
+++ b/feature/dashboard/src/main/res/layout/fragment_troubleshooting_list.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/troubleshootingList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+    <ProgressBar
+        android:id="@+id/troubleshootingListProgress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/dashboard/src/main/res/layout/fragment_troubleshooting_standalone_list.xml
+++ b/feature/dashboard/src/main/res/layout/fragment_troubleshooting_standalone_list.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/troubleshootingAppBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/troubleshootingToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?android:attr/actionBarSize"
+            app:navigationContentDescription="back"
+            app:navigationIcon="?android:attr/homeAsUpIndicator"
+            app:title="Troubleshooting" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/troubleshootingList"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/troubleshootingAppBar" />
+
+    <ProgressBar
+        android:id="@+id/troubleshootingListProgress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/troubleshootingAppBar" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/dashboard/src/main/res/layout/item_troubleshooting_list.xml
+++ b/feature/dashboard/src/main/res/layout/item_troubleshooting_list.xml
@@ -24,21 +24,37 @@
             <TextView
                 android:id="@+id/troubleshootingItemTitle"
                 style="@style/Text.Body1.Bold"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:maxLines="2"
                 android:textIsSelectable="true"
+                app:layout_constraintEnd_toStartOf="@id/troubleshootingItemCopy"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 tools:text="Event scope id" />
 
+            <ImageView
+                android:id="@+id/troubleshootingItemCopy"
+                android:layout_width="36dp"
+                android:layout_height="36dp"
+                android:clickable="true"
+                android:focusable="true"
+                android:padding="4dp"
+                android:src="@drawable/ic_copy"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/simprints_text_grey_light" />
+
             <TextView
                 android:id="@+id/troubleshootingItemSubtitle"
-                style="@style/Text.Body2"
-                android:layout_width="match_parent"
+                style="@style/Text.Body2.Secondary"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:maxLines="4"
                 android:textIsSelectable="true"
+                app:layout_constraintEnd_toStartOf="@id/troubleshootingItemCopy"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/troubleshootingItemTitle"
                 tools:text="Timestamps\nTimestamps" />
 

--- a/feature/dashboard/src/main/res/layout/item_troubleshooting_list.xml
+++ b/feature/dashboard/src/main/res/layout/item_troubleshooting_list.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="8dp"
+        android:layout_marginVertical="4dp"
+        app:cardBackgroundColor="#fff"
+        app:cardCornerRadius="8dp"
+        app:cardElevation="2dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="8dp"
+            android:paddingTop="8dp">
+
+            <TextView
+                android:id="@+id/troubleshootingItemTitle"
+                style="@style/Text.Body1.Bold"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:maxLines="2"
+                android:textIsSelectable="true"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="Event scope id" />
+
+            <TextView
+                android:id="@+id/troubleshootingItemSubtitle"
+                style="@style/Text.Body2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:maxLines="3"
+                android:textIsSelectable="true"
+                app:layout_constraintTop_toBottomOf="@id/troubleshootingItemTitle"
+                tools:text="Timestamps\nTimestamps" />
+
+            <TextView
+                android:id="@+id/troubleshootingItemBody"
+                style="@style/Text.Body1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:maxLines="8"
+                android:textIsSelectable="true"
+                app:layout_constraintBottom_toTopOf="@id/troubleshootingItemButton"
+                app:layout_constraintTop_toBottomOf="@id/troubleshootingItemSubtitle"
+                app:layout_goneMarginBottom="8dp"
+                tools:text="@tools:sample/lorem/random" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/troubleshootingItemButton"
+                style="@style/Widget.Simprints.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Details"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/troubleshootingItemBody"
+                tools:visibility="visible" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
+
+</FrameLayout>

--- a/feature/dashboard/src/main/res/layout/item_troubleshooting_list.xml
+++ b/feature/dashboard/src/main/res/layout/item_troubleshooting_list.xml
@@ -26,7 +26,6 @@
                 style="@style/Text.Body1.Bold"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="4dp"
                 android:maxLines="2"
                 android:textIsSelectable="true"
                 app:layout_constraintTop_toTopOf="parent"
@@ -37,8 +36,8 @@
                 style="@style/Text.Body2"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="4dp"
-                android:maxLines="3"
+                android:layout_marginTop="4dp"
+                android:maxLines="4"
                 android:textIsSelectable="true"
                 app:layout_constraintTop_toBottomOf="@id/troubleshootingItemTitle"
                 tools:text="Timestamps\nTimestamps" />
@@ -48,6 +47,7 @@
                 style="@style/Text.Body1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
                 android:maxLines="8"
                 android:textIsSelectable="true"
                 app:layout_constraintBottom_toTopOf="@id/troubleshootingItemButton"
@@ -68,5 +68,4 @@
                 tools:visibility="visible" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.cardview.widget.CardView>
-
 </FrameLayout>

--- a/feature/dashboard/src/main/res/navigation/graph_dashboard.xml
+++ b/feature/dashboard/src/main/res/navigation/graph_dashboard.xml
@@ -25,8 +25,7 @@
             app:popUpToInclusive="true" />
         <action
             android:id="@+id/action_requestLoginFragment_to_troubleshootingFragment"
-            app:destination="@id/troubleshootingFragment"
-            />
+            app:destination="@id/troubleshootingFragment" />
     </fragment>
     <fragment
         android:id="@+id/baseFragment"
@@ -79,7 +78,22 @@
         android:id="@+id/troubleshootingFragment"
         android:name="com.simprints.feature.dashboard.settings.troubleshooting.TroubleshootingFragment"
         android:label="TroubleshootingFragment"
-        tools:layout="@layout/fragment_troubleshooting" />
+        tools:layout="@layout/fragment_troubleshooting">
+        <action
+            android:id="@+id/action_troubleshootingFragment_to_troubleshootingEventLogFragment"
+            app:destination="@id/troubleshootingEventLogFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/troubleshootingEventLogFragment"
+        android:name="com.simprints.feature.dashboard.settings.troubleshooting.events.EventLogFragment"
+        android:label="TroubleshootingEventFragment"
+        tools:layout="@layout/fragment_troubleshooting_standalone_list">
+        <argument
+            android:name="scopeId"
+            app:argType="string"
+            app:nullable="false" />
+    </fragment>
+
     <fragment
         android:id="@+id/settingsFragment"
         android:name="com.simprints.feature.dashboard.settings.SettingsFragment"

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/troubleshooting/events/EventsLogViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/troubleshooting/events/EventsLogViewModelTest.kt
@@ -1,0 +1,79 @@
+package com.simprints.feature.dashboard.settings.troubleshooting.events
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.google.common.truth.Truth.assertThat
+import com.jraska.livedata.test
+import com.simprints.infra.events.EventRepository
+import com.simprints.infra.events.sampledata.createAlertScreenEvent
+import com.simprints.infra.events.sampledata.createSessionScope
+import com.simprints.testtools.common.coroutines.TestCoroutineRule
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class EventsLogViewModelTest {
+
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val testCoroutineRule = TestCoroutineRule()
+
+    @MockK
+    private lateinit var eventRepository: EventRepository
+
+    private lateinit var viewModel: EventsLogViewModel
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        viewModel = EventsLogViewModel(
+            eventRepository = eventRepository,
+        )
+    }
+
+    @Test
+    fun `sets list of scopes on request`() = runTest {
+        coEvery { eventRepository.getAllScopes() } returns listOf(createSessionScope())
+
+        val scopes = viewModel.scopes.test()
+        viewModel.collectEventScopes()
+
+        assertThat(scopes.value()).isNotEmpty()
+    }
+
+    @Test
+    fun `sets list of scopes placeholder if no scopes`() = runTest {
+        coEvery { eventRepository.getAllScopes() } returns emptyList()
+
+        val scopes = viewModel.scopes.test()
+        viewModel.collectEventScopes()
+
+        assertThat(scopes.value()).isNotEmpty()
+    }
+
+    @Test
+    fun `sets list of events on request`() = runTest {
+        coEvery { eventRepository.getEventsFromScope(any()) } returns listOf(createAlertScreenEvent())
+
+        val scopes = viewModel.events.test()
+        viewModel.collectEvents("scopeId")
+
+        assertThat(scopes.value()).isNotEmpty()
+    }
+
+    @Test
+    fun `sets list of events placeholder if no events`() = runTest {
+        coEvery { eventRepository.getEventsFromScope(any()) } returns emptyList()
+
+        val scopes = viewModel.events.test()
+        viewModel.collectEvents("scopeId")
+
+        assertThat(scopes.value()).isNotEmpty()
+    }
+}

--- a/infra/events/src/main/java/com/simprints/infra/events/EventRepository.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/EventRepository.kt
@@ -18,6 +18,7 @@ interface EventRepository {
     suspend fun closeEventScope(eventScopeId: String, reason: EventScopeEndCause?)
     suspend fun closeAllOpenScopes(type: EventScopeType, reason: EventScopeEndCause?)
     suspend fun saveEventScope(eventScope: EventScope)
+    suspend fun getAllScopes(): List<EventScope>
     suspend fun getOpenEventScopes(type: EventScopeType): List<EventScope>
     suspend fun getClosedEventScopes(type: EventScopeType, limit: Int): List<EventScope>
     suspend fun getClosedEventScopesCount(type: EventScopeType): Int

--- a/infra/events/src/main/java/com/simprints/infra/events/EventRepositoryImpl.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/EventRepositoryImpl.kt
@@ -123,6 +123,8 @@ internal open class EventRepositoryImpl @Inject constructor(
     override suspend fun saveEventScope(eventScope: EventScope) {
         eventLocalDataSource.saveEventScope(eventScope)
     }
+    override suspend fun getAllScopes(): List<EventScope> =
+        eventLocalDataSource.loadAllScopes()
 
     override suspend fun getOpenEventScopes(type: EventScopeType): List<EventScope> =
         eventLocalDataSource.loadOpenedScopes(type)

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AgeGroupSelectionEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AgeGroupSelectionEvent.kt
@@ -38,7 +38,10 @@ data class AgeGroupSelectionEvent(
         override val endedAt: Timestamp?,
         val subjectAgeGroup: AgeGroup,
         override val type: EventType = AGE_GROUP_SELECTION,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "age group: [${subjectAgeGroup.startInclusive}, ${subjectAgeGroup.endExclusive})"
+    }
 
     @Keep
     data class AgeGroup(

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AlertScreenEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AlertScreenEvent.kt
@@ -39,6 +39,8 @@ data class AlertScreenEvent(
         override val type: EventType = ALERT_SCREEN,
     ) : EventPayload() {
 
+        override fun toSafeString(): String = "type: $alertType"
+
         enum class AlertScreenEventType {
             DIFFERENT_PROJECT_ID,
             DIFFERENT_USER_ID,

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AuthenticationEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AuthenticationEvent.kt
@@ -50,6 +50,8 @@ data class AuthenticationEvent(
         override val type: EventType = AUTHENTICATION,
     ) : EventPayload() {
 
+        override fun toSafeString(): String = "result: $result"
+
         @Keep
         data class UserInfo(val projectId: String, val userId: TokenizableString)
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AuthorizationEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AuthorizationEvent.kt
@@ -50,6 +50,8 @@ data class AuthorizationEvent(
         override val type: EventType = AUTHORIZATION,
     ) : EventPayload() {
 
+        override fun toSafeString(): String = "result: $result"
+
         @Keep
         enum class AuthorizationResult {
             AUTHORIZED, NOT_AUTHORIZED

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/CandidateReadEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/CandidateReadEvent.kt
@@ -50,6 +50,9 @@ data class CandidateReadEvent(
         override val type: EventType = CANDIDATE_READ
     ) : EventPayload() {
 
+        override fun toSafeString(): String =
+            "guid: $candidateId, local: $localResult, remote: $remoteResult"
+
         @Keep
         enum class LocalResult {
             FOUND, NOT_FOUND

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/CompletionCheckEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/CompletionCheckEvent.kt
@@ -37,7 +37,10 @@ data class CompletionCheckEvent(
         val completed: Boolean,
         override val endedAt: Timestamp? = null,
         override val type: EventType = COMPLETION_CHECK,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "completed: $completed"
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ConnectivitySnapshotEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ConnectivitySnapshotEvent.kt
@@ -38,7 +38,11 @@ data class ConnectivitySnapshotEvent(
         val connections: List<SimNetworkUtils.Connection>,
         override val endedAt: Timestamp? = null,
         override val type: EventType = CONNECTIVITY_SNAPSHOT,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String =
+            connections.joinToString(", ") { "${it.type}: ${it.state}" }
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ConsentEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ConsentEvent.kt
@@ -42,6 +42,8 @@ data class ConsentEvent(
         override val type: EventType = CONSENT,
     ) : EventPayload() {
 
+        override fun toSafeString(): String = "consent: $consentType, result: $result"
+
         @Keep
         enum class Type {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/EnrolmentEventV1.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/EnrolmentEventV1.kt
@@ -38,7 +38,10 @@ data class EnrolmentEventV1(
         val personId: String,
         override val endedAt: Timestamp? = null,
         override val type: EventType = ENROLMENT_V1,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "person ID: $personId"
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/EnrolmentEventV2.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/EnrolmentEventV2.kt
@@ -60,7 +60,10 @@ data class EnrolmentEventV2(
         val personCreationEventId: String,
         override val endedAt: Timestamp? = null,
         override val type: EventType = ENROLMENT_V2,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "subject ID: $subjectId, module ID: $moduleId"
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/EventPayload.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/EventPayload.kt
@@ -36,13 +36,13 @@ import com.simprints.infra.events.event.domain.models.callout.EnrolmentLastBiome
 import com.simprints.infra.events.event.domain.models.callout.IdentificationCalloutEvent.IdentificationCalloutPayload
 import com.simprints.infra.events.event.domain.models.callout.VerificationCalloutEvent.VerificationCalloutPayload
 import com.simprints.infra.events.event.domain.models.downsync.EventDownSyncRequestEvent.EventDownSyncRequestPayload
-import com.simprints.infra.events.event.domain.models.face.FaceCaptureBiometricsEvent
+import com.simprints.infra.events.event.domain.models.face.FaceCaptureBiometricsEvent.FaceCaptureBiometricsPayload
 import com.simprints.infra.events.event.domain.models.face.FaceCaptureConfirmationEvent.FaceCaptureConfirmationPayload
-import com.simprints.infra.events.event.domain.models.face.FaceCaptureEvent
+import com.simprints.infra.events.event.domain.models.face.FaceCaptureEvent.FaceCapturePayload
 import com.simprints.infra.events.event.domain.models.face.FaceFallbackCaptureEvent.FaceFallbackCapturePayload
 import com.simprints.infra.events.event.domain.models.face.FaceOnboardingCompleteEvent.FaceOnboardingCompletePayload
-import com.simprints.infra.events.event.domain.models.fingerprint.FingerprintCaptureBiometricsEvent
-import com.simprints.infra.events.event.domain.models.fingerprint.FingerprintCaptureEvent
+import com.simprints.infra.events.event.domain.models.fingerprint.FingerprintCaptureBiometricsEvent.FingerprintCaptureBiometricsPayload
+import com.simprints.infra.events.event.domain.models.fingerprint.FingerprintCaptureEvent.FingerprintCapturePayload
 import com.simprints.infra.events.event.domain.models.upsync.EventUpSyncRequestEvent.EventUpSyncRequestPayload
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
@@ -59,8 +59,8 @@ import com.simprints.infra.events.event.domain.models.upsync.EventUpSyncRequestE
     JsonSubTypes.Type(value = IdentificationCalloutPayload::class, name = EventType.CALLOUT_IDENTIFICATION_KEY),
     JsonSubTypes.Type(value = VerificationCalloutPayload::class, name = EventType.CALLOUT_VERIFICATION_KEY),
     JsonSubTypes.Type(value = FaceCaptureConfirmationPayload::class, name = EventType.FACE_CAPTURE_CONFIRMATION_KEY),
-    JsonSubTypes.Type(value = FaceCaptureEvent.FaceCapturePayload::class, name = EventType.FACE_CAPTURE_KEY),
-    JsonSubTypes.Type(value = FaceCaptureBiometricsEvent.FaceCaptureBiometricsPayload::class, name = EventType.FACE_CAPTURE_BIOMETRICS_KEY),
+    JsonSubTypes.Type(value = FaceCapturePayload::class, name = EventType.FACE_CAPTURE_KEY),
+    JsonSubTypes.Type(value = FaceCaptureBiometricsPayload::class, name = EventType.FACE_CAPTURE_BIOMETRICS_KEY),
     JsonSubTypes.Type(value = FaceFallbackCapturePayload::class, name = EventType.FACE_FALLBACK_CAPTURE_KEY),
     JsonSubTypes.Type(value = FaceOnboardingCompletePayload::class, name = EventType.FACE_ONBOARDING_COMPLETE_KEY),
     JsonSubTypes.Type(value = AlertScreenPayload::class, name = EventType.ALERT_SCREEN_KEY),
@@ -72,8 +72,8 @@ import com.simprints.infra.events.event.domain.models.upsync.EventUpSyncRequestE
     JsonSubTypes.Type(value = ConsentPayload::class, name = EventType.CONSENT_KEY),
     JsonSubTypes.Type(value = EnrolmentEventV1.EnrolmentPayload::class, name = EventType.ENROLMENT_V1_KEY),
     JsonSubTypes.Type(value = EnrolmentEventV2.EnrolmentPayload::class, name = EventType.ENROLMENT_V2_KEY),
-    JsonSubTypes.Type(value = FingerprintCaptureEvent.FingerprintCapturePayload::class, name = EventType.FINGERPRINT_CAPTURE_KEY),
-    JsonSubTypes.Type(value = FingerprintCaptureBiometricsEvent.FingerprintCaptureBiometricsPayload::class, name = EventType.FINGERPRINT_CAPTURE_BIOMETRICS_KEY),
+    JsonSubTypes.Type(value = FingerprintCapturePayload::class, name = EventType.FINGERPRINT_CAPTURE_KEY),
+    JsonSubTypes.Type(value = FingerprintCaptureBiometricsPayload::class, name = EventType.FINGERPRINT_CAPTURE_BIOMETRICS_KEY),
     JsonSubTypes.Type(value = GuidSelectionPayload::class, name = EventType.GUID_SELECTION_KEY),
     JsonSubTypes.Type(value = IntentParsingPayload::class, name = EventType.INTENT_PARSING_KEY),
     JsonSubTypes.Type(value = InvalidIntentPayload::class, name = EventType.INVALID_INTENT_KEY),
@@ -95,4 +95,6 @@ abstract class EventPayload {
     abstract val eventVersion: Int
     abstract val createdAt: Timestamp
     abstract val endedAt: Timestamp?
+
+    open fun toSafeString(): String = ""
 }

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/GuidSelectionEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/GuidSelectionEvent.kt
@@ -36,7 +36,10 @@ data class GuidSelectionEvent(
         val selectedId: String,
         override val endedAt: Timestamp? = null,
         override val type: EventType = GUID_SELECTION,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "guid: $selectedId"
+    }
 
     companion object {
         const val EVENT_VERSION = 2

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/IntentParsingEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/IntentParsingEvent.kt
@@ -40,6 +40,8 @@ data class IntentParsingEvent(
         override val type: EventType = INTENT_PARSING,
     ) : EventPayload() {
 
+        override fun toSafeString(): String = "integration: $integration"
+
         @Keep
         enum class IntegrationInfo {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/InvalidIntentEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/InvalidIntentEvent.kt
@@ -39,7 +39,12 @@ data class InvalidIntentEvent(
         val extras: Map<String, Any?>,
         override val endedAt: Timestamp? = null,
         override val type: EventType = INVALID_INTENT,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String {
+            return "action: $action, extras: $extras"
+        }
+    }
 
     companion object {
         const val EVENT_VERSION = 2

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/LicenseCheckEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/LicenseCheckEvent.kt
@@ -51,7 +51,11 @@ constructor(
         val vendor: String,
         override val endedAt: Timestamp? = null,
         override val type: EventType = LICENSE_CHECK,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "vendor: $vendor, status: $status"
+    }
+
     companion object {
         const val EVENT_VERSION = 1
     }

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/OneToManyMatchEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/OneToManyMatchEvent.kt
@@ -44,6 +44,9 @@ data class OneToManyMatchEvent(
         override val type: EventType = ONE_TO_MANY_MATCH,
     ) : EventPayload() {
 
+        override fun toSafeString(): String =
+            "matcher: $matcher, pool: ${pool.type}, size: ${pool.count}, results: ${result?.size}"
+
         @Keep
         data class MatchPool(val type: MatchPoolType, val count: Int)
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/OneToOneMatchEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/OneToOneMatchEvent.kt
@@ -52,7 +52,12 @@ data class OneToOneMatchEvent(
         val result: MatchEntry?,
         val fingerComparisonStrategy: FingerComparisonStrategy?,
         override val type: EventType = ONE_TO_ONE_MATCH,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String =
+            "matcher: $matcher, candidate ID: $candidateId, " +
+                "result: ${result?.score}, finger strategy: $fingerComparisonStrategy"
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/PersonCreationEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/PersonCreationEvent.kt
@@ -51,7 +51,11 @@ data class PersonCreationEvent(
         val faceReferenceId: String?,
         override val endedAt: Timestamp? = null,
         override val type: EventType = PERSON_CREATION,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String =
+            "face reference: $faceReferenceId, fingerprint reference: $fingerprintReferenceId"
+    }
 
     fun hasFingerprintReference() = payload.fingerprintReferenceId != null
     fun hasFaceReference() = payload.faceReferenceId != null

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/RefusalEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/RefusalEvent.kt
@@ -49,6 +49,8 @@ data class RefusalEvent(
         override val type: EventType = REFUSAL,
     ) : EventPayload() {
 
+        override fun toSafeString(): String = "reason: $reason, extra: $otherText"
+
         @Keep
         enum class Answer {
             REFUSED_RELIGION,

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ScannerConnectionEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ScannerConnectionEvent.kt
@@ -39,6 +39,10 @@ data class ScannerConnectionEvent(
         override val type: EventType = SCANNER_CONNECTION,
     ) : EventPayload() {
 
+        override fun toSafeString(): String =
+            "scanner: ${scannerInfo.scannerId}, mac: ${scannerInfo.macAddress}, " +
+                "generation: ${scannerInfo.generation}, hardware version: ${scannerInfo.hardwareVersion}"
+
         @Keep
         data class ScannerInfo(
             val scannerId: String,

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ScannerFirmwareUpdateEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ScannerFirmwareUpdateEvent.kt
@@ -50,7 +50,11 @@ data class ScannerFirmwareUpdateEvent(
         val targetAppVersion: String,
         var failureReason: String? = null,
         override val type: EventType = SCANNER_FIRMWARE_UPDATE,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String =
+            "chip: $chip, target version: $targetAppVersion, failure reason: $failureReason"
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/SuspiciousIntentEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/SuspiciousIntentEvent.kt
@@ -37,7 +37,11 @@ data class SuspiciousIntentEvent(
         val unexpectedExtras: Map<String, Any?>,
         override val endedAt: Timestamp? = null,
         override val type: EventType = SUSPICIOUS_INTENT,
-    ) : EventPayload()
+    ) : EventPayload() {
+        override fun toSafeString(): String = unexpectedExtras.entries.joinToString(", ") {
+            "${it.key}: ${it.value}"
+        }
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/Vero2InfoSnapshotEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/Vero2InfoSnapshotEvent.kt
@@ -36,7 +36,8 @@ data class Vero2InfoSnapshotEvent(
 
     override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
-    override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
+    override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) =
+        this // No tokenized fields
 
     @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
@@ -63,6 +64,11 @@ data class Vero2InfoSnapshotEvent(
         override val endedAt: Timestamp? = null,
         override val type: EventType = VERO_2_INFO_SNAPSHOT,
     ) : EventPayload() {
+
+        override fun toSafeString(): String = "battery charge: ${battery.charge}, " +
+            version.let { it as? Vero2Version.Vero2NewApiVersion }?.let {
+                "hardware: ${it.hardwareRevision}, cypress: ${it.cypressApp},  stm: ${it.stmApp}, un20: ${it.un20App}"
+            }.orEmpty()
 
         @Keep
         data class Vero2InfoSnapshotPayloadForNewApi(

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/ConfirmationCallbackEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/ConfirmationCallbackEvent.kt
@@ -40,7 +40,10 @@ data class ConfirmationCallbackEvent(
         val identificationOutcome: Boolean,
         override val endedAt: Timestamp? = null,
         override val type: EventType = CALLBACK_CONFIRMATION,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "outcome: $identificationOutcome"
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/EnrolmentCallbackEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/EnrolmentCallbackEvent.kt
@@ -40,7 +40,10 @@ data class EnrolmentCallbackEvent(
         val guid: String,
         override val endedAt: Timestamp? = null,
         override val type: EventType = CALLBACK_ENROLMENT,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "guid: $guid"
+    }
 
 
     companion object {

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/ErrorCallbackEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/ErrorCallbackEvent.kt
@@ -43,6 +43,8 @@ data class ErrorCallbackEvent(
         override val type: EventType = CALLBACK_ERROR,
     ) : EventPayload() {
 
+        override fun toSafeString(): String = "reason: $reason"
+
         @Keep
         enum class Reason {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/IdentificationCallbackEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/IdentificationCallbackEvent.kt
@@ -41,7 +41,13 @@ data class IdentificationCallbackEvent(
         val scores: List<CallbackComparisonScore>,
         override val endedAt: Timestamp? = null,
         override val type: EventType = EventType.CALLBACK_IDENTIFICATION,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String =
+            scores.joinToString(", ", prefix = "[", postfix = "]") {
+                "${it.guid}: ${it.confidence}"
+            }
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/RefusalCallbackEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/RefusalCallbackEvent.kt
@@ -42,7 +42,10 @@ data class RefusalCallbackEvent(
         val extra: String,
         override val endedAt: Timestamp? = null,
         override val type: EventType = CALLBACK_REFUSAL,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "reason: $reason, extra: $extra"
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/VerificationCallbackEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/VerificationCallbackEvent.kt
@@ -40,7 +40,10 @@ data class VerificationCallbackEvent(
         val score: CallbackComparisonScore,
         override val endedAt: Timestamp? = null,
         override val type: EventType = CALLBACK_VERIFICATION,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "confidence: ${score.confidence}"
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEvent.kt
@@ -44,7 +44,10 @@ data class ConfirmationCalloutEvent(
         val sessionId: String,
         override val endedAt: Timestamp? = null,
         override val type: EventType = CALLOUT_CONFIRMATION,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "guid: $selectedGuid, session ID: $sessionId"
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/EnrolmentCalloutEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/EnrolmentCalloutEvent.kt
@@ -61,7 +61,10 @@ data class EnrolmentCalloutEvent(
         val metadata: String?,
         override val endedAt: Timestamp? = null,
         override val type: EventType = CALLOUT_ENROLMENT,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "module: $moduleId, metadata: $metadata"
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/EnrolmentLastBiometricsCalloutEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/EnrolmentLastBiometricsCalloutEvent.kt
@@ -63,7 +63,10 @@ data class EnrolmentLastBiometricsCalloutEvent(
         val sessionId: String,
         override val endedAt: Timestamp? = null,
         override val type: EventType = CALLOUT_LAST_BIOMETRICS,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "metadata: $metadata, session ID: $sessionId"
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/IdentificationCalloutEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/IdentificationCalloutEvent.kt
@@ -60,7 +60,10 @@ data class IdentificationCalloutEvent(
         val metadata: String?,
         override val endedAt: Timestamp? = null,
         override val type: EventType = CALLOUT_IDENTIFICATION,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String = "module ID: $moduleId, metadata: $metadata"
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/VerificationCalloutEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/VerificationCalloutEvent.kt
@@ -63,7 +63,11 @@ data class VerificationCalloutEvent(
         val metadata: String,
         override val endedAt: Timestamp? = null,
         override val type: EventType = CALLOUT_VERIFICATION,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String =
+            "module ID: $moduleId, guid: $verifyGuid, metadata: $metadata"
+    }
 
     companion object {
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/downsync/EventDownSyncRequestEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/downsync/EventDownSyncRequestEvent.kt
@@ -61,7 +61,12 @@ data class EventDownSyncRequestEvent(
         val eventsRead: Int?,
         override val eventVersion: Int,
         override val type: EventType = EventType.EVENT_DOWN_SYNC_REQUEST,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String =
+            "request ID: $requestId, status: $responseStatus, error: $errorType, " +
+                "ms to response: $msToFirstResponseByte, events read: $eventsRead"
+    }
 
     @Keep
     data class QueryParameters(

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureBiometricsEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureBiometricsEvent.kt
@@ -49,6 +49,8 @@ data class FaceCaptureBiometricsEvent(
         override val type: EventType = EventType.FACE_CAPTURE_BIOMETRICS,
     ) : EventPayload() {
 
+        override fun toSafeString(): String = "format: ${face.format}, quality: ${face.quality}"
+
         @Keep
         data class Face(
             val yaw: Float,

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureConfirmationEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureConfirmationEvent.kt
@@ -44,6 +44,8 @@ data class FaceCaptureConfirmationEvent(
         override val type: EventType = FACE_CAPTURE_CONFIRMATION,
     ) : EventPayload() {
 
+        override fun toSafeString(): String = "result: $result"
+
         enum class Result {
             CONTINUE,
             RECAPTURE

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureEvent.kt
@@ -65,6 +65,10 @@ data class FaceCaptureEvent(
         override val type: EventType = FACE_CAPTURE,
     ) : EventPayload() {
 
+        override fun toSafeString(): String =
+            "result: $result, attempt nr: $attemptNb, fallback: $isFallback, " +
+                "quality: ${face?.quality},  format: ${face?.format}"
+
         @Keep
         data class Face(
             val yaw: Float,

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/fingerprint/FingerprintCaptureBiometricsEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/fingerprint/FingerprintCaptureBiometricsEvent.kt
@@ -50,6 +50,9 @@ data class FingerprintCaptureBiometricsEvent(
         override val type: EventType = EventType.FINGERPRINT_CAPTURE_BIOMETRICS,
     ) : EventPayload() {
 
+        override fun toSafeString(): String =
+            "format: ${fingerprint.format}, quality: ${fingerprint.quality}"
+
         @Keep
         data class Fingerprint(
             val finger: IFingerIdentifier,

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/fingerprint/FingerprintCaptureEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/fingerprint/FingerprintCaptureEvent.kt
@@ -62,6 +62,10 @@ data class FingerprintCaptureEvent(
         override val type: EventType = FINGERPRINT_CAPTURE,
     ) : EventPayload() {
 
+        override fun toSafeString(): String =
+            "finger: ${finger}, result: $result, " +
+                "quality: ${fingerprint?.quality}, format: ${fingerprint?.format}"
+
         @Keep
         data class Fingerprint(
             val finger: IFingerIdentifier,

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/upsync/EventUpSyncRequestEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/upsync/EventUpSyncRequestEvent.kt
@@ -49,7 +49,12 @@ data class EventUpSyncRequestEvent(
         val errorType: String?,
         override val eventVersion: Int,
         override val type: EventType = EventType.EVENT_UP_SYNC_REQUEST,
-    ) : EventPayload()
+    ) : EventPayload() {
+
+        override fun toSafeString(): String =
+            "request ID: $requestId, response: $responseStatus, error: $errorType," +
+                "sessions: ${content.sessionCount}, eventsUp: ${content.eventUpSyncCount}, eventsDown: ${content.eventDownSyncCount}"
+    }
 
     @Keep
     data class UpSyncContent(

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/EventLocalDataSource.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/EventLocalDataSource.kt
@@ -104,6 +104,10 @@ internal open class EventLocalDataSource @Inject constructor(
         scopeDao.countClosed(type)
     }
 
+    suspend fun loadAllScopes(): List<EventScope> = useRoom(readingDispatcher) {
+        scopeDao.loadAll().map { it.fromDbToDomain(jsonHelper) }
+    }
+
     suspend fun loadOpenedScopes(type: EventScopeType): List<EventScope> =
         useRoom(readingDispatcher) {
             scopeDao.loadOpen(type).map { it.fromDbToDomain(jsonHelper) }

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/SessionScopeRoomDao.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/SessionScopeRoomDao.kt
@@ -11,6 +11,9 @@ import com.simprints.infra.events.event.local.models.DbEventScope
 @Dao
 internal interface SessionScopeRoomDao {
 
+    @Query("select * from DbEventScope order by start_unixMs desc")
+    suspend fun loadAll(): List<DbEventScope>
+
     @Query("select * from DbEventScope where type = :type AND end_unixMs IS NULL order by start_unixMs desc")
     suspend fun loadOpen(type: EventScopeType): List<DbEventScope>
 

--- a/infra/events/src/test/java/com/simprints/infra/events/EventRepositoryImplTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/EventRepositoryImplTest.kt
@@ -243,6 +243,13 @@ internal class EventRepositoryImplTest {
     }
 
     @Test
+    fun `should delegate all scope fetch`() = runTest {
+        eventRepo.getAllScopes()
+
+        coVerify { eventLocalDataSource.loadAllScopes() }
+    }
+
+    @Test
     fun `should delegate open scope fetch`() = runTest {
         eventRepo.getOpenEventScopes(type = EventScopeType.SESSION)
 
@@ -254,6 +261,13 @@ internal class EventRepositoryImplTest {
         eventRepo.getClosedEventScopes(type = EventScopeType.SESSION, limit = 10)
 
         coVerify { eventLocalDataSource.loadClosedScopes(EventScopeType.SESSION, limit = 10) }
+    }
+
+    @Test
+    fun `should delegate closed scope count fetch`() = runTest {
+        eventRepo.getClosedEventScopesCount(type = EventScopeType.SESSION)
+
+        coVerify { eventLocalDataSource.countClosedEventScopes(EventScopeType.SESSION) }
     }
 
     @Test

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/EventPayloadTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/EventPayloadTest.kt
@@ -1,0 +1,242 @@
+package com.simprints.infra.events.event.domain.models
+
+import com.google.common.truth.Truth.assertThat
+import com.simprints.core.domain.fingerprint.IFingerIdentifier
+import com.simprints.core.domain.response.AppMatchConfidence
+import com.simprints.core.domain.response.AppResponseTier.TIER_1
+import com.simprints.core.tools.utils.SimNetworkUtils
+import com.simprints.core.tools.utils.SimNetworkUtils.Connection
+import com.simprints.infra.events.event.domain.models.AlertScreenEvent.AlertScreenPayload.AlertScreenEventType.BLUETOOTH_NOT_ENABLED
+import com.simprints.infra.events.event.domain.models.AuthenticationEvent.AuthenticationPayload
+import com.simprints.infra.events.event.domain.models.AuthorizationEvent.AuthorizationPayload.AuthorizationResult.AUTHORIZED
+import com.simprints.infra.events.event.domain.models.CandidateReadEvent.CandidateReadPayload.LocalResult
+import com.simprints.infra.events.event.domain.models.CandidateReadEvent.CandidateReadPayload.RemoteResult.NOT_FOUND
+import com.simprints.infra.events.event.domain.models.ConsentEvent.ConsentPayload.Result.ACCEPTED
+import com.simprints.infra.events.event.domain.models.ConsentEvent.ConsentPayload.Type.INDIVIDUAL
+import com.simprints.infra.events.event.domain.models.IntentParsingEvent.IntentParsingPayload.IntegrationInfo.COMMCARE
+import com.simprints.infra.events.event.domain.models.OneToManyMatchEvent.OneToManyMatchPayload.MatchPool
+import com.simprints.infra.events.event.domain.models.OneToManyMatchEvent.OneToManyMatchPayload.MatchPoolType.PROJECT
+import com.simprints.infra.events.event.domain.models.RefusalEvent.RefusalPayload.Answer.OTHER
+import com.simprints.infra.events.event.domain.models.ScannerConnectionEvent.ScannerConnectionPayload.ScannerGeneration
+import com.simprints.infra.events.event.domain.models.ScannerConnectionEvent.ScannerConnectionPayload.ScannerInfo
+import com.simprints.infra.events.event.domain.models.callback.CallbackComparisonScore
+import com.simprints.infra.events.event.domain.models.callback.ConfirmationCallbackEvent
+import com.simprints.infra.events.event.domain.models.callback.EnrolmentCallbackEvent
+import com.simprints.infra.events.event.domain.models.callback.ErrorCallbackEvent
+import com.simprints.infra.events.event.domain.models.callback.ErrorCallbackEvent.ErrorCallbackPayload.Reason
+import com.simprints.infra.events.event.domain.models.callback.IdentificationCallbackEvent
+import com.simprints.infra.events.event.domain.models.callback.RefusalCallbackEvent
+import com.simprints.infra.events.event.domain.models.callback.VerificationCallbackEvent
+import com.simprints.infra.events.event.domain.models.callout.ConfirmationCalloutEvent
+import com.simprints.infra.events.event.domain.models.callout.EnrolmentCalloutEvent
+import com.simprints.infra.events.event.domain.models.callout.EnrolmentLastBiometricsCalloutEvent
+import com.simprints.infra.events.event.domain.models.callout.IdentificationCalloutEvent
+import com.simprints.infra.events.event.domain.models.callout.VerificationCalloutEvent
+import com.simprints.infra.events.event.domain.models.downsync.EventDownSyncRequestEvent
+import com.simprints.infra.events.event.domain.models.downsync.EventDownSyncRequestEvent.QueryParameters
+import com.simprints.infra.events.event.domain.models.face.FaceCaptureBiometricsEvent
+import com.simprints.infra.events.event.domain.models.face.FaceCaptureConfirmationEvent
+import com.simprints.infra.events.event.domain.models.face.FaceCaptureConfirmationEvent.FaceCaptureConfirmationPayload.Result.CONTINUE
+import com.simprints.infra.events.event.domain.models.face.FaceCaptureEvent
+import com.simprints.infra.events.event.domain.models.face.FaceFallbackCaptureEvent
+import com.simprints.infra.events.event.domain.models.face.FaceOnboardingCompleteEvent
+import com.simprints.infra.events.event.domain.models.fingerprint.FingerprintCaptureBiometricsEvent
+import com.simprints.infra.events.event.domain.models.fingerprint.FingerprintCaptureEvent
+import com.simprints.infra.events.sampledata.FACE_TEMPLATE_FORMAT
+import com.simprints.infra.events.sampledata.SampleDefaults.CREATED_AT
+import com.simprints.infra.events.sampledata.SampleDefaults.DEFAULT_METADATA
+import com.simprints.infra.events.sampledata.SampleDefaults.DEFAULT_MODULE_ID
+import com.simprints.infra.events.sampledata.SampleDefaults.DEFAULT_PROJECT_ID
+import com.simprints.infra.events.sampledata.SampleDefaults.DEFAULT_USER_ID
+import com.simprints.infra.events.sampledata.SampleDefaults.ENDED_AT
+import com.simprints.infra.events.sampledata.SampleDefaults.GUID1
+import com.simprints.infra.events.sampledata.SampleDefaults.GUID2
+import org.junit.Test
+import com.simprints.infra.events.event.domain.models.AuthenticationEvent.AuthenticationPayload.UserInfo as AuthenticationUserInfo
+import com.simprints.infra.events.event.domain.models.AuthorizationEvent.AuthorizationPayload.UserInfo as AuthorizationUserInfo
+
+class EventPayloadTest {
+
+    @Test
+    fun `safe string does not include sensitive data`() {
+        val sensitiveInfoList = listOf(
+            DEFAULT_USER_ID.value,
+            DEFAULT_PROJECT_ID,
+            "template"
+        )
+
+        allEventsList().forEach {
+            val safeString = it.payload.toSafeString()
+            sensitiveInfoList.forEach { assertThat(safeString).doesNotContain(it) }
+        }
+    }
+
+    private fun allEventsList(): List<Event> = listOf(
+        ConfirmationCallbackEvent(CREATED_AT, true),
+        EnrolmentCallbackEvent(CREATED_AT, GUID1),
+        ErrorCallbackEvent(CREATED_AT, Reason.DIFFERENT_PROJECT_ID_SIGNED_IN),
+        IdentificationCallbackEvent(
+            createdAt = CREATED_AT,
+            sessionId = GUID1,
+            scores = listOf(CallbackComparisonScore(GUID1, 1, TIER_1, AppMatchConfidence.NONE))
+        ),
+        RefusalCallbackEvent(CREATED_AT, "some_reason", "some_extra"),
+        VerificationCallbackEvent(
+            createdAt = CREATED_AT,
+            score = CallbackComparisonScore(GUID1, 1, TIER_1, AppMatchConfidence.NONE)
+        ),
+        ConfirmationCalloutEvent(CREATED_AT, DEFAULT_PROJECT_ID, GUID1, GUID2),
+        EnrolmentCalloutEvent(
+            createdAt = CREATED_AT,
+            projectId = DEFAULT_PROJECT_ID,
+            userId = DEFAULT_USER_ID,
+            moduleId = DEFAULT_MODULE_ID,
+            metadata = DEFAULT_METADATA,
+        ),
+        EnrolmentLastBiometricsCalloutEvent(
+            createdAt = CREATED_AT,
+            projectId = DEFAULT_PROJECT_ID,
+            userId = DEFAULT_USER_ID,
+            moduleId = DEFAULT_MODULE_ID,
+            metadata = DEFAULT_METADATA,
+            sessionId = GUID1,
+        ),
+        IdentificationCalloutEvent(
+            createdAt = CREATED_AT,
+            projectId = DEFAULT_PROJECT_ID,
+            userId = DEFAULT_USER_ID,
+            moduleId = DEFAULT_MODULE_ID,
+            metadata = DEFAULT_METADATA,
+        ),
+        VerificationCalloutEvent(
+            createdAt = CREATED_AT,
+            projectId = DEFAULT_PROJECT_ID,
+            userId = DEFAULT_USER_ID,
+            moduleId = DEFAULT_MODULE_ID,
+            verifyGuid = GUID1,
+            metadata = DEFAULT_METADATA,
+        ),
+        EventDownSyncRequestEvent(
+            createdAt = CREATED_AT,
+            endedAt = ENDED_AT,
+            query = QueryParameters(
+                moduleId = DEFAULT_MODULE_ID.value,
+                attendantId = DEFAULT_USER_ID.value,
+            ),
+            requestId = "requestId",
+        ),
+        FaceCaptureBiometricsEvent(
+            startTime = CREATED_AT,
+            face = FaceCaptureBiometricsEvent.FaceCaptureBiometricsPayload.Face(
+                yaw = 0.0f,
+                roll = 1.0f,
+                template = "template",
+                quality = 1.0f,
+                format = FACE_TEMPLATE_FORMAT
+            ),
+        ),
+        FaceCaptureConfirmationEvent(CREATED_AT, ENDED_AT, CONTINUE),
+        FaceCaptureEvent(
+            startTime = CREATED_AT,
+            endTime = ENDED_AT,
+            attemptNb = 0,
+            qualityThreshold = 1F,
+            result = FaceCaptureEvent.FaceCapturePayload.Result.VALID, isFallback = true,
+            face = FaceCaptureEvent.FaceCapturePayload.Face(0F, 1F, 2F, FACE_TEMPLATE_FORMAT),
+        ),
+        FaceFallbackCaptureEvent(CREATED_AT, ENDED_AT),
+        FaceOnboardingCompleteEvent(CREATED_AT, ENDED_AT),
+        FingerprintCaptureBiometricsEvent(
+            createdAt = CREATED_AT,
+            fingerprint = FingerprintCaptureBiometricsEvent.FingerprintCaptureBiometricsPayload.Fingerprint(
+                finger = IFingerIdentifier.LEFT_3RD_FINGER,
+                template = "template",
+                quality = 1,
+                format = "ISO_19794_2",
+            ),
+            id = "someId",
+        ),
+        FingerprintCaptureEvent(
+            createdAt = CREATED_AT,
+            endTime = ENDED_AT,
+            finger = IFingerIdentifier.LEFT_THUMB,
+            qualityThreshold = 10,
+            result = FingerprintCaptureEvent.FingerprintCapturePayload.Result.BAD_QUALITY,
+            fingerprint = FingerprintCaptureEvent.FingerprintCapturePayload.Fingerprint(
+                finger = IFingerIdentifier.LEFT_THUMB,
+                quality = 8,
+                format = "ISO_19794_2"
+            ),
+        ),
+        AlertScreenEvent(CREATED_AT, BLUETOOTH_NOT_ENABLED),
+        AuthenticationEvent(
+            createdAt = CREATED_AT,
+            endTime = ENDED_AT,
+            userInfo = AuthenticationUserInfo(DEFAULT_PROJECT_ID, DEFAULT_USER_ID),
+            result = AuthenticationPayload.Result.INTEGRITY_SERVICE_ERROR,
+        ),
+        AuthorizationEvent(
+            createdAt = CREATED_AT,
+            result = AUTHORIZED,
+            userInfo = AuthorizationUserInfo(DEFAULT_PROJECT_ID, DEFAULT_USER_ID)
+        ),
+        CandidateReadEvent(CREATED_AT, ENDED_AT, GUID1, LocalResult.NOT_FOUND, NOT_FOUND),
+        CompletionCheckEvent(CREATED_AT, true),
+        ConnectivitySnapshotEvent(
+            createdAt = CREATED_AT,
+            connections = listOf(
+                Connection(
+                    SimNetworkUtils.ConnectionType.MOBILE,
+                    SimNetworkUtils.ConnectionState.CONNECTED
+                )
+            ),
+        ),
+        ConsentEvent(CREATED_AT, ENDED_AT, INDIVIDUAL, ACCEPTED),
+        EnrolmentEventV1(CREATED_AT, GUID2),
+        EnrolmentEventV2(
+            createdAt = CREATED_AT,
+            subjectId = GUID1,
+            projectId = DEFAULT_PROJECT_ID,
+            moduleId = DEFAULT_MODULE_ID,
+            attendantId = DEFAULT_USER_ID,
+            personCreationEventId = GUID2,
+        ),
+        GuidSelectionEvent(CREATED_AT, GUID1),
+        IntentParsingEvent(CREATED_AT, COMMCARE),
+        InvalidIntentEvent(CREATED_AT, "REGISTER", mapOf("extra_key" to "value")),
+        OneToManyMatchEvent(
+            createdAt = CREATED_AT,
+            endTime = ENDED_AT,
+            pool = MatchPool(PROJECT, 100),
+            matcher = "MATCHER_NAME",
+            result = listOf(MatchEntry(GUID1, 0F))
+        ),
+        OneToOneMatchEvent(
+            createdAt = CREATED_AT,
+            endTime = ENDED_AT,
+            candidateId = GUID1,
+            matcher = "MATCHER_NAME",
+            result = MatchEntry(GUID1, 0F),
+            fingerComparisonStrategy = FingerComparisonStrategy.SAME_FINGER
+        ),
+        PersonCreationEvent(
+            startTime = CREATED_AT,
+            fingerprintCaptureIds = listOf(GUID1),
+            fingerprintReferenceId = GUID1,
+            faceCaptureIds = listOf(GUID2),
+            faceReferenceId = GUID2,
+        ),
+        RefusalEvent(CREATED_AT, ENDED_AT, OTHER, "other_text"),
+        ScannerConnectionEvent(
+            createdAt = CREATED_AT,
+            scannerInfo = ScannerInfo(
+                scannerId = "scanner_id",
+                macAddress = "mac_address",
+                generation = ScannerGeneration.VERO_1,
+                hardwareVersion = "hardware_version"
+            )
+        ),
+        ScannerFirmwareUpdateEvent(CREATED_AT, ENDED_AT, "chip", "v1", "error"),
+        SuspiciousIntentEvent(CREATED_AT, mapOf("extra_key" to "value")),
+    )
+}

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/EventLocalDataSourceTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/EventLocalDataSourceTest.kt
@@ -353,6 +353,20 @@ internal class EventLocalDataSourceTest {
     }
 
     @Test
+    fun countClosedEventScopes() = runTest {
+        eventLocalDataSource.countClosedEventScopes(EventScopeType.SESSION)
+
+        coVerify { scopeDao.countClosed(EventScopeType.SESSION) }
+    }
+
+    @Test
+    fun loadAllScopes() = runTest {
+        eventLocalDataSource.loadAllScopes()
+
+        coVerify { scopeDao.loadAll() }
+    }
+
+    @Test
     fun saveEventScope() = runTest {
         mockkStatic("com.simprints.infra.events.event.local.models.DbEventScopeKt")
         eventLocalDataSource.saveEventScope(mockk())

--- a/infra/resources/src/main/res/values/styles-text.xml
+++ b/infra/resources/src/main/res/values/styles-text.xml
@@ -209,6 +209,10 @@
         <item name="android:textAppearance">@style/TextAppearance.Simprints.Body1</item>
     </style>
 
+    <style name="Text.Body1.Bold">
+        <item name="android:textStyle">bold</item>
+    </style>
+
     <style name="Text.Body1.White">
         <item name="android:textColor">@color/simprints_text_white</item>
     </style>


### PR DESCRIPTION
* Added a generic list layout and adapter that could be reused for other troubleshooting log screens.
* Created a new screen that lists all local event scopes with a "details" screen that lists all of the events in the scope.
* Added a special "toSafeString()" method to all event payload classes that expose only technical (sometimes even tokenized) data to be displayed in the log screen.  