### PR TITLE
Do not consider caller package name unexpected paramerer

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/extractors/ActionRequestExtractor.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/extractors/ActionRequestExtractor.kt
@@ -16,6 +16,7 @@ internal abstract class ActionRequestExtractor(private val extras: Map<String, A
         Constants.SIMPRINTS_USER_ID,
         Constants.SIMPRINTS_MODULE_ID,
         Constants.SIMPRINTS_METADATA,
+        ClientApiConstants.CALLER_PACKAGE_NAME,
     )
 
     open fun getProjectId(): String = extras.extractString(Constants.SIMPRINTS_PROJECT_ID)


### PR DESCRIPTION
* On every session the "callerPackageName" is erroneously logged with a SUSPICIOS_INTENT event.