### PR TITLE
Hotfix: preserve step cache for all followup calls

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
@@ -82,7 +82,9 @@ internal class OrchestratorViewModel @Inject constructor(
         actionRequest = action
 
         try {
-            steps = stepsBuilder.build(action, projectConfiguration)
+            // We must preserve all of the steps across multiple callouts in to correctly
+            // resolve missing modality capture in enrol last followup call.
+            steps = cache.steps + stepsBuilder.build(action, projectConfiguration)
         } catch (e: SubjectAgeNotSupportedException) {
             sendErrorResponse(AppErrorResponse(AppErrorReason.AGE_GROUP_NOT_SUPPORTED))
             return@launch

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/OrchestratorViewModelTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/OrchestratorViewModelTest.kt
@@ -348,27 +348,8 @@ internal class OrchestratorViewModelTest {
         every { cache.steps } returns savedSteps
 
         viewModel.handleAction(mockk())
-        viewModel.restoreStepsIfNeeded()
 
         verify { cache.steps }
-    }
-
-    @Test
-    fun `Does not restore steps if not empty`() = runTest {
-        val originalSteps = listOf(
-            createMockStep(StepId.FINGERPRINT_CAPTURE),
-        )
-        every { stepsBuilder.build(any(), any()) } returns originalSteps
-        val savedSteps = listOf(
-            createMockStep(StepId.SETUP),
-            createMockStep(StepId.CONSENT),
-        )
-        every { cache.steps } returns savedSteps
-
-        viewModel.handleAction(mockk())
-        viewModel.restoreStepsIfNeeded()
-
-        verify(exactly = 0) { cache.steps }
     }
 
     @Test


### PR DESCRIPTION
* With the introduction of matching modalities, callout sequence "identify->confirm->enrol last" led to an unexpected double capture.
* The issue was caused by the step cache being re-written to contain only "confirm" callout steps by the time "enrol last" is called.
* Steps of each new callout are being appended to the already cached steps. Since old steps are in "COMPLETE" step, it does not interfere with the currently executing steps. 
