### PR TITLE
[MS-833] include scanner details in image metadata

### DIFF
--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
@@ -41,6 +41,7 @@ import com.simprints.fingerprint.infra.scanner.domain.fingerprint.AcquireFingerp
 import com.simprints.fingerprint.infra.scanner.exceptions.safe.NoFingerDetectedException
 import com.simprints.fingerprint.infra.scanner.exceptions.safe.ScannerDisconnectedException
 import com.simprints.fingerprint.infra.scanner.exceptions.safe.ScannerOperationInterruptedException
+import com.simprints.fingerprint.infra.scanner.v2.scanner.ScannerInfo
 import com.simprints.fingerprint.infra.scanner.wrapper.ScannerWrapper
 import com.simprints.infra.config.store.models.FingerprintConfiguration
 import com.simprints.infra.config.store.models.Vero2Configuration.ImageSavingStrategy.EAGER
@@ -667,6 +668,8 @@ internal class FingerprintCaptureViewModel @Inject constructor(
             finger = id.finger,
             captureEventId = captureEventId,
             collectedFinger = collectedFinger,
+            scannerId = ScannerInfo.scannerId,
+            un20SerialNumber = ScannerInfo.un20SerialNumber,
         )
         imageRefs[id] = imageRef
     }

--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
@@ -41,7 +41,6 @@ import com.simprints.fingerprint.infra.scanner.domain.fingerprint.AcquireFingerp
 import com.simprints.fingerprint.infra.scanner.exceptions.safe.NoFingerDetectedException
 import com.simprints.fingerprint.infra.scanner.exceptions.safe.ScannerDisconnectedException
 import com.simprints.fingerprint.infra.scanner.exceptions.safe.ScannerOperationInterruptedException
-import com.simprints.fingerprint.infra.scanner.v2.scanner.ScannerInfo
 import com.simprints.fingerprint.infra.scanner.wrapper.ScannerWrapper
 import com.simprints.infra.config.store.models.FingerprintConfiguration
 import com.simprints.infra.config.store.models.Vero2Configuration.ImageSavingStrategy.EAGER
@@ -668,8 +667,6 @@ internal class FingerprintCaptureViewModel @Inject constructor(
             finger = id.finger,
             captureEventId = captureEventId,
             collectedFinger = collectedFinger,
-            scannerId = ScannerInfo.scannerId,
-            un20SerialNumber = ScannerInfo.un20SerialNumber,
         )
         imageRefs[id] = imageRef
     }

--- a/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModelTest.kt
+++ b/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModelTest.kt
@@ -477,7 +477,7 @@ class FingerprintCaptureViewModelTest {
         )
         coVerify(exactly = 12) { addCaptureEventsUseCase.invoke(any(), any(), any(), any()) }
         vm.handleConfirmFingerprintsAndContinue()
-        coVerify(exactly = 4) { saveImageUseCase.invoke(any(), any(), any(), any(),any(),any()) }
+        coVerify(exactly = 4) { saveImageUseCase.invoke(any(), any(), any(), any()) }
 
         vm.finishWithFingerprints.assertEventReceivedWithContentAssertions { actualFingerprints ->
             assertThat(actualFingerprints?.results).hasSize(FOUR_FINGERS_IDS.size)
@@ -530,7 +530,7 @@ class FingerprintCaptureViewModelTest {
         coVerify(exactly = 2) { addCaptureEventsUseCase.invoke(any(), any(), any(), any()) }
 
         vm.handleConfirmFingerprintsAndContinue()
-        coVerify(exactly = 2) { saveImageUseCase.invoke(any(), any(), any(), any(),any(),any()) }
+        coVerify(exactly = 2) { saveImageUseCase.invoke(any(), any(), any(), any()) }
 
         vm.finishWithFingerprints.assertEventReceivedWithContentAssertions { actualFingerprints ->
             assertThat(actualFingerprints?.results).hasSize(TWO_FINGERS_IDS.size)
@@ -581,7 +581,7 @@ class FingerprintCaptureViewModelTest {
         )
         coVerify(exactly = 2) { addCaptureEventsUseCase.invoke(any(), any(), any(), any()) }
         vm.handleConfirmFingerprintsAndContinue()
-        coVerify(exactly = 0) { saveImageUseCase.invoke(any(), any(), any(), any(),any(),any()) }
+        coVerify(exactly = 0) { saveImageUseCase.invoke(any(), any(), any(), any()) }
 
         vm.finishWithFingerprints.assertEventReceivedWithContentAssertions { actualFingerprints ->
             assertThat(actualFingerprints?.results).hasSize(TWO_FINGERS_IDS.size)
@@ -784,7 +784,7 @@ class FingerprintCaptureViewModelTest {
         coVerify(exactly = 14) { addCaptureEventsUseCase.invoke(any(), any(), any(), any()) }
 
         vm.handleConfirmFingerprintsAndContinue()
-        coVerify(exactly = 3) { saveImageUseCase.invoke(any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 3) { saveImageUseCase.invoke(any(), any(), any(), any()) }
 
         vm.finishWithFingerprints.assertEventReceivedWithContentAssertions { actualFingerprints ->
             assertThat(actualFingerprints?.results).hasSize(3)
@@ -895,7 +895,7 @@ class FingerprintCaptureViewModelTest {
 
         coVerify(exactly = 14) { addCaptureEventsUseCase.invoke(any(), any(), any(), any()) }
         // If eager, expect that images were saved before confirm was pressed, including bad scans
-        coVerify(exactly = 8) { saveImageUseCase.invoke(any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 8) { saveImageUseCase.invoke(any(), any(), any(), any()) }
 
         vm.handleConfirmFingerprintsAndContinue()
 
@@ -995,7 +995,7 @@ class FingerprintCaptureViewModelTest {
 
         vm.handleConfirmFingerprintsAndContinue()
         // Save image is called even if scanResult.image == null
-        coVerify(exactly = 3) { saveImageUseCase.invoke(any(), any(), any(),any(), any(), any()) }
+        coVerify(exactly = 3) { saveImageUseCase.invoke(any(), any(), any(),any()) }
 
         vm.finishWithFingerprints.assertEventReceivedWithContentAssertions { actualFingerprints ->
             assertThat(actualFingerprints?.results).hasSize(3)
@@ -1391,7 +1391,7 @@ class FingerprintCaptureViewModelTest {
 
     private fun withImageTransfer(strategy: ImageSavingStrategy = ImageSavingStrategy.ONLY_USED_IN_REFERENCE) {
         every { vero2Configuration.imageSavingStrategy } returns strategy
-        coEvery { saveImageUseCase.invoke(any(), any(), any(), any(), any(), any()) } returns mockk {
+        coEvery { saveImageUseCase.invoke(any(), any(), any(), any()) } returns mockk {
             every { relativePath } returns Path(emptyArray())
         }
     }

--- a/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModelTest.kt
+++ b/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModelTest.kt
@@ -477,7 +477,7 @@ class FingerprintCaptureViewModelTest {
         )
         coVerify(exactly = 12) { addCaptureEventsUseCase.invoke(any(), any(), any(), any()) }
         vm.handleConfirmFingerprintsAndContinue()
-        coVerify(exactly = 4) { saveImageUseCase.invoke(any(), any(), any(), any()) }
+        coVerify(exactly = 4) { saveImageUseCase.invoke(any(), any(), any(), any(),any(),any()) }
 
         vm.finishWithFingerprints.assertEventReceivedWithContentAssertions { actualFingerprints ->
             assertThat(actualFingerprints?.results).hasSize(FOUR_FINGERS_IDS.size)
@@ -530,7 +530,7 @@ class FingerprintCaptureViewModelTest {
         coVerify(exactly = 2) { addCaptureEventsUseCase.invoke(any(), any(), any(), any()) }
 
         vm.handleConfirmFingerprintsAndContinue()
-        coVerify(exactly = 2) { saveImageUseCase.invoke(any(), any(), any(), any()) }
+        coVerify(exactly = 2) { saveImageUseCase.invoke(any(), any(), any(), any(),any(),any()) }
 
         vm.finishWithFingerprints.assertEventReceivedWithContentAssertions { actualFingerprints ->
             assertThat(actualFingerprints?.results).hasSize(TWO_FINGERS_IDS.size)
@@ -581,7 +581,7 @@ class FingerprintCaptureViewModelTest {
         )
         coVerify(exactly = 2) { addCaptureEventsUseCase.invoke(any(), any(), any(), any()) }
         vm.handleConfirmFingerprintsAndContinue()
-        coVerify(exactly = 0) { saveImageUseCase.invoke(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { saveImageUseCase.invoke(any(), any(), any(), any(),any(),any()) }
 
         vm.finishWithFingerprints.assertEventReceivedWithContentAssertions { actualFingerprints ->
             assertThat(actualFingerprints?.results).hasSize(TWO_FINGERS_IDS.size)
@@ -784,7 +784,7 @@ class FingerprintCaptureViewModelTest {
         coVerify(exactly = 14) { addCaptureEventsUseCase.invoke(any(), any(), any(), any()) }
 
         vm.handleConfirmFingerprintsAndContinue()
-        coVerify(exactly = 3) { saveImageUseCase.invoke(any(), any(), any(), any()) }
+        coVerify(exactly = 3) { saveImageUseCase.invoke(any(), any(), any(), any(), any(), any()) }
 
         vm.finishWithFingerprints.assertEventReceivedWithContentAssertions { actualFingerprints ->
             assertThat(actualFingerprints?.results).hasSize(3)
@@ -895,7 +895,7 @@ class FingerprintCaptureViewModelTest {
 
         coVerify(exactly = 14) { addCaptureEventsUseCase.invoke(any(), any(), any(), any()) }
         // If eager, expect that images were saved before confirm was pressed, including bad scans
-        coVerify(exactly = 8) { saveImageUseCase.invoke(any(), any(), any(), any()) }
+        coVerify(exactly = 8) { saveImageUseCase.invoke(any(), any(), any(), any(), any(), any()) }
 
         vm.handleConfirmFingerprintsAndContinue()
 
@@ -995,7 +995,7 @@ class FingerprintCaptureViewModelTest {
 
         vm.handleConfirmFingerprintsAndContinue()
         // Save image is called even if scanResult.image == null
-        coVerify(exactly = 3) { saveImageUseCase.invoke(any(), any(), any(),any()) }
+        coVerify(exactly = 3) { saveImageUseCase.invoke(any(), any(), any(),any(), any(), any()) }
 
         vm.finishWithFingerprints.assertEventReceivedWithContentAssertions { actualFingerprints ->
             assertThat(actualFingerprints?.results).hasSize(3)
@@ -1391,7 +1391,7 @@ class FingerprintCaptureViewModelTest {
 
     private fun withImageTransfer(strategy: ImageSavingStrategy = ImageSavingStrategy.ONLY_USED_IN_REFERENCE) {
         every { vero2Configuration.imageSavingStrategy } returns strategy
-        coEvery { saveImageUseCase.invoke(any(), any(), any(), any()) } returns mockk {
+        coEvery { saveImageUseCase.invoke(any(), any(), any(), any(), any(), any()) } returns mockk {
             every { relativePath } returns Path(emptyArray())
         }
     }

--- a/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/usecase/SaveImageUseCaseTest.kt
+++ b/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/usecase/SaveImageUseCaseTest.kt
@@ -48,7 +48,9 @@ class SaveImageUseCaseTest {
             vero2Configuration,
             IFingerIdentifier.LEFT_3RD_FINGER,
             "captureEventId",
-            createCollectedStub(null)
+            createCollectedStub(null),
+            null,
+            null,
         )
         assertThat(result).isNull()
     }
@@ -59,13 +61,23 @@ class SaveImageUseCaseTest {
             vero2Configuration,
             IFingerIdentifier.LEFT_3RD_FINGER,
             null,
-            createCollectedStub(byteArrayOf())
+            createCollectedStub(byteArrayOf()),
+            null,
+            null,
         )
         assertThat(result).isNull()
     }
 
     @Test
-    fun `Save image should call the event and image repos`() = runTest {
+    fun `Save image should call the event and image repos with correct metadata`() = runTest {
+        val scannerId = "scannerId"
+        val un20SerialNumber = "un20SerialNumber"
+        val expectedMetadata = mapOf(
+            "finger" to IFingerIdentifier.LEFT_3RD_FINGER.name,
+            "dpi" to "1300",
+            "scannerID" to scannerId,
+            "un20SerialNumber" to un20SerialNumber
+        )
         coEvery { eventRepo.getCurrentSessionScope() } returns mockk {
             every { projectId } returns "projectId"
             every { id } returns "sessionId"
@@ -85,7 +97,9 @@ class SaveImageUseCaseTest {
             vero2Configuration,
             IFingerIdentifier.LEFT_3RD_FINGER,
             "captureEventId",
-            createCollectedStub(byteArrayOf())
+            createCollectedStub(byteArrayOf()),
+            scannerId,
+            un20SerialNumber,
         )).isNotNull()
 
         coVerify {
@@ -95,10 +109,11 @@ class SaveImageUseCaseTest {
                 withArg {
                     assert(expectedPath.compose().contains(it.compose()))
                 },
-                any()
+               withArg { assert(it == expectedMetadata) }
             )
         }
     }
+
 
     @Test
     fun `Returns null when no current session event`() = runTest {
@@ -108,7 +123,9 @@ class SaveImageUseCaseTest {
             vero2Configuration,
             IFingerIdentifier.LEFT_3RD_FINGER,
             "captureEventId",
-            createCollectedStub(byteArrayOf())
+            createCollectedStub(byteArrayOf()),
+            null,
+            null,
         )).isNull()
     }
 
@@ -126,7 +143,9 @@ class SaveImageUseCaseTest {
             vero2Configuration,
             IFingerIdentifier.LEFT_3RD_FINGER,
             "captureEventId",
-            createCollectedStub(byteArrayOf())
+            createCollectedStub(byteArrayOf()),
+            null,
+            null,
         )).isNull()
 
         coVerify { imageRepo.storeImageSecurely(any(), "projectId", any(), any()) }

--- a/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/usecase/SaveImageUseCaseTest.kt
+++ b/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/usecase/SaveImageUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.fingerprint.IFingerIdentifier
 import com.simprints.fingerprint.capture.state.CaptureState
 import com.simprints.fingerprint.capture.state.ScanResult
+import com.simprints.fingerprint.infra.scanner.v2.scanner.ScannerInfo
 import com.simprints.infra.config.store.models.Vero2Configuration
 import com.simprints.infra.events.SessionEventRepository
 import com.simprints.infra.images.ImageRepository
@@ -31,15 +32,16 @@ class SaveImageUseCaseTest {
     lateinit var vero2Configuration: Vero2Configuration
 
     private lateinit var useCase: SaveImageUseCase
+    private lateinit var scannerInfo: ScannerInfo
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-
+        scannerInfo = ScannerInfo()
         every { vero2Configuration.imageSavingStrategy } returns Vero2Configuration.ImageSavingStrategy.EAGER
         every { vero2Configuration.captureStrategy } returns Vero2Configuration.CaptureStrategy.SECUGEN_ISO_1300_DPI
 
-        useCase = SaveImageUseCase(imageRepo, eventRepo)
+        useCase = SaveImageUseCase(imageRepo, eventRepo, scannerInfo)
     }
 
     @Test
@@ -49,8 +51,6 @@ class SaveImageUseCaseTest {
             IFingerIdentifier.LEFT_3RD_FINGER,
             "captureEventId",
             createCollectedStub(null),
-            null,
-            null,
         )
         assertThat(result).isNull()
     }
@@ -62,8 +62,6 @@ class SaveImageUseCaseTest {
             IFingerIdentifier.LEFT_3RD_FINGER,
             null,
             createCollectedStub(byteArrayOf()),
-            null,
-            null,
         )
         assertThat(result).isNull()
     }
@@ -82,35 +80,31 @@ class SaveImageUseCaseTest {
             every { projectId } returns "projectId"
             every { id } returns "sessionId"
         }
+        scannerInfo.setScannerId(scannerId)
+        scannerInfo.setUn20SerialNumber(un20SerialNumber)
 
-        val expectedPath = Path(arrayOf(
-            "sessions",
-            "sessionId",
-            "fingerprints",
-            "captureEventId.wsq"
-        ))
+        val expectedPath = Path(
+            arrayOf(
+                "sessions", "sessionId", "fingerprints", "captureEventId.wsq"
+            )
+        )
         coEvery {
             imageRepo.storeImageSecurely(any(), "projectId", any(), any())
         } returns SecuredImageRef(expectedPath)
 
-        assertThat(useCase.invoke(
-            vero2Configuration,
-            IFingerIdentifier.LEFT_3RD_FINGER,
-            "captureEventId",
-            createCollectedStub(byteArrayOf()),
-            scannerId,
-            un20SerialNumber,
-        )).isNotNull()
+        assertThat(
+            useCase.invoke(
+                vero2Configuration,
+                IFingerIdentifier.LEFT_3RD_FINGER,
+                "captureEventId",
+                createCollectedStub(byteArrayOf()),
+            )
+        ).isNotNull()
 
         coVerify {
-            imageRepo.storeImageSecurely(
-                withArg { assert(it.isEmpty()) },
-                "projectId",
-                withArg {
-                    assert(expectedPath.compose().contains(it.compose()))
-                },
-               withArg { assert(it == expectedMetadata) }
-            )
+            imageRepo.storeImageSecurely(withArg { assert(it.isEmpty()) }, "projectId", withArg {
+                assert(expectedPath.compose().contains(it.compose()))
+            }, withArg { assert(it == expectedMetadata) })
         }
     }
 
@@ -119,14 +113,14 @@ class SaveImageUseCaseTest {
     fun `Returns null when no current session event`() = runTest {
         coEvery { eventRepo.getCurrentSessionScope() } throws Exception("no session")
 
-        assertThat(useCase.invoke(
-            vero2Configuration,
-            IFingerIdentifier.LEFT_3RD_FINGER,
-            "captureEventId",
-            createCollectedStub(byteArrayOf()),
-            null,
-            null,
-        )).isNull()
+        assertThat(
+            useCase.invoke(
+                vero2Configuration,
+                IFingerIdentifier.LEFT_3RD_FINGER,
+                "captureEventId",
+                createCollectedStub(byteArrayOf()),
+            )
+        ).isNull()
     }
 
     @Test
@@ -139,14 +133,14 @@ class SaveImageUseCaseTest {
             imageRepo.storeImageSecurely(any(), "projectId", any(), any())
         } returns null
 
-        assertThat(useCase.invoke(
-            vero2Configuration,
-            IFingerIdentifier.LEFT_3RD_FINGER,
-            "captureEventId",
-            createCollectedStub(byteArrayOf()),
-            null,
-            null,
-        )).isNull()
+        assertThat(
+            useCase.invoke(
+                vero2Configuration,
+                IFingerIdentifier.LEFT_3RD_FINGER,
+                "captureEventId",
+                createCollectedStub(byteArrayOf()),
+            )
+        ).isNull()
 
         coVerify { imageRepo.storeImageSecurely(any(), "projectId", any(), any()) }
     }

--- a/fingerprint/infra/nec-bio-sdk/src/main/java/com/simprints/fingerprint/infra/necsdkimpl/acquisition/template/FingerprintTemplateProviderImpl.kt
+++ b/fingerprint/infra/nec-bio-sdk/src/main/java/com/simprints/fingerprint/infra/necsdkimpl/acquisition/template/FingerprintTemplateProviderImpl.kt
@@ -15,6 +15,7 @@ internal class FingerprintTemplateProviderImpl @Inject constructor(
     private val captureProcessedImageCache: ProcessedImageCache,
     private val extractNecTemplateUseCase: ExtractNecTemplateUseCase,
     private val processImage: ProcessRawImageUseCase,
+    private val scannerInfo: ScannerInfo,
 ) : FingerprintTemplateProvider<FingerprintTemplateAcquisitionSettings, FingerprintTemplateMetadata> {
 
     /**
@@ -44,7 +45,7 @@ internal class FingerprintTemplateProviderImpl @Inject constructor(
         // Store the recently captured image in the cache
         captureProcessedImageCache.recentlyCapturedImage = rawFingerprintScan.imageData
         // Store the serial number of the scanner for future use int the image upload
-        ScannerInfo.setUn20SerialNumber(rawFingerprintScan.un20SerialNumber.toHexString())
+        scannerInfo.setUn20SerialNumber(rawFingerprintScan.un20SerialNumber.toHexString())
         log("processing image using secugen image correction")
         val secugenProcessedImage = processImage(
             settings,

--- a/fingerprint/infra/nec-bio-sdk/src/test/java/com/simprints/fingerprint/infra/necsdkimpl/acquisition/template/FingerprintTemplateProviderImplTest.kt
+++ b/fingerprint/infra/nec-bio-sdk/src/test/java/com/simprints/fingerprint/infra/necsdkimpl/acquisition/template/FingerprintTemplateProviderImplTest.kt
@@ -41,9 +41,12 @@ class FingerprintTemplateProviderImplTest {
     @RelaxedMockK
     private lateinit var processRawImage: ProcessRawImageUseCase
 
+    private lateinit var scannerInfo: ScannerInfo
+
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
+        scannerInfo = ScannerInfo()
         every { fingerprintCaptureWrapperFactory.captureWrapper } returns captureWrapper
         coEvery {
             captureWrapper.acquireUnprocessedImage(any())
@@ -62,7 +65,8 @@ class FingerprintTemplateProviderImplTest {
             calculateNecImageQualityUseCase = calculateNecImageQualityUseCase,
             captureProcessedImageCache = processedImageCache,
             extractNecTemplateUseCase = extractNecTemplateUseCase,
-            processImage = processRawImage
+            processImage = processRawImage,
+            scannerInfo = scannerInfo
         )
 
     }
@@ -97,7 +101,7 @@ class FingerprintTemplateProviderImplTest {
             calculateNecImageQualityUseCase.invoke(any())
             extractNecTemplateUseCase.invoke(any(), any())
         }
-        Truth.assertThat(ScannerInfo.un20SerialNumber).isEqualTo(UN20_SERIAL_NUMBER.toHexString())
+        Truth.assertThat(scannerInfo.un20SerialNumber).isEqualTo(UN20_SERIAL_NUMBER.toHexString())
     }
 
     @Test
@@ -149,6 +153,7 @@ class FingerprintTemplateProviderImplTest {
             }
             Truth.assertThat(result.template).isNotEmpty()
         }
+
     fun createDummyRawUnprocessedImage(): RawUnprocessedImage {
         // Create a ByteArray of size 50 (header + image data)
         val imageBytes = ByteArray(50)
@@ -167,7 +172,8 @@ class FingerprintTemplateProviderImplTest {
         // Create and return the RawUnprocessedImage instance
         return RawUnprocessedImage(imageBytes)
     }
+
     companion object {
-        private  val UN20_SERIAL_NUMBER = "123456789123456".toByteArray()
+        private val UN20_SERIAL_NUMBER = "123456789123456".toByteArray()
     }
 }

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/ScannerModule.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/ScannerModule.kt
@@ -2,8 +2,13 @@ package com.simprints.fingerprint.infra.scanner
 
 import android.content.Context
 import android.nfc.NfcAdapter
+import com.simprints.core.CoreModule.provideDispatcherIo
 import com.simprints.fingerprint.infra.scanner.nfc.ComponentNfcAdapter
 import com.simprints.fingerprint.infra.scanner.nfc.android.AndroidNfcAdapter
+import com.simprints.fingerprint.infra.scanner.v2.domain.main.packet.Route
+import com.simprints.fingerprint.infra.scanner.v2.incoming.main.packet.ByteArrayToPacketAccumulator
+import com.simprints.fingerprint.infra.scanner.v2.incoming.main.packet.PacketParser
+import com.simprints.fingerprint.infra.scanner.v2.incoming.main.packet.PacketRouter
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -31,4 +36,12 @@ object FingerprintDependenciesModule {
     @Provides
     fun provideNfcAdapter(@ApplicationContext context: Context): ComponentNfcAdapter =
         AndroidNfcAdapter(NfcAdapter.getDefaultAdapter(context))
+
+    @Provides
+    fun providePacketRouter(): PacketRouter = PacketRouter(
+        listOf(Route.Remote.VeroServer, Route.Remote.VeroEvent, Route.Remote.Un20Server),
+        { source },
+        ByteArrayToPacketAccumulator(PacketParser()),
+        provideDispatcherIo()
+    )
 }

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/domain/fingerprint/RawUnprocessedImage.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/domain/fingerprint/RawUnprocessedImage.kt
@@ -8,7 +8,6 @@ package com.simprints.fingerprint.infra.scanner.domain.fingerprint
  *
  */
 class RawUnprocessedImage(private val imageBytes: ByteArray) {
-    fun isValidFormat() = imageBytes.size > IMAGE_HEADER_SIZE
     val imageData
         get() = with(imageBytes) { copyOfRange(IMAGE_HEADER_SIZE, imageBytes.size) }
     val brightness

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/channel/CypressOtaMessageChannel.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/channel/CypressOtaMessageChannel.kt
@@ -1,5 +1,6 @@
 package com.simprints.fingerprint.infra.scanner.v2.channel
 
+import com.simprints.core.DispatcherIO
 import com.simprints.fingerprint.infra.scanner.v2.domain.cypressota.CypressOtaCommand
 import com.simprints.fingerprint.infra.scanner.v2.domain.cypressota.CypressOtaResponse
 import com.simprints.fingerprint.infra.scanner.v2.incoming.cypressota.CypressOtaMessageInputStream
@@ -7,11 +8,14 @@ import com.simprints.fingerprint.infra.scanner.v2.outgoing.cypressota.CypressOta
 import com.simprints.fingerprint.infra.scanner.v2.tools.reactive.doSimultaneously
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.rx2.await
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class CypressOtaMessageChannel(
+@Singleton
+class CypressOtaMessageChannel @Inject constructor(
     incoming: CypressOtaMessageInputStream,
     outgoing: CypressOtaMessageOutputStream,
-    dispatcher: CoroutineDispatcher
+    @DispatcherIO dispatcher: CoroutineDispatcher
 ) : MessageChannel<CypressOtaMessageInputStream, CypressOtaMessageOutputStream>(
     incoming, outgoing, dispatcher
 ) {

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/channel/MainMessageChannel.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/channel/MainMessageChannel.kt
@@ -1,5 +1,6 @@
 package com.simprints.fingerprint.infra.scanner.v2.channel
 
+import com.simprints.core.DispatcherIO
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.IncomingMainMessage
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.OutgoingMainMessage
 import com.simprints.fingerprint.infra.scanner.v2.incoming.main.MainMessageInputStream
@@ -7,11 +8,14 @@ import com.simprints.fingerprint.infra.scanner.v2.outgoing.main.MainMessageOutpu
 import com.simprints.fingerprint.infra.scanner.v2.tools.reactive.doSimultaneously
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.rx2.await
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class MainMessageChannel(
+@Singleton
+class MainMessageChannel @Inject constructor(
     incoming: MainMessageInputStream,
     outgoing: MainMessageOutputStream,
-    dispatcher: CoroutineDispatcher
+    @DispatcherIO dispatcher: CoroutineDispatcher
 ) : MessageChannel<MainMessageInputStream, MainMessageOutputStream>(
     incoming, outgoing, dispatcher
 ) {

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/channel/RootMessageChannel.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/channel/RootMessageChannel.kt
@@ -1,5 +1,6 @@
 package com.simprints.fingerprint.infra.scanner.v2.channel
 
+import com.simprints.core.DispatcherIO
 import com.simprints.fingerprint.infra.scanner.v2.domain.root.RootCommand
 import com.simprints.fingerprint.infra.scanner.v2.domain.root.RootResponse
 import com.simprints.fingerprint.infra.scanner.v2.incoming.root.RootMessageInputStream
@@ -7,11 +8,14 @@ import com.simprints.fingerprint.infra.scanner.v2.outgoing.root.RootMessageOutpu
 import com.simprints.fingerprint.infra.scanner.v2.tools.reactive.doSimultaneously
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.rx2.await
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class RootMessageChannel(
+@Singleton
+class RootMessageChannel @Inject constructor(
     incoming: RootMessageInputStream,
     outgoing: RootMessageOutputStream,
-    dispatcher: CoroutineDispatcher
+    @DispatcherIO dispatcher: CoroutineDispatcher
 ) : MessageChannel<RootMessageInputStream, RootMessageOutputStream>(
     incoming, outgoing, dispatcher
 ) {

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/channel/StmOtaMessageChannel.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/channel/StmOtaMessageChannel.kt
@@ -1,5 +1,6 @@
 package com.simprints.fingerprint.infra.scanner.v2.channel
 
+import com.simprints.core.DispatcherIO
 import com.simprints.fingerprint.infra.scanner.v2.domain.stmota.StmOtaCommand
 import com.simprints.fingerprint.infra.scanner.v2.domain.stmota.StmOtaResponse
 import com.simprints.fingerprint.infra.scanner.v2.incoming.stmota.StmOtaMessageInputStream
@@ -7,11 +8,14 @@ import com.simprints.fingerprint.infra.scanner.v2.outgoing.stmota.StmOtaMessageO
 import com.simprints.fingerprint.infra.scanner.v2.tools.reactive.doSimultaneously
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.rx2.await
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class StmOtaMessageChannel(
+@Singleton
+class StmOtaMessageChannel @Inject constructor(
     incoming: StmOtaMessageInputStream,
     outgoing: StmOtaMessageOutputStream,
-    dispatcher: CoroutineDispatcher
+    @DispatcherIO dispatcher: CoroutineDispatcher
 ) : MessageChannel<StmOtaMessageInputStream, StmOtaMessageOutputStream>(
     incoming, outgoing, dispatcher
 ) {

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/cypressota/CypressOtaResponseParser.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/cypressota/CypressOtaResponseParser.kt
@@ -9,8 +9,9 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.cypressota.responses.Co
 import com.simprints.fingerprint.infra.scanner.v2.domain.cypressota.responses.ErrorResponse
 import com.simprints.fingerprint.infra.scanner.v2.domain.cypressota.responses.OkResponse
 import com.simprints.fingerprint.infra.scanner.v2.incoming.common.MessageParser
+import javax.inject.Inject
 
-class CypressOtaResponseParser : MessageParser<CypressOtaResponse> {
+class CypressOtaResponseParser @Inject constructor() : MessageParser<CypressOtaResponse> {
 
     override fun parse(messageBytes: ByteArray): CypressOtaResponse =
         try {

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/MainMessageInputStream.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/MainMessageInputStream.kt
@@ -1,5 +1,6 @@
 package com.simprints.fingerprint.infra.scanner.v2.incoming.main
 
+import com.simprints.core.DispatcherIO
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.IncomingMainMessage
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.un20.Un20Response
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.vero.VeroEvent
@@ -17,6 +18,8 @@ import com.simprints.fingerprint.infra.scanner.v2.tools.reactive.subscribeOnIoAn
 import io.reactivex.Flowable
 import io.reactivex.Single
 import io.reactivex.disposables.Disposable
+import kotlinx.coroutines.CoroutineDispatcher
+import javax.inject.Inject
 
 /**
  * Transforms each of the Flowable<Packet> streams exposed by [PacketRouter] into a
@@ -25,11 +28,12 @@ import io.reactivex.disposables.Disposable
  * [receiveResponse] can be used to take a message from the [veroResponses] or [un20Responses]
  * streams, while the [veroEvents] stream can be observed directly.
  */
-class MainMessageInputStream(
+class MainMessageInputStream @Inject constructor(
     private val packetRouter: PacketRouter,
     private val veroResponseAccumulator: VeroResponseAccumulator,
     private val veroEventAccumulator: VeroEventAccumulator,
-    private val un20ResponseAccumulator: Un20ResponseAccumulator
+    private val un20ResponseAccumulator: Un20ResponseAccumulator,
+    @DispatcherIO private val ioDispatcher: CoroutineDispatcher,
 ) : MessageInputStream {
 
     var veroResponses: Flowable<VeroResponse>? = null
@@ -43,12 +47,16 @@ class MainMessageInputStream(
     override fun connect(flowableInputStream: Flowable<ByteArray>) {
         packetRouter.connect(flowableInputStream)
         with(packetRouter.incomingPacketRoutes) {
-            veroResponses = getValue(Route.Remote.VeroServer).toMainMessageStream(veroResponseAccumulator)
-                .subscribeOnIoAndPublish().also { veroResponsesDisposable = it.connect() }
+            veroResponses =
+                getValue(Route.Remote.VeroServer).toMainMessageStream(veroResponseAccumulator)
+                    .subscribeOnIoAndPublish(ioDispatcher)
+                    .also { veroResponsesDisposable = it.connect() }
             veroEvents = getValue(Route.Remote.VeroEvent).toMainMessageStream(veroEventAccumulator)
-                .subscribeOnIoAndPublish().also { veroEventsDisposable = it.connect() }
-            un20Responses = getValue(Route.Remote.Un20Server).toMainMessageStream(un20ResponseAccumulator)
-                .subscribeOnIoAndPublish().also { un20ResponsesDisposable = it.connect() }
+                .subscribeOnIoAndPublish(ioDispatcher).also { veroEventsDisposable = it.connect() }
+            un20Responses =
+                getValue(Route.Remote.Un20Server).toMainMessageStream(un20ResponseAccumulator)
+                    .subscribeOnIoAndPublish(ioDispatcher)
+                    .also { un20ResponsesDisposable = it.connect() }
         }
     }
 

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/message/accumulators/Un20ResponseAccumulator.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/message/accumulators/Un20ResponseAccumulator.kt
@@ -3,6 +3,7 @@ package com.simprints.fingerprint.infra.scanner.v2.incoming.main.message.accumul
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.un20.Un20MessageProtocol
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.un20.Un20Response
 import com.simprints.fingerprint.infra.scanner.v2.incoming.main.message.parsers.Un20ResponseParser
+import javax.inject.Inject
 
-class Un20ResponseAccumulator(un20ResponseParser: Un20ResponseParser) :
+class Un20ResponseAccumulator @Inject constructor(un20ResponseParser: Un20ResponseParser) :
     PacketToMainMessageAccumulator<Un20Response>(Un20MessageProtocol, un20ResponseParser)

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/message/accumulators/VeroEventAccumulator.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/message/accumulators/VeroEventAccumulator.kt
@@ -3,6 +3,7 @@ package com.simprints.fingerprint.infra.scanner.v2.incoming.main.message.accumul
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.vero.VeroEvent
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.vero.VeroMessageProtocol
 import com.simprints.fingerprint.infra.scanner.v2.incoming.main.message.parsers.VeroEventParser
+import javax.inject.Inject
 
-class VeroEventAccumulator(veroEventParser: VeroEventParser) :
+class VeroEventAccumulator @Inject constructor(veroEventParser: VeroEventParser) :
     PacketToMainMessageAccumulator<VeroEvent>(VeroMessageProtocol, veroEventParser)

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/message/accumulators/VeroResponseAccumulator.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/message/accumulators/VeroResponseAccumulator.kt
@@ -3,6 +3,7 @@ package com.simprints.fingerprint.infra.scanner.v2.incoming.main.message.accumul
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.vero.VeroMessageProtocol
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.vero.VeroResponse
 import com.simprints.fingerprint.infra.scanner.v2.incoming.main.message.parsers.VeroResponseParser
+import javax.inject.Inject
 
-class VeroResponseAccumulator(veroResponseParser: VeroResponseParser) :
+class VeroResponseAccumulator @Inject constructor(veroResponseParser: VeroResponseParser) :
     PacketToMainMessageAccumulator<VeroResponse>(VeroMessageProtocol, veroResponseParser)

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/message/parsers/Un20ResponseParser.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/message/parsers/Un20ResponseParser.kt
@@ -17,8 +17,9 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.un20.respo
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.un20.responses.VerifyOtaResponse
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.un20.responses.WriteOtaChunkResponse
 import com.simprints.fingerprint.infra.scanner.v2.incoming.common.MessageParser
+import javax.inject.Inject
 
-class Un20ResponseParser : MessageParser<Un20Response> {
+class Un20ResponseParser @Inject constructor() : MessageParser<Un20Response> {
 
     override fun parse(messageBytes: ByteArray): Un20Response =
         try {

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/message/parsers/VeroEventParser.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/message/parsers/VeroEventParser.kt
@@ -7,8 +7,9 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.vero.event
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.vero.models.VeroMessageType
 import com.simprints.fingerprint.infra.scanner.v2.exceptions.parsing.InvalidMessageException
 import com.simprints.fingerprint.infra.scanner.v2.incoming.common.MessageParser
+import javax.inject.Inject
 
-class VeroEventParser : MessageParser<VeroEvent> {
+class VeroEventParser @Inject constructor() : MessageParser<VeroEvent> {
 
     override fun parse(messageBytes: ByteArray): VeroEvent =
         try {

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/message/parsers/VeroResponseParser.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/message/parsers/VeroResponseParser.kt
@@ -32,8 +32,9 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.vero.respo
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.vero.responses.SetUn20OnResponse
 import com.simprints.fingerprint.infra.scanner.v2.exceptions.parsing.InvalidMessageException
 import com.simprints.fingerprint.infra.scanner.v2.incoming.common.MessageParser
+import javax.inject.Inject
 
-class VeroResponseParser : MessageParser<VeroResponse> {
+class VeroResponseParser @Inject constructor() : MessageParser<VeroResponse> {
 
     override fun parse(messageBytes: ByteArray): VeroResponse =
         try {

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/packet/ByteArrayToPacketAccumulator.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/packet/ByteArrayToPacketAccumulator.kt
@@ -5,8 +5,9 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.main.packet.PacketProto
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.packet.PacketProtocol.HEADER_SIZE
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.packet.PacketProtocol.getTotalLengthFromHeader
 import com.simprints.fingerprint.infra.scanner.v2.tools.accumulator.ByteArrayAccumulator
+import javax.inject.Inject
 
-class ByteArrayToPacketAccumulator(
+class ByteArrayToPacketAccumulator @Inject constructor(
     private val packetParser: PacketParser
 ) : ByteArrayAccumulator<ByteArray, Packet>(
     fragmentAsByteArray = { bytes -> bytes },

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/packet/PacketParser.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/packet/PacketParser.kt
@@ -4,8 +4,9 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.main.packet.Packet
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.packet.PacketProtocol
 import com.simprints.fingerprint.infra.scanner.v2.exceptions.parsing.InvalidPacketException
 import java.nio.BufferUnderflowException
+import javax.inject.Inject
 
-class PacketParser {
+class PacketParser @Inject constructor() {
 
     /** @throws InvalidPacketException */
     fun parse(bytes: ByteArray): Packet =

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/packet/PacketRouter.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/packet/PacketRouter.kt
@@ -1,5 +1,6 @@
 package com.simprints.fingerprint.infra.scanner.v2.incoming.main.packet
 
+import com.simprints.core.DispatcherIO
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.packet.Packet
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.packet.Route
 import com.simprints.fingerprint.infra.scanner.v2.incoming.IncomingConnectable
@@ -7,6 +8,8 @@ import com.simprints.fingerprint.infra.scanner.v2.tools.reactive.subscribeOnIoAn
 import io.reactivex.Flowable
 import io.reactivex.disposables.Disposable
 import io.reactivex.flowables.ConnectableFlowable
+import kotlinx.coroutines.CoroutineDispatcher
+import javax.inject.Inject
 
 /**
  * The PacketRouter takes an InputStream of bytes, converting it into a single stream of
@@ -14,9 +17,12 @@ import io.reactivex.flowables.ConnectableFlowable
  * and forwards them to a separate Flowable<Packet> dedicated to that route, which is exposed
  * in the map [incomingPacketRoutes].
  */
-class PacketRouter(private val routes: List<Route>,
-                   private val packetRouteDesignator: Packet.() -> Byte,
-                   private val byteArrayToPacketAccumulator: ByteArrayToPacketAccumulator) : IncomingConnectable {
+class PacketRouter @Inject constructor(
+    private val routes: List<Route>,
+    private val packetRouteDesignator: Packet.() -> Byte,
+    private val byteArrayToPacketAccumulator: ByteArrayToPacketAccumulator,
+    @DispatcherIO private val ioDispatcher: CoroutineDispatcher,
+    ) : IncomingConnectable {
 
     lateinit var incomingPacketRoutes: Map<Route, ConnectableFlowable<Packet>>
 
@@ -25,9 +31,9 @@ class PacketRouter(private val routes: List<Route>,
 
     override fun connect(flowableInputStream: Flowable<ByteArray>) {
         val rawPacketStream = transformToPacketStream(flowableInputStream)
-        val incomingPackets = rawPacketStream.subscribeOnIoAndPublish()
+        val incomingPackets = rawPacketStream.subscribeOnIoAndPublish(ioDispatcher)
         incomingPacketRoutes = routes.associateWith {
-            incomingPackets.filterRoute(it).subscribeOnIoAndPublish()
+            incomingPackets.filterRoute(it).subscribeOnIoAndPublish(ioDispatcher)
         }
         incomingPacketsDisposable = incomingPackets.connect()
         incomingPacketRoutesDisposable = incomingPacketRoutes.mapValues { it.value.connect() }

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/root/RootResponseAccumulator.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/root/RootResponseAccumulator.kt
@@ -5,8 +5,9 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.root.RootMessageProtoco
 import com.simprints.fingerprint.infra.scanner.v2.domain.root.RootMessageProtocol.getTotalLengthFromHeader
 import com.simprints.fingerprint.infra.scanner.v2.domain.root.RootResponse
 import com.simprints.fingerprint.infra.scanner.v2.tools.accumulator.ByteArrayAccumulator
+import javax.inject.Inject
 
-class RootResponseAccumulator(rootResponseParser: RootResponseParser) :
+class RootResponseAccumulator @Inject constructor(rootResponseParser: RootResponseParser) :
     ByteArrayAccumulator<ByteArray, RootResponse>(
         fragmentAsByteArray = { it },
         canComputeElementLength = { bytes -> bytes.size >= HEADER_SIZE },

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/root/RootResponseParser.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/root/RootResponseParser.kt
@@ -22,8 +22,9 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.root.responses.GetHardw
 import com.simprints.fingerprint.infra.scanner.v2.domain.root.responses.GetVersionResponse
 import com.simprints.fingerprint.infra.scanner.v2.domain.root.responses.SetVersionResponse
 import com.simprints.fingerprint.infra.scanner.v2.incoming.common.MessageParser
+import javax.inject.Inject
 
-class RootResponseParser : MessageParser<RootResponse> {
+class RootResponseParser  @Inject constructor(): MessageParser<RootResponse> {
 
     override fun parse(messageBytes: ByteArray): RootResponse =
         try {

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/stmota/StmOtaMessageInputStream.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/stmota/StmOtaMessageInputStream.kt
@@ -1,5 +1,6 @@
 package com.simprints.fingerprint.infra.scanner.v2.incoming.stmota
 
+import com.simprints.core.DispatcherIO
 import com.simprints.fingerprint.infra.scanner.v2.domain.stmota.StmOtaResponse
 import com.simprints.fingerprint.infra.scanner.v2.incoming.common.MessageInputStream
 import com.simprints.fingerprint.infra.scanner.v2.tools.reactive.filterCast
@@ -7,12 +8,17 @@ import com.simprints.fingerprint.infra.scanner.v2.tools.reactive.subscribeOnIoAn
 import io.reactivex.Flowable
 import io.reactivex.Single
 import io.reactivex.disposables.Disposable
+import kotlinx.coroutines.CoroutineDispatcher
+import javax.inject.Inject
 
 /**
  * Takes an InputStream and transforms it into a Flowable<StmOtaResponse> for use while the Vero is
  * in STM OTA Mode.
  */
-class StmOtaMessageInputStream(private val stmOtaResponseParser: StmOtaResponseParser) : MessageInputStream {
+class StmOtaMessageInputStream @Inject constructor(
+    private val stmOtaResponseParser: StmOtaResponseParser,
+    @DispatcherIO private val ioDispatcher: CoroutineDispatcher,
+) : MessageInputStream {
 
     var stmOtaResponseStream: Flowable<StmOtaResponse>? = null
 
@@ -20,7 +26,7 @@ class StmOtaMessageInputStream(private val stmOtaResponseParser: StmOtaResponseP
 
     override fun connect(flowableInputStream: Flowable<ByteArray>) {
         stmOtaResponseStream = transformToStmOtaResponseStream(flowableInputStream)
-            .subscribeOnIoAndPublish()
+            .subscribeOnIoAndPublish(ioDispatcher)
             .also {
                 stmOtaResponseStreamDisposable = it.connect()
             }

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/stmota/StmOtaResponseParser.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/stmota/StmOtaResponseParser.kt
@@ -3,8 +3,9 @@ package com.simprints.fingerprint.infra.scanner.v2.incoming.stmota
 import com.simprints.fingerprint.infra.scanner.v2.domain.stmota.StmOtaResponse
 import com.simprints.fingerprint.infra.scanner.v2.domain.stmota.responses.CommandAcknowledgement
 import com.simprints.fingerprint.infra.scanner.v2.incoming.common.MessageParser
+import javax.inject.Inject
 
-class StmOtaResponseParser : MessageParser<StmOtaResponse> {
+class StmOtaResponseParser @Inject constructor() : MessageParser<StmOtaResponse> {
 
     override fun parse(messageBytes: ByteArray): StmOtaResponse =
         try {

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/common/OutputStreamDispatcher.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/common/OutputStreamDispatcher.kt
@@ -5,12 +5,13 @@ import com.simprints.fingerprint.infra.scanner.v2.tools.reactive.completable
 import io.reactivex.Completable
 import java.io.IOException
 import java.io.OutputStream
+import javax.inject.Inject
 
 /**
  * Class for sending any Iterable<ByteArray>, representing Bluetooth packets, out of the
  * [outputStream]
  */
-class OutputStreamDispatcher : OutgoingConnectable {
+class OutputStreamDispatcher @Inject constructor() : OutgoingConnectable {
 
     private var outputStream: OutputStream? = null
 

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/cypressota/CypressOtaMessageOutputStream.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/cypressota/CypressOtaMessageOutputStream.kt
@@ -3,8 +3,9 @@ package com.simprints.fingerprint.infra.scanner.v2.outgoing.cypressota
 import com.simprints.fingerprint.infra.scanner.v2.domain.cypressota.CypressOtaCommand
 import com.simprints.fingerprint.infra.scanner.v2.outgoing.common.MessageOutputStream
 import com.simprints.fingerprint.infra.scanner.v2.outgoing.common.OutputStreamDispatcher
+import javax.inject.Inject
 
-class CypressOtaMessageOutputStream(
+class CypressOtaMessageOutputStream @Inject constructor(
     cypressOtaMessageSerializer: CypressOtaMessageSerializer,
     outputStreamDispatcher: OutputStreamDispatcher
 ) : MessageOutputStream<CypressOtaCommand>(cypressOtaMessageSerializer, outputStreamDispatcher)

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/cypressota/CypressOtaMessageSerializer.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/cypressota/CypressOtaMessageSerializer.kt
@@ -2,8 +2,9 @@ package com.simprints.fingerprint.infra.scanner.v2.outgoing.cypressota
 
 import com.simprints.fingerprint.infra.scanner.v2.domain.cypressota.CypressOtaCommand
 import com.simprints.fingerprint.infra.scanner.v2.outgoing.common.MessageSerializer
+import javax.inject.Inject
 
-class CypressOtaMessageSerializer : MessageSerializer<CypressOtaCommand> {
+class CypressOtaMessageSerializer  @Inject constructor(): MessageSerializer<CypressOtaCommand> {
 
     override fun serialize(message: CypressOtaCommand): List<ByteArray> =
         listOf(message.getBytes())

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/main/MainMessageOutputStream.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/main/MainMessageOutputStream.kt
@@ -3,8 +3,9 @@ package com.simprints.fingerprint.infra.scanner.v2.outgoing.main
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.OutgoingMainMessage
 import com.simprints.fingerprint.infra.scanner.v2.outgoing.common.MessageOutputStream
 import com.simprints.fingerprint.infra.scanner.v2.outgoing.common.OutputStreamDispatcher
+import javax.inject.Inject
 
-class MainMessageOutputStream(
+class MainMessageOutputStream @Inject constructor(
     mainMessageSerializer: MainMessageSerializer,
     outputStreamDispatcher: OutputStreamDispatcher
 ) : MessageOutputStream<OutgoingMainMessage>(mainMessageSerializer, outputStreamDispatcher)

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/main/MainMessageSerializer.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/main/MainMessageSerializer.kt
@@ -7,8 +7,9 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.main.packet.PacketProto
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.packet.Route
 import com.simprints.fingerprint.infra.scanner.v2.outgoing.common.MessageSerializer
 import com.simprints.fingerprint.infra.scanner.v2.tools.primitives.chunked
+import javax.inject.Inject
 
-class MainMessageSerializer : MessageSerializer<OutgoingMainMessage> {
+class MainMessageSerializer @Inject constructor() : MessageSerializer<OutgoingMainMessage> {
 
     override fun serialize(message: OutgoingMainMessage): List<ByteArray> =
         message

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/root/RootMessageOutputStream.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/root/RootMessageOutputStream.kt
@@ -3,8 +3,9 @@ package com.simprints.fingerprint.infra.scanner.v2.outgoing.root
 import com.simprints.fingerprint.infra.scanner.v2.domain.root.RootCommand
 import com.simprints.fingerprint.infra.scanner.v2.outgoing.common.MessageOutputStream
 import com.simprints.fingerprint.infra.scanner.v2.outgoing.common.OutputStreamDispatcher
+import javax.inject.Inject
 
-class RootMessageOutputStream(
+class RootMessageOutputStream @Inject constructor(
     rootMessageSerializer: RootMessageSerializer,
     outputStreamDispatcher: OutputStreamDispatcher
 ) : MessageOutputStream<RootCommand>(rootMessageSerializer, outputStreamDispatcher)

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/root/RootMessageSerializer.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/root/RootMessageSerializer.kt
@@ -4,8 +4,9 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.root.RootCommand
 import com.simprints.fingerprint.infra.scanner.v2.domain.root.RootMessageProtocol
 import com.simprints.fingerprint.infra.scanner.v2.outgoing.common.MessageSerializer
 import com.simprints.fingerprint.infra.scanner.v2.tools.primitives.chunked
+import javax.inject.Inject
 
-class RootMessageSerializer : MessageSerializer<RootCommand> {
+class RootMessageSerializer @Inject constructor() : MessageSerializer<RootCommand> {
 
     override fun serialize(message: RootCommand): List<ByteArray> =
         message.getBytes().chunked(RootMessageProtocol.MAX_PAYLOAD_SIZE)

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/stmota/StmOtaMessageOutputStream.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/stmota/StmOtaMessageOutputStream.kt
@@ -3,8 +3,9 @@ package com.simprints.fingerprint.infra.scanner.v2.outgoing.stmota
 import com.simprints.fingerprint.infra.scanner.v2.domain.stmota.StmOtaCommand
 import com.simprints.fingerprint.infra.scanner.v2.outgoing.common.MessageOutputStream
 import com.simprints.fingerprint.infra.scanner.v2.outgoing.common.OutputStreamDispatcher
+import javax.inject.Inject
 
-class StmOtaMessageOutputStream(
+class StmOtaMessageOutputStream @Inject constructor(
     stmOtaMessageSerializer: StmOtaMessageSerializer,
     outputStreamDispatcher: OutputStreamDispatcher
 ) : MessageOutputStream<StmOtaCommand>(stmOtaMessageSerializer, outputStreamDispatcher)

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/stmota/StmOtaMessageSerializer.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/outgoing/stmota/StmOtaMessageSerializer.kt
@@ -2,8 +2,9 @@ package com.simprints.fingerprint.infra.scanner.v2.outgoing.stmota
 
 import com.simprints.fingerprint.infra.scanner.v2.domain.stmota.StmOtaCommand
 import com.simprints.fingerprint.infra.scanner.v2.outgoing.common.MessageSerializer
+import javax.inject.Inject
 
-class StmOtaMessageSerializer : MessageSerializer<StmOtaCommand> {
+class StmOtaMessageSerializer @Inject constructor() : MessageSerializer<StmOtaCommand> {
 
     override fun serialize(message: StmOtaCommand): List<ByteArray> =
         listOf(message.getBytes())

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/CreateScanner.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/CreateScanner.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 /**
  * Helper function to build a new [Scanner] instance with manual dependency injection
  */
+/*
 fun Scanner.Companion.create(dispatcher: CoroutineDispatcher): Scanner {
     val mainMessageChannel = MainMessageChannel(
         MainMessageInputStream(
@@ -105,3 +106,4 @@ fun Scanner.Companion.create(dispatcher: CoroutineDispatcher): Scanner {
     )
 
 }
+*/

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/Scanner.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/Scanner.kt
@@ -91,6 +91,7 @@ class Scanner(
             }
             flowableDisposable.dispose()
             state = disconnectedScannerState()
+            ScannerInfo.clear()
         }
     }
 

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/Scanner.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/Scanner.kt
@@ -1,5 +1,6 @@
 package com.simprints.fingerprint.infra.scanner.v2.scanner
 
+import com.simprints.core.DispatcherIO
 import com.simprints.fingerprint.infra.scanner.v2.channel.CypressOtaMessageChannel
 import com.simprints.fingerprint.infra.scanner.v2.channel.MainMessageChannel
 import com.simprints.fingerprint.infra.scanner.v2.channel.RootMessageChannel
@@ -30,10 +31,13 @@ import com.simprints.fingerprint.infra.scanner.v2.tools.reactive.*
 import io.reactivex.*
 import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.subscribeBy
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import javax.inject.Inject
+import javax.inject.Singleton
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.un20.models.DigitalValue as Un20DigitalValue
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.vero.models.DigitalValue as StmDigitalValue
 
@@ -43,8 +47,8 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.vero.model
  * @throws IllegalStateException On attempting to call certain methods whilst in an incorrect state
  * @throws IllegalArgumentException On receiving unexpected or invalid bytes from the scanner
  */
-@Suppress("unused")
-class Scanner(
+@Singleton
+class Scanner @Inject constructor(
     private val mainMessageChannel: MainMessageChannel,
     private val rootMessageChannel: RootMessageChannel,
     private val scannerInfoReaderHelper: ScannerExtendedInfoReaderHelper,
@@ -53,7 +57,10 @@ class Scanner(
     private val cypressOtaController: CypressOtaController,
     private val stmOtaController: StmOtaController,
     private val un20OtaController: Un20OtaController,
-) {
+    private val scannerInfo: ScannerInfo,
+    @DispatcherIO private val ioDispatcher: CoroutineDispatcher,
+
+    ) {
     private lateinit var flowableDisposable: Disposable
 
     private lateinit var outputStream: OutputStream
@@ -65,7 +72,7 @@ class Scanner(
     private var scannerTriggerListenerDisposable: Disposable? = null
 
     fun connect(inputStream: InputStream, outputStream: OutputStream) {
-        this.flowableInputStream = inputStream.toFlowable().subscribeOnIoAndPublish()
+        this.flowableInputStream = inputStream.toFlowable().subscribeOnIoAndPublish(ioDispatcher)
             .also { this.flowableDisposable = it.connect() }
         this.outputStream = outputStream
         state.connected = true
@@ -91,7 +98,7 @@ class Scanner(
             }
             flowableDisposable.dispose()
             state = disconnectedScannerState()
-            ScannerInfo.clear()
+            scannerInfo.clear()
         }
     }
 
@@ -120,13 +127,6 @@ class Scanner(
         assertMode(ROOT)
         return scannerInfoReaderHelper.readScannerInfo()
     }
-
-    suspend fun getExtendedVersionInformation(): ExtendedVersionInformation {
-        assertConnected()
-        assertMode(ROOT)
-        return scannerInfoReaderHelper.getExtendedVersionInfo().version
-    }
-
 
     suspend fun setVersionInformation(versionInformation: ExtendedVersionInformation) {
         assertConnected()

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ScannerExtendedInfoReaderHelper.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ScannerExtendedInfoReaderHelper.kt
@@ -24,9 +24,10 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.root.responses.GetExten
 import com.simprints.fingerprint.infra.scanner.v2.domain.root.responses.GetHardwareVersionResponse
 import com.simprints.fingerprint.infra.scanner.v2.domain.root.responses.GetVersionResponse
 import com.simprints.fingerprint.infra.scanner.v2.domain.root.responses.SetVersionResponse
+import javax.inject.Inject
 
 
-class ScannerExtendedInfoReaderHelper(
+class ScannerExtendedInfoReaderHelper @Inject constructor(
     private val mainMessageChannel: MainMessageChannel,
     private val rootMessageChannel: RootMessageChannel,
 ) {

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ScannerInfo.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ScannerInfo.kt
@@ -1,0 +1,56 @@
+package com.simprints.fingerprint.infra.scanner.v2.scanner
+
+
+/**
+ * Singleton class to manage and provide access to scanner-related information.
+ *
+ * This class handles two key pieces of information:
+ * 1. `scannerId`: The unique identifier of the scanner, available after connecting to the scanner.
+ * 2. `un20SerialNumber`: The serial number of the scanner, available only after reading an unprocessed image.
+ *
+ * Both properties can be updated independently based on the scanner's lifecycle and operations.
+ *
+ * Todo: When refactoring this module to use DI, consider using Hilt annotations (e.g., `@Singleton` and `@Inject`) to manage this class as a singleton within the DI framework.
+ */
+object ScannerInfo {
+
+    /**
+     * The unique identifier of the scanner.
+     * This property is set after successfully connecting to the scanner.
+     */
+    var scannerId: String? = null
+        private set
+
+    /**
+     * The serial number of the scanner.
+     * This property is set after successfully reading an unprocessed image from the scanner.
+     */
+    var un20SerialNumber: String? = null
+        private set
+
+    /**
+     * Updates the scanner ID.
+     *
+     * @param id The unique identifier of the scanner.
+     */
+    fun setScannerId(id: String) {
+        scannerId = id
+    }
+
+    /**
+     * Updates the serial number of the scanner.
+     *
+     * @param serialNumber The serial number retrieved from an unprocessed image.
+     */
+    fun setUn20SerialNumber(serialNumber: String) {
+        un20SerialNumber = serialNumber
+    }
+
+    /**
+     *  Clears the scanner ID and serial number.
+     */
+    fun clear() {
+        scannerId = null
+        un20SerialNumber = null
+    }
+}

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ScannerInfo.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ScannerInfo.kt
@@ -1,5 +1,8 @@
 package com.simprints.fingerprint.infra.scanner.v2.scanner
 
+import javax.inject.Inject
+import javax.inject.Singleton
+
 
 /**
  * Singleton class to manage and provide access to scanner-related information.
@@ -10,9 +13,9 @@ package com.simprints.fingerprint.infra.scanner.v2.scanner
  *
  * Both properties can be updated independently based on the scanner's lifecycle and operations.
  *
- * Todo: When refactoring this module to use DI, consider using Hilt annotations (e.g., `@Singleton` and `@Inject`) to manage this class as a singleton within the DI framework.
  */
-object ScannerInfo {
+@Singleton
+class ScannerInfo @Inject constructor() {
 
     /**
      * The unique identifier of the scanner.

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/errorhandler/ResponseErrorHandler.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/errorhandler/ResponseErrorHandler.kt
@@ -8,8 +8,9 @@ import com.simprints.fingerprint.infra.scanner.v2.domain.main.message.vero.respo
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import java.io.IOException
+import javax.inject.Inject
 
-class ResponseErrorHandler(
+class ResponseErrorHandler @Inject constructor(
     val strategy: ResponseErrorHandlingStrategy
 ) {
     /**

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ota/cypress/CypressOtaController.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ota/cypress/CypressOtaController.kt
@@ -16,13 +16,14 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
+import javax.inject.Inject
 
 /**
  * Conducts OTA for the Cypress module in accordance to
  * https://cypresssemiconductorco.github.io/btsdk-docs/BT-SDK/WICED-Firmware-Upgrade-Library.pdf
  * Pages 7-9
  */
-class CypressOtaController(private val crc32Calculator: Crc32Calculator) {
+class CypressOtaController @Inject constructor(private val crc32Calculator: Crc32Calculator) {
 
 
     suspend fun program(

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ota/stm/StmOtaController.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ota/stm/StmOtaController.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
+import javax.inject.Inject
 
 
 /**
@@ -31,7 +32,7 @@ import kotlinx.coroutines.flow.onCompletion
  * There are some particular memory address involved which reference specific parts in memory on
  * the STM32 - [START_ADDRESS] and [GO_ADDRESS].
  */
-class StmOtaController {
+class StmOtaController @Inject constructor() {
 
     /**
      * @throws OtaFailedException if received a NACK when communicating with STM

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ota/un20/Un20OtaController.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ota/un20/Un20OtaController.kt
@@ -17,8 +17,9 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import java.util.UUID
+import javax.inject.Inject
 
-class Un20OtaController(private val crc32Calculator: Crc32Calculator) {
+class Un20OtaController @Inject constructor(private val crc32Calculator: Crc32Calculator) {
 
     suspend fun program(
         mainMessageChannel: MainMessageChannel,

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/crc/Crc32Calculator.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/crc/Crc32Calculator.kt
@@ -1,10 +1,12 @@
 package com.simprints.fingerprint.infra.scanner.v2.tools.crc
 
+import javax.inject.Inject
+
 /**
  * Calculates the CRC checksum for given bytes using a popular standard [CRC32_TABLE].
  * Used for verifying sent firmware for Cypress and UN20 OTA.
  */
-class Crc32Calculator {
+class Crc32Calculator  @Inject constructor(){
 
     fun calculateCrc32(bytes: ByteArray): Int {
 

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/reactive/RxTools.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/reactive/RxTools.kt
@@ -5,7 +5,7 @@ import io.reactivex.Flowable
 import io.reactivex.Single
 import io.reactivex.flowables.ConnectableFlowable
 import io.reactivex.rxkotlin.Singles
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.rx2.asScheduler
 
 fun <T : Any> single(function: () -> T): Single<T> = Single.create { emitter ->
@@ -23,12 +23,9 @@ fun completable(function: () -> Unit): Completable = Completable.fromAction {
 
 inline fun <reified R> Flowable<*>.filterCast() = this.filter { it is R }.map { it as R }
 
-fun <T> Flowable<T>.subscribeOnIoAndPublish(): ConnectableFlowable<T> =
-    this.subscribeOn(ioScheduler).publish()
+fun <T> Flowable<T>.subscribeOnIoAndPublish(dispatcher: CoroutineDispatcher): ConnectableFlowable<T> =
+    this.subscribeOn(dispatcher.asScheduler()).publish()
 
 fun <T : Any> Completable.doSimultaneously(single: Single<T>): Single<T> =
     Singles.zip(single, this.toSingleDefault(Unit)) { value, _ -> value }
 
-
-//Todo Make it more generic by injecting scheduler once refactoring the scanner module
-val ioScheduler = Dispatchers.IO.asScheduler()

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/wrapper/ScannerFactory.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/wrapper/ScannerFactory.kt
@@ -11,7 +11,6 @@ import com.simprints.fingerprint.infra.scanner.helpers.Un20OtaHelper
 import com.simprints.fingerprint.infra.scanner.tools.ScannerGenerationDeterminer
 import com.simprints.fingerprint.infra.scanner.tools.SerialNumberConverter
 import com.simprints.fingerprint.infra.scanner.v2.scanner.ScannerInfo
-import com.simprints.fingerprint.infra.scanner.v2.scanner.create
 import com.simprints.fingerprint.infra.scanner.v2.tools.ScannerUiHelper
 import com.simprints.infra.config.store.models.FingerprintConfiguration
 import com.simprints.infra.config.sync.ConfigManager
@@ -36,10 +35,11 @@ class ScannerFactory @Inject internal constructor(
     private val un20OtaHelper: Un20OtaHelper,
     private val fingerprintCaptureWrapperFactory: FingerprintCaptureWrapperFactory,
     @DispatcherIO private val ioDispatcher: CoroutineDispatcher,
+    private val scannerInfo: ScannerInfo,
+    private val scannerV2 : ScannerV2
 ) {
 
     var scannerV1: ScannerV1? = null
-    var scannerV2: ScannerV2? = null
     var scannerOtaOperationsWrapper: ScannerOtaOperationsWrapper? = null
     var scannerWrapper: ScannerWrapper? = null
 
@@ -66,14 +66,13 @@ class ScannerFactory @Inject internal constructor(
             }
 
             FingerprintConfiguration.VeroGeneration.VERO_2 -> {
-                scannerV2 = ScannerV2.create(ioDispatcher)
                 scannerWrapper = createScannerWrapperV2(macAddress)
                 // Create OTA wrapper for V2 scanner only as V1 scanner doesn't support OTA
                 scannerOtaOperationsWrapper = createScannerOtaOperationsWrapper(macAddress)
                 //Cache the scannerV2 instance to be used by the FingerprintCaptureWrapperFactory
-                fingerprintCaptureWrapperFactory.createV2(scannerV2!!)
+                fingerprintCaptureWrapperFactory.createV2(scannerV2)
                 // Store the scanner ID
-                ScannerInfo.setScannerId(scannerId)
+                scannerInfo.setScannerId(scannerId)
             }
         }
     }
@@ -81,7 +80,7 @@ class ScannerFactory @Inject internal constructor(
     private fun createScannerOtaOperationsWrapper(macAddress: String): ScannerOtaOperationsWrapper =
         ScannerOtaOperationsWrapper(
             macAddress,
-            scannerV2!!,
+            scannerV2,
             cypressOtaHelper,
             stmOtaHelper,
             un20OtaHelper,
@@ -97,7 +96,7 @@ class ScannerFactory @Inject internal constructor(
 
     private fun createScannerWrapperV2(macAddress: String): ScannerWrapper {
         return ScannerWrapperV2(
-            scannerV2!!,
+            scannerV2,
             scannerUiHelper,
             macAddress,
             scannerInitialSetupHelper,

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/cypressota/CypressOtaMessageInputStreamTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/cypressota/CypressOtaMessageInputStreamTest.kt
@@ -14,6 +14,8 @@ import io.mockk.verify
 import io.reactivex.Flowable
 import io.reactivex.disposables.Disposable
 import io.reactivex.functions.Function
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Test
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
@@ -22,7 +24,11 @@ import java.util.concurrent.TimeUnit
 class CypressOtaMessageInputStreamTest {
 
     private val cypressOtaResponseParser = CypressOtaResponseParser()
-    private val cypressOtaMessageInputStream = CypressOtaMessageInputStream(cypressOtaResponseParser)
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val cypressOtaMessageInputStream = CypressOtaMessageInputStream(
+        cypressOtaResponseParser,
+        UnconfinedTestDispatcher()
+    )
 
     @Test
     fun `test disconnect disposes the flowable stream`() {

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/MainMessageInputStreamTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/MainMessageInputStreamTest.kt
@@ -27,6 +27,8 @@ import io.mockk.mockk
 import io.reactivex.Flowable
 import io.reactivex.rxkotlin.toFlowable
 import io.reactivex.schedulers.TestScheduler
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Test
 import java.util.concurrent.TimeUnit
 
@@ -34,7 +36,8 @@ class MainMessageInputStreamTest {
     private val packetRouter = mockk<PacketRouter> {
         justRun { connect(any()) }
     }
-
+@OptIn(ExperimentalCoroutinesApi::class)
+val dispatcher = UnconfinedTestDispatcher()
     @Suppress(
         "Ignoring flaky tests introduced by Ridwan. These tests do not follow proper" +
             " RxJava testing methodology and fail frequently on the CI machines. They need to be " +
@@ -49,7 +52,8 @@ class MainMessageInputStreamTest {
             packetRouter,
             veroResponseAccumulator,
             veroEventAccumulator,
-            un20ResponseAccumulator
+            un20ResponseAccumulator,
+            dispatcher
         )
 
         val messageBytes = "20 10 01 00 FF".hexToByteArray()
@@ -97,7 +101,8 @@ class MainMessageInputStreamTest {
             packetRouter,
             veroResponseAccumulator,
             veroEventAccumulator,
-            un20ResponseAccumulator
+            un20ResponseAccumulator,
+            dispatcher,
         )
 
         val messageBytes = "30 00 01 00 00 00 10".hexToByteArray()
@@ -142,7 +147,8 @@ class MainMessageInputStreamTest {
             packetRouter,
             veroResponseAccumulator,
             veroEventAccumulator,
-            un20ResponseAccumulator
+            un20ResponseAccumulator,
+            dispatcher,
         )
 
         val numberOfEvents = 5
@@ -187,7 +193,8 @@ class MainMessageInputStreamTest {
             packetRouter,
             veroResponseAccumulator,
             veroEventAccumulator,
-            un20ResponseAccumulator
+            un20ResponseAccumulator,
+            dispatcher,
         )
 
         val messageBytes = "20 10 01 00 FF 20 10 01 00 00".hexToByteArray()
@@ -231,7 +238,8 @@ class MainMessageInputStreamTest {
             packetRouter,
             veroResponseAccumulator,
             veroEventAccumulator,
-            un20ResponseAccumulator
+            un20ResponseAccumulator,
+            dispatcher,
         )
 
         val messageBytes = "20 20 01 00 00 30 10 01 00 FF 20 10 01 00 FF".hexToByteArray()
@@ -280,7 +288,8 @@ class MainMessageInputStreamTest {
             packetRouter,
             veroResponseAccumulator,
             veroEventAccumulator,
-            un20ResponseAccumulator
+            un20ResponseAccumulator,
+            dispatcher,
         )
 
         val veroResponseBytes = "20 10 01 00 FF".hexToByteArray()

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/packet/PacketRouterTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/packet/PacketRouterTest.kt
@@ -8,6 +8,8 @@ import com.simprints.fingerprint.infra.scanner.v2.tools.lang.objects
 import com.simprints.fingerprint.infra.scanner.v2.tools.reactive.toFlowable
 import com.simprints.testtools.common.syntax.failTest
 import com.simprints.testtools.unit.reactive.testSubscribe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
 import org.junit.Test
 import java.io.PipedInputStream
@@ -19,13 +21,19 @@ class PacketRouterTest {
     private lateinit var inputStream: PipedInputStream
     private lateinit var router: PacketRouter
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun setUp() {
         outputStream = PipedOutputStream()
         inputStream = PipedInputStream()
         inputStream.connect(outputStream)
 
-        router = PacketRouter(Route.Remote::class.objects(), { source }, ByteArrayToPacketAccumulator(PacketParser()))
+        router = PacketRouter(
+            Route.Remote::class.objects(), { source }, ByteArrayToPacketAccumulator(
+                PacketParser(),
+            )
+            , Dispatchers.IO
+        )
 
         router.connect(inputStream.toFlowable())
     }

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/root/RootMessageInputStreamTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/root/RootMessageInputStreamTest.kt
@@ -16,6 +16,8 @@ import io.mockk.verify
 import io.reactivex.Flowable
 import io.reactivex.disposables.Disposable
 import io.reactivex.observers.BaseTestConsumer.TestWaitStrategy
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Test
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
@@ -24,7 +26,9 @@ import java.util.concurrent.TimeUnit
 class RootMessageInputStreamTest {
 
     private val rootMessageAccumulator = RootResponseAccumulator(RootResponseParser())
-    private val rootMessageInputStream = RootMessageInputStream(rootMessageAccumulator)
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val rootMessageInputStream =
+        RootMessageInputStream(rootMessageAccumulator, UnconfinedTestDispatcher())
 
     @Test
     fun `test disconnect disposes the flowable stream`() {

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/stmota/StmOtaMessageInputStreamTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/stmota/StmOtaMessageInputStreamTest.kt
@@ -14,6 +14,8 @@ import io.mockk.verify
 import io.reactivex.Flowable
 import io.reactivex.disposables.Disposable
 import io.reactivex.functions.Function
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Test
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
@@ -22,7 +24,10 @@ import java.util.concurrent.TimeUnit
 class StmOtaMessageInputStreamTest {
 
     private val stmOtaResponseParser = StmOtaResponseParser()
-    private val stmOtaMessageInputStream = StmOtaMessageInputStream(stmOtaResponseParser)
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val stmOtaMessageInputStream = StmOtaMessageInputStream(stmOtaResponseParser,
+        UnconfinedTestDispatcher()
+    )
 
     @Test
     fun `test disconnect disposes the flowable stream`() {

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ScannerExtendedInfoReaderHelperTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ScannerExtendedInfoReaderHelperTest.kt
@@ -169,7 +169,7 @@ class ScannerExtendedInfoReaderHelperTest {
     private fun getRootMessageChannel(): RootMessageChannel {
         val responseSubject = PublishSubject.create<RootResponse>()
 
-        val spyRootMessageInputStream = spyk(RootMessageInputStream(mockk())).apply {
+        val spyRootMessageInputStream = spyk(RootMessageInputStream(mockk(),mockk())).apply {
             justRun { connect(any()) }
             justRun { disconnect() }
             every { rootResponseStream } returns responseSubject.toFlowable(BackpressureStrategy.BUFFER)

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ScannerTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ScannerTest.kt
@@ -97,6 +97,7 @@ class ScannerTest {
     private lateinit var mockkInputStream: InputStream
     private val un20OtaController: Un20OtaController = mockk()
     private val mockkOutputStream = mockk<OutputStream>()
+    private val scannerInfo = ScannerInfo()
 
     @get:Rule
     val rule = InstantTaskExecutorRule()
@@ -127,7 +128,7 @@ class ScannerTest {
             MainMessageChannel(mockkMessageInputStream, mockkMessageOutputStream, dispatcher),
             setupRootMessageChannelMock(),
             mockk(), mockk(), mockk(), mockk(), mockk(),
-            un20OtaController,
+            un20OtaController,scannerInfo,dispatcher,
         )
     }
 
@@ -289,6 +290,8 @@ class ScannerTest {
             mockk(),
             mockk(),
             mockk(),
+            scannerInfo,
+dispatcher,
         )
         scanner.connect(mockkInputStream, mockkOutputStream)
         verify { rootMessageChannel.connect(any(), any()) }
@@ -336,6 +339,8 @@ class ScannerTest {
             mockk(),
             mockk(),
             mockk(),
+            scannerInfo,
+dispatcher,
         )
         scanner.disconnect()
         verify(exactly = 0) { mockRootMessageChannel.disconnect() }
@@ -357,6 +362,8 @@ class ScannerTest {
             mockk(),
             mockk(),
             mockk(),
+            scannerInfo,
+dispatcher,
         )
         scanner.connect(mockkInputStream, mockkOutputStream)
         scanner.enterCypressOtaMode()
@@ -380,6 +387,8 @@ class ScannerTest {
             mockk(),
             mockk(),
             mockk(),
+            scannerInfo,
+dispatcher,
         )
         scanner.connect(mockkInputStream, mockkOutputStream)
 
@@ -415,6 +424,8 @@ class ScannerTest {
                 mockkCypressOtaController,
                 mockk(),
                 mockk(),
+                scannerInfo,
+dispatcher,
             )
             scanner.connect(mockkInputStream, mockkOutputStream)
             scanner.enterCypressOtaMode()
@@ -448,6 +459,8 @@ class ScannerTest {
             mockk(),
             mockk(),
             mockk(),
+            scannerInfo,
+dispatcher,
         )
         scanner.connect(mockkInputStream, mockkOutputStream)
 
@@ -478,6 +491,8 @@ class ScannerTest {
             mockk(),
             mockk(),
             mockk(),
+            scannerInfo,
+dispatcher,
         )
         scanner.connect(mockkInputStream, mockkOutputStream)
 
@@ -506,6 +521,8 @@ class ScannerTest {
             mockk(),
             mockkStmOtaController,
             mockk(),
+            scannerInfo,
+dispatcher,
         )
         scanner.connect(mockkInputStream, mockkOutputStream)
 
@@ -669,10 +686,10 @@ class ScannerTest {
     @Test
     fun scanner_connectThenDisconnect_clearScannerInfo() {
         scanner.connect(mockkInputStream, mockkOutputStream)
-        ScannerInfo.setScannerId("123")
+        scannerInfo.setScannerId("123")
         scanner.disconnect()
         assertThat(scanner.state).isEqualTo(disconnectedScannerState())
-        assertThat(ScannerInfo.scannerId).isNull()
+        assertThat(scannerInfo.scannerId).isNull()
     }
 
     @Test
@@ -704,6 +721,8 @@ class ScannerTest {
             mockk(),
             mockk(),
             mockk(),
+            scannerInfo,
+dispatcher,
         )
         scanner.connect(mockkInputStream, mockkOutputStream)
 
@@ -767,6 +786,8 @@ class ScannerTest {
         mockk(),
         mockk(),
         mockk(),
+        scannerInfo,
+dispatcher,
     )
 
     private fun createScanner(scannerInfoReaderMockk: ScannerExtendedInfoReaderHelper) = Scanner(
@@ -778,5 +799,7 @@ class ScannerTest {
         mockk(),
         mockk(),
         mockk(),
+        scannerInfo,
+dispatcher,
     )
 }

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ScannerTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ScannerTest.kt
@@ -666,6 +666,14 @@ class ScannerTest {
         scanner.disconnect()
         assertThat(scanner.state).isEqualTo(disconnectedScannerState())
     }
+    @Test
+    fun scanner_connectThenDisconnect_clearScannerInfo() {
+        scanner.connect(mockkInputStream, mockkOutputStream)
+        ScannerInfo.setScannerId("123")
+        scanner.disconnect()
+        assertThat(scanner.state).isEqualTo(disconnectedScannerState())
+        assertThat(ScannerInfo.scannerId).isNull()
+    }
 
     @Test
     fun scanner_getStmVersion_shouldReturnStmExtendedVersion() = runTest {

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ota/cypress/CypressOtaControllerTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ota/cypress/CypressOtaControllerTest.kt
@@ -123,7 +123,7 @@ class CypressOtaControllerTest {
         val messageIndex = AtomicInteger(0)
 
         return CypressOtaMessageChannel(
-            spyk(CypressOtaMessageInputStream(mockk())) {
+            spyk(CypressOtaMessageInputStream(mockk(), mockk())) {
                 justRun { connect(any()) }
                 cypressOtaResponseStream = responseSubject.toFlowable(BackpressureStrategy.BUFFER)
             },

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ota/stm/StmOtaControllerTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ota/stm/StmOtaControllerTest.kt
@@ -79,7 +79,7 @@ class StmOtaControllerTest {
         val messageIndex = AtomicInteger(0)
 
         return StmOtaMessageChannel(
-            spyk(StmOtaMessageInputStream(mockk())).apply {
+            spyk(StmOtaMessageInputStream(mockk(), mockk())).apply {
                 justRun { connect(any()) }
                 every { stmOtaResponseStream } returns responseSubject.toFlowable(
                     BackpressureStrategy.BUFFER

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ota/un20/Un20OtaControllerTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/scanner/ota/un20/Un20OtaControllerTest.kt
@@ -26,6 +26,7 @@ import io.reactivex.subjects.PublishSubject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
@@ -120,7 +121,9 @@ class Un20OtaControllerTest {
         val messageIndex = AtomicInteger(0)
 
         return MainMessageChannel(
-            spyk(MainMessageInputStream(mockk(), mockk(), mockk(), mockk())).apply {
+            spyk(MainMessageInputStream(mockk(), mockk(), mockk(), mockk(),
+                UnconfinedTestDispatcher()
+            )).apply {
                 justRun { connect(any()) }
                 every { un20Responses } returns responseSubject.toFlowable(BackpressureStrategy.BUFFER)
             },

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/wrapper/ScannerFactoryTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/wrapper/ScannerFactoryTest.kt
@@ -5,6 +5,7 @@ import com.simprints.fingerprint.infra.scanner.capture.FingerprintCaptureWrapper
 import com.simprints.fingerprint.infra.scanner.component.bluetooth.ComponentBluetoothAdapter
 import com.simprints.fingerprint.infra.scanner.tools.ScannerGenerationDeterminer
 import com.simprints.fingerprint.infra.scanner.tools.SerialNumberConverter
+import com.simprints.fingerprint.infra.scanner.v2.scanner.Scanner
 import com.simprints.fingerprint.infra.scanner.v2.scanner.ScannerInfo
 import com.simprints.fingerprint.infra.scanner.v2.tools.ScannerUiHelper
 import com.simprints.infra.config.store.models.FingerprintConfiguration
@@ -39,6 +40,9 @@ class ScannerFactoryTest {
 
     @MockK(relaxed = true)
     private lateinit var fingerprintCaptureWrapperFactory: FingerprintCaptureWrapperFactory
+    private val scannerInfo = ScannerInfo()
+    @MockK
+    private lateinit var scannerV2: Scanner
 
     @Before
     fun setUp() {
@@ -56,6 +60,8 @@ class ScannerFactoryTest {
             mockk(),
             fingerprintCaptureWrapperFactory,
             mockk(),
+            scannerInfo,
+            scannerV2,
         )
     }
 
@@ -95,8 +101,7 @@ class ScannerFactoryTest {
             // When
             scannerFactory.initScannerOperationWrappers(macAddress)
             // Then
-            Truth.assertThat(scannerFactory.scannerV2).isNotNull()
-            Truth.assertThat(ScannerInfo.scannerId).isEqualTo(serialNumber)
+            Truth.assertThat(scannerInfo.scannerId).isEqualTo(serialNumber)
             Truth.assertThat(scannerFactory.scannerWrapper)
                 .isInstanceOf(ScannerWrapperV2::class.java)
             Truth.assertThat(scannerFactory.scannerOtaOperationsWrapper).isNotNull()

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/wrapper/ScannerFactoryTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/wrapper/ScannerFactoryTest.kt
@@ -5,6 +5,7 @@ import com.simprints.fingerprint.infra.scanner.capture.FingerprintCaptureWrapper
 import com.simprints.fingerprint.infra.scanner.component.bluetooth.ComponentBluetoothAdapter
 import com.simprints.fingerprint.infra.scanner.tools.ScannerGenerationDeterminer
 import com.simprints.fingerprint.infra.scanner.tools.SerialNumberConverter
+import com.simprints.fingerprint.infra.scanner.v2.scanner.ScannerInfo
 import com.simprints.fingerprint.infra.scanner.v2.tools.ScannerUiHelper
 import com.simprints.infra.config.store.models.FingerprintConfiguration
 import com.simprints.infra.config.sync.ConfigManager
@@ -95,6 +96,7 @@ class ScannerFactoryTest {
             scannerFactory.initScannerOperationWrappers(macAddress)
             // Then
             Truth.assertThat(scannerFactory.scannerV2).isNotNull()
+            Truth.assertThat(ScannerInfo.scannerId).isEqualTo(serialNumber)
             Truth.assertThat(scannerFactory.scannerWrapper)
                 .isInstanceOf(ScannerWrapperV2::class.java)
             Truth.assertThat(scannerFactory.scannerOtaOperationsWrapper).isNotNull()

--- a/fingerprint/infra/scannermock/src/main/java/com/simprints/fingerprint/infra/scannermock/simulated/v2/SimulatedCommandInputStream.kt
+++ b/fingerprint/infra/scannermock/src/main/java/com/simprints/fingerprint/infra/scannermock/simulated/v2/SimulatedCommandInputStream.kt
@@ -84,6 +84,7 @@ import com.simprints.fingerprint.infra.scanner.v2.tools.reactive.toFlowable
 import io.reactivex.Flowable
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.Dispatchers
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
 
@@ -101,7 +102,8 @@ class SimulatedCommandInputStream {
         PacketRouter(
             listOf(Route.Remote.VeroServer, Route.Remote.Un20Server),
             { destination },
-            ByteArrayToPacketAccumulator(PacketParser())
+            ByteArrayToPacketAccumulator(PacketParser()),
+            Dispatchers.IO,
         ).also { it.connect(mainInputStream.toFlowable()) }
 
     val rootCommands: Flowable<RootCommand> =


### PR DESCRIPTION
This PR introduces the ScannerInfo class to manage scanner-related information (scannerId and un20SerialNumber) and ensures that this information is included in the image metadata when available.
Key Changes:
- Added ScannerInfo as a singleton to handle scanner-related details.
- Updated image metadata to inclode scannerId and un20SerialNumber.
- Attached screenshots showcasing the differences in metadata structure for NEC and SimMatcher SDKs.

NEC 
![image](https://github.com/user-attachments/assets/bd0f0d94-582c-4bac-9ec3-3fca8b578073)
SimMatcher
![image](https://github.com/user-attachments/assets/bfd1c83b-4994-4443-8e47-6de72891bea2)
