### PR TITLE
MS-679 Logging interface cleanup

### DIFF
--- a/face/capture/src/androidTest/java/com/simprints/face/capture/livefeedback/LiveFeedbackFragmentTest.kt
+++ b/face/capture/src/androidTest/java/com/simprints/face/capture/livefeedback/LiveFeedbackFragmentTest.kt
@@ -67,7 +67,7 @@ class LiveFeedbackFragmentTest {
                 try {
                     allowPermissions.click()
                 } catch (e: UiObjectNotFoundException) {
-                    Simber.e(e, "There is no permissions dialog to interact with.")
+                    Simber.e("There is no permissions dialog to interact with.", e)
                 }
             }
         }

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/FaceCaptureViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/FaceCaptureViewModel.kt
@@ -201,7 +201,7 @@ internal class FaceCaptureViewModel @Inject constructor(
     }
 
     fun submitError(throwable: Throwable) {
-        Simber.e(throwable)
+        Simber.e("Face capture failed", throwable)
         _unexpectedErrorEvent.send()
     }
 

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/FaceCaptureViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/FaceCaptureViewModel.kt
@@ -26,7 +26,8 @@ import com.simprints.infra.license.models.License
 import com.simprints.infra.license.models.LicenseState
 import com.simprints.infra.license.models.LicenseVersion
 import com.simprints.infra.license.models.Vendor
-import com.simprints.infra.logging.LoggingConstants.CrashReportTag
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.FACE_CAPTURE
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.LICENSE
 import com.simprints.infra.logging.Simber
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.filterNotNull
@@ -78,7 +79,7 @@ internal class FaceCaptureViewModel @Inject constructor(
     private val _invalidLicense = MutableLiveData<LiveDataEvent>()
 
     init {
-        Simber.tag(CrashReportTag.FACE_CAPTURE.name).i("Starting face capture flow")
+        Simber.tag(FACE_CAPTURE.name).i("Starting face capture flow")
     }
 
     fun setupCapture(samplesToCapture: Int) {
@@ -95,7 +96,7 @@ internal class FaceCaptureViewModel @Inject constructor(
 
         // In some cases license is invalidated on initialisation attempt
         if (licenseStatus != LicenseStatus.VALID) {
-            Simber.tag(CrashReportTag.LICENSE.name).i("Face license is $licenseStatus - attempting download")
+            Simber.tag(LICENSE.name).i("Face license is $licenseStatus - attempting download")
             licenseStatus = refreshLicenceAndRetry(
                 activity,
                 licenseVendor,
@@ -111,7 +112,7 @@ internal class FaceCaptureViewModel @Inject constructor(
         }
         // Still invalid after attempted refresh
         if (licenseStatus != LicenseStatus.VALID) {
-            Simber.tag(CrashReportTag.LICENSE.name).i("Face license is $licenseStatus")
+            Simber.tag(LICENSE.name).i("Face license is $licenseStatus")
             licenseRepository.deleteCachedLicense(Vendor.RankOne)
             _invalidLicense.send()
         }
@@ -181,13 +182,13 @@ internal class FaceCaptureViewModel @Inject constructor(
     }
 
     fun recapture() {
-        Simber.tag(CrashReportTag.FACE_CAPTURE.name).i("Starting face recapture flow")
+        Simber.tag(FACE_CAPTURE.name).i("Starting face recapture flow")
         faceDetections = listOf()
         _recaptureEvent.send()
     }
 
     private fun saveFaceDetections() {
-        Simber.tag(CrashReportTag.FACE_CAPTURE.name).i("Saving captures to disk")
+        Simber.tag(FACE_CAPTURE.name).i("Saving captures to disk")
         faceDetections.forEach { saveImage(it, it.id) }
     }
 

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -182,7 +182,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
         try {
             vm.process(croppedBitmap = image)
         } catch (t: Throwable) {
-            Simber.e(t)
+            Simber.e("Image analysis crashed", t)
             // Image analysis is running in bg thread
             lifecycleScope.launch {
                 mainVm.submitError(t)

--- a/face/capture/src/main/java/com/simprints/face/capture/usecases/SaveFaceImageUseCase.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/usecases/SaveFaceImageUseCase.kt
@@ -41,7 +41,7 @@ internal class SaveFaceImageUseCase @Inject constructor(
             ),
         )
     } catch (t: Throwable) {
-        Simber.e(t)
+        Simber.e("Error determining path for captureId=$captureEventId", t)
         null
     }
 

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/ClientApiViewModel.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/ClientApiViewModel.kt
@@ -79,7 +79,7 @@ class ClientApiViewModel @Inject internal constructor(
             }
             intentMapper(action = action, extras = extrasMap, project = getProject())
         } catch (validationException: InvalidRequestException) {
-            Simber.e(validationException)
+            Simber.e("Cannot parse intent data", validationException)
             simpleEventReporter.addInvalidIntentEvent(action, extrasMap)
             _showAlert.send(validationException.error)
             null

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/usecases/CreateSessionIfRequiredUseCase.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/usecases/CreateSessionIfRequiredUseCase.kt
@@ -27,7 +27,7 @@ internal class CreateSessionIfRequiredUseCase @Inject constructor(
 
         coreEventRepository
             .createSession()
-            .also { Simber.tag(LoggingConstants.CrashReportingCustomKeys.SESSION_ID, true).i(it.id) }
+            .also { Simber.setUserProperty(LoggingConstants.CrashReportingCustomKeys.SESSION_ID, it.id) }
         coreEventRepository.addOrUpdateEvent(IntentParsingEvent(timeHelper.now(), integrationInfo))
         return true
     }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/MainViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/MainViewModel.kt
@@ -39,7 +39,7 @@ internal class MainViewModel @Inject constructor(
     private fun checkIfDeviceIsSafe() = try {
         securityManager.checkIfDeviceIsRooted()
     } catch (ex: RootedDeviceException) {
-        Simber.e(ex)
+        Simber.e("Rooted device detected", ex)
         _rootedDeviceDetected.send()
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.simprints.infra.config.store.models.GeneralConfiguration
 import com.simprints.infra.config.store.models.SettingsPasswordConfig
 import com.simprints.infra.config.sync.ConfigManager
-import com.simprints.infra.logging.LoggingConstants
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SETTINGS
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.sync.SyncOrchestrator
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -39,7 +39,7 @@ internal class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             configManager.updateDeviceConfiguration { it.apply { it.language = language } }
             _languagePreference.postValue(language)
-            Simber.tag(LoggingConstants.CrashReportTag.SETTINGS.name).i("Language set to $language")
+            Simber.tag(SETTINGS.name).i("Language set to $language")
         }
     }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
@@ -221,7 +221,7 @@ internal class SyncInfoViewModel @Inject constructor(
     private suspend fun fetchAndUpdateRecordsToDownSyncAndDeleteCount(): DownSyncCounts = try {
         eventSyncManager.countEventsToDownload()
     } catch (t: Throwable) {
-        Simber.d(t)
+        Simber.d("Could not count events for download", t)
         DownSyncCounts(0, isLowerBound = false)
     }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/repository/ModuleRepositoryImpl.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/repository/ModuleRepositoryImpl.kt
@@ -5,7 +5,7 @@ import com.simprints.infra.config.sync.ConfigManager
 import com.simprints.infra.enrolment.records.store.EnrolmentRecordRepository
 import com.simprints.infra.enrolment.records.store.domain.models.SubjectQuery
 import com.simprints.infra.eventsync.EventSyncManager
-import com.simprints.infra.logging.LoggingConstants
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SETTINGS
 import com.simprints.infra.logging.LoggingConstants.CrashReportingCustomKeys.MODULE_IDS
 import com.simprints.infra.logging.Simber
 import javax.inject.Inject
@@ -61,6 +61,6 @@ internal class ModuleRepositoryImpl @Inject constructor(
     }
 
     private fun logMessageForCrashReport(message: String) {
-        Simber.tag(LoggingConstants.CrashReportTag.SETTINGS.name).i(message.take(99))
+        Simber.tag(SETTINGS.name).i(message.take(99))
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/repository/ModuleRepositoryImpl.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/repository/ModuleRepositoryImpl.kt
@@ -57,7 +57,7 @@ internal class ModuleRepositoryImpl @Inject constructor(
     }
 
     private fun setCrashlyticsKeyForModules(modules: List<String>) {
-        Simber.tag(MODULE_IDS, true).i(modules.toString().take(80))
+        Simber.setUserProperty(MODULE_IDS, modules.toString().take(80))
     }
 
     private fun logMessageForCrashReport(message: String) {

--- a/feature/enrol-last-biometric/src/main/java/com/simprints/feature/enrollast/screen/EnrolLastBiometricViewModel.kt
+++ b/feature/enrol-last-biometric/src/main/java/com/simprints/feature/enrollast/screen/EnrolLastBiometricViewModel.kt
@@ -78,7 +78,7 @@ internal class EnrolLastBiometricViewModel @Inject constructor(
 
             _finish.send(EnrolLastState.Success(subject.subjectId))
         } catch (t: Throwable) {
-            Simber.tag(ENROLMENT.name).e(t)
+            Simber.tag(ENROLMENT.name).e("Enrolment failed", t)
             _finish.send(EnrolLastState.Failed(GENERAL_ERROR, modalities))
         }
     }

--- a/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/screen/usecase/FetchSubjectUseCase.kt
+++ b/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/screen/usecase/FetchSubjectUseCase.kt
@@ -38,7 +38,7 @@ internal class FetchSubjectUseCase @Inject constructor(
 
             return notFoundState()
         } catch (t: Throwable) {
-            Simber.e(t)
+            Simber.e("[FETCH_GUID] Error fetching", t)
             return notFoundState()
         }
     }

--- a/feature/login-check/src/main/java/com/simprints/feature/logincheck/LoginCheckViewModel.kt
+++ b/feature/login-check/src/main/java/com/simprints/feature/logincheck/LoginCheckViewModel.kt
@@ -73,7 +73,7 @@ class LoginCheckViewModel @Inject internal constructor(
         rootManager.checkIfDeviceIsRooted()
         true
     } catch (e: RootedDeviceException) {
-        Simber.e(e)
+        Simber.e("Rooted device detected on login check", e)
         _showAlert.send(LoginCheckError.ROOTED_DEVICE)
         false
     }

--- a/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/ExtractCrashKeysUseCase.kt
+++ b/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/ExtractCrashKeysUseCase.kt
@@ -14,9 +14,12 @@ internal class ExtractCrashKeysUseCase @Inject constructor(
     suspend operator fun invoke(action: ActionRequest) {
         val projectConfiguration = configManager.getProjectConfiguration()
         val deviceConfiguration = configManager.getDeviceConfiguration()
-        Simber.tag(CrashReportingCustomKeys.PROJECT_ID, true).i(authStore.signedInProjectId)
-        Simber.tag(CrashReportingCustomKeys.USER_ID, true).i(action.userId.toString())
-        Simber.tag(CrashReportingCustomKeys.MODULE_IDS, true).i(deviceConfiguration.selectedModules.toString())
-        Simber.tag(CrashReportingCustomKeys.SUBJECTS_DOWN_SYNC_TRIGGERS, true).i(projectConfiguration.synchronization.frequency.toString())
+        Simber.setUserProperty(CrashReportingCustomKeys.PROJECT_ID, authStore.signedInProjectId)
+        Simber.setUserProperty(CrashReportingCustomKeys.USER_ID, action.userId.toString())
+        Simber.setUserProperty(CrashReportingCustomKeys.MODULE_IDS, deviceConfiguration.selectedModules.toString())
+        Simber.setUserProperty(
+            CrashReportingCustomKeys.SUBJECTS_DOWN_SYNC_TRIGGERS,
+            projectConfiguration.synchronization.frequency.toString(),
+        )
     }
 }

--- a/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/ExtractParametersForAnalyticsUseCase.kt
+++ b/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/ExtractParametersForAnalyticsUseCase.kt
@@ -15,10 +15,10 @@ internal class ExtractParametersForAnalyticsUseCase @Inject constructor(
     suspend operator fun invoke(action: ActionRequest) = with(action) {
         ignoreException {
             if (this is ActionRequest.FlowAction) {
-                Simber.tag(AnalyticsUserProperties.USER_ID, true).i(userId.toString())
-                Simber.tag(AnalyticsUserProperties.PROJECT_ID).i(projectId)
-                Simber.tag(AnalyticsUserProperties.MODULE_ID).i(moduleId.toString())
-                Simber.tag(AnalyticsUserProperties.DEVICE_ID).i(deviceId)
+                Simber.setUserProperty(AnalyticsUserProperties.USER_ID, userId.toString())
+                Simber.setUserProperty(AnalyticsUserProperties.PROJECT_ID, projectId)
+                Simber.setUserProperty(AnalyticsUserProperties.MODULE_ID, moduleId.toString())
+                Simber.setUserProperty(AnalyticsUserProperties.DEVICE_ID, deviceId)
             }
             Simber.i(eventRepository.getCurrentSessionScope().id)
         }

--- a/feature/login-check/src/test/java/com/simprints/feature/logincheck/usecases/ExtractCrashKeysUseCaseTest.kt
+++ b/feature/login-check/src/test/java/com/simprints/feature/logincheck/usecases/ExtractCrashKeysUseCaseTest.kt
@@ -56,10 +56,10 @@ class ExtractCrashKeysUseCaseTest {
         useCase(ActionFactory.getFlowRequest())
 
         verify {
-            Simber.i("projectId")
-            Simber.i("userId")
-            Simber.i("[module1, module2]")
-            Simber.i("PERIODICALLY")
+            Simber.setUserProperty(any(), "projectId")
+            Simber.setUserProperty(any(), "userId")
+            Simber.setUserProperty(any(), "[module1, module2]")
+            Simber.setUserProperty(any(), "PERIODICALLY")
         }
     }
 }

--- a/feature/login-check/src/test/java/com/simprints/feature/logincheck/usecases/ExtractParametersForAnalyticsUseCaseTest.kt
+++ b/feature/login-check/src/test/java/com/simprints/feature/logincheck/usecases/ExtractParametersForAnalyticsUseCaseTest.kt
@@ -44,10 +44,10 @@ internal class ExtractParametersForAnalyticsUseCaseTest {
         useCase(ActionFactory.getFlowRequest())
 
         verify {
-            Simber.i(ActionFactory.MOCK_USER_ID.toString())
-            Simber.i(ActionFactory.MOCK_PROJECT_ID)
-            Simber.i(ActionFactory.MOCK_MODULE_ID.toString())
-            Simber.i("deviceId")
+            Simber.setUserProperty(any(), ActionFactory.MOCK_USER_ID.toString())
+            Simber.setUserProperty(any(), ActionFactory.MOCK_PROJECT_ID)
+            Simber.setUserProperty(any(), ActionFactory.MOCK_MODULE_ID.toString())
+            Simber.setUserProperty(any(), "deviceId")
             Simber.i("sessionId")
         }
     }
@@ -57,10 +57,7 @@ internal class ExtractParametersForAnalyticsUseCaseTest {
         useCase(ActionFactory.getFolowUpRequest())
 
         verify(exactly = 0) {
-            Simber.i(ActionFactory.MOCK_USER_ID.toString())
-            Simber.i(ActionFactory.MOCK_PROJECT_ID)
-            Simber.i(ActionFactory.MOCK_MODULE_ID.toString())
-            Simber.i("deviceId")
+            Simber.setUserProperty(any(), any())
         }
     }
 }

--- a/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
@@ -39,7 +39,7 @@ import com.simprints.feature.login.screens.form.SignInState.TechnicalFailure
 import com.simprints.feature.login.screens.form.SignInState.Unknown
 import com.simprints.feature.login.screens.qrscanner.QrScannerResult
 import com.simprints.feature.login.tools.play.GooglePlayServicesAvailabilityChecker
-import com.simprints.infra.logging.LoggingConstants
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.LOGIN
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.navigation.handleResult
@@ -98,16 +98,16 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
         binding.loginProjectId.setText(args.loginParams.projectId)
 
         binding.loginChangeUrlButton.setOnClickListener {
-            Simber.tag(LoggingConstants.CrashReportTag.LOGIN.name).i("Change URL button clicked")
+            Simber.tag(LOGIN.name).i("Change URL button clicked")
             viewModel.changeUrlClicked()
         }
 
         binding.loginButtonScanQr.setOnClickListener {
-            Simber.tag(LoggingConstants.CrashReportTag.LOGIN.name).i("Scan QR button clicked")
+            Simber.tag(LOGIN.name).i("Scan QR button clicked")
             findNavController().navigateSafely(this, R.id.action_loginFormFragment_to_loginQrScanner)
         }
         binding.loginButtonSignIn.setOnClickListener {
-            Simber.tag(LoggingConstants.CrashReportTag.LOGIN.name).i("Login button clicked")
+            Simber.tag(LOGIN.name).i("Login button clicked")
             viewModel.signInClicked(
                 args.loginParams,
                 binding.loginProjectId.text.toString(),

--- a/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormViewModel.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormViewModel.kt
@@ -15,7 +15,7 @@ import com.simprints.feature.login.screens.qrscanner.QrScannerResult
 import com.simprints.feature.login.screens.qrscanner.QrScannerResult.QrScannerError
 import com.simprints.infra.authlogic.AuthManager
 import com.simprints.infra.authlogic.model.AuthenticateDataResult
-import com.simprints.infra.logging.LoggingConstants.CrashReportTag
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.LOGIN
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.SimNetwork
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -89,7 +89,7 @@ internal class LoginFormViewModel @Inject constructor(
         } else if (!result.content.isNullOrEmpty()) {
             try {
                 val qrContent = jsonHelper.fromJson<QrCodeContent>(result.content)
-                Simber.tag(CrashReportTag.LOGIN.name).i("QR scanning successful")
+                Simber.tag(LOGIN.name).i("QR scanning successful")
 
                 if (projectId != qrContent.projectId) {
                     _signInState.send(SignInState.ProjectIdMismatch)
@@ -103,11 +103,11 @@ internal class LoginFormViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
-                Simber.tag(CrashReportTag.LOGIN.name).i("QR scanning unsuccessful")
+                Simber.tag(LOGIN.name).i("QR scanning unsuccessful")
                 _signInState.send(SignInState.QrInvalidCode)
             }
         } else {
-            Simber.tag(CrashReportTag.LOGIN.name).i("QR code missing")
+            Simber.tag(LOGIN.name).i("QR code missing")
             _signInState.send(SignInState.QrInvalidCode)
         }
     }

--- a/feature/login/src/main/java/com/simprints/feature/login/screens/qrscanner/QrScannerFragment.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/qrscanner/QrScannerFragment.kt
@@ -54,7 +54,7 @@ internal class QrScannerFragment : Fragment(R.layout.fragment_qr_scanner) {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 qrCodeAnalyzer.scannedCode
                     .catch { e ->
-                        Simber.e(e)
+                        Simber.e("Camera not available for QR scanning", e)
                         finishWithError(QrScannerResult.QrScannerError.CameraNotAvailable)
                     }.collectLatest { qrCode ->
                         if (qrCode.isNotEmpty()) {

--- a/feature/login/src/main/java/com/simprints/feature/login/tools/camera/CameraFocusManager.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/tools/camera/CameraFocusManager.kt
@@ -51,7 +51,7 @@ internal class CameraFocusManager @Inject constructor() {
                 try {
                     cameraControl.startFocusAndMetering(focusAction)
                 } catch (e: CameraInfoUnavailableException) {
-                    Simber.e(e, "Cannot access camera")
+                    Simber.e("Cannot access camera", e)
                 }
                 true
             }
@@ -77,7 +77,7 @@ internal class CameraFocusManager @Inject constructor() {
             try {
                 camera.cameraControl.startFocusAndMetering(focusAction)
             } catch (e: CameraInfoUnavailableException) {
-                Simber.e(e, "Cannot access camera")
+                Simber.e("Cannot access camera", e)
             }
         }
     }

--- a/feature/login/src/main/java/com/simprints/feature/login/tools/camera/CameraHelper.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/tools/camera/CameraHelper.kt
@@ -55,8 +55,7 @@ internal class CameraHelper @Inject constructor(
                             }
                         }
                 } catch (e: Exception) {
-                    // Can be thrown if the camera is already in use by another process
-                    Simber.i(e)
+                    Simber.i("Camera is already in use by another process", e)
                     initializationErrorListener.onCameraError()
                 }
             },

--- a/feature/login/src/main/java/com/simprints/feature/login/tools/camera/QrCodeAnalyzer.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/tools/camera/QrCodeAnalyzer.kt
@@ -33,7 +33,7 @@ internal class QrCodeAnalyzer @Inject constructor(
                         val image = RawImage(mediaImage, rotationDegrees)
                         qrCodeDetector.detectInImage(image)?.let(_scannedCode::tryEmit)
                     } catch (t: Throwable) {
-                        Simber.e(t)
+                        Simber.e("QR code detection failed", t)
                     }
                 }
             }

--- a/feature/login/src/main/java/com/simprints/feature/login/tools/camera/QrCodeDetector.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/tools/camera/QrCodeDetector.kt
@@ -30,7 +30,7 @@ internal class QrCodeDetector @Inject constructor() {
             ?.firstOrNull { !it.rawValue.isNullOrEmpty() }
             ?.rawValue
     } catch (t: Throwable) {
-        Simber.e(t)
+        Simber.e("QR code processing failed", t)
         null
     }
 

--- a/feature/login/src/main/java/com/simprints/feature/login/tools/play/GooglePlayServicesAvailabilityChecker.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/tools/play/GooglePlayServicesAvailabilityChecker.kt
@@ -73,6 +73,7 @@ internal class GooglePlayServicesAvailabilityChecker @Inject constructor(
     ) {
         errorCallback(LoginError.MissingPlayServices)
         Simber.e(
+            "Missing GooglePlay services",
             MissingGooglePlayServices(
                 "Error with GooglePlayServices version. Error code=$statusCode",
             ),
@@ -85,6 +86,7 @@ internal class GooglePlayServicesAvailabilityChecker @Inject constructor(
     ) {
         errorCallback(LoginError.OutdatedPlayServices)
         Simber.e(
+            "Outdated GooglePlay services",
             OutdatedGooglePlayServices(
                 "Error with GooglePlayServices version. Error code=$statusCode",
             ),

--- a/feature/login/src/test/java/com/simprints/feature/login/tools/play/GooglePlayServicesAvailabilityCheckerTest.kt
+++ b/feature/login/src/test/java/com/simprints/feature/login/tools/play/GooglePlayServicesAvailabilityCheckerTest.kt
@@ -62,7 +62,7 @@ internal class GooglePlayServicesAvailabilityCheckerTest {
     }
 
     @Test
-    fun `check shows alert and logs MissingGooglePlayServices exception for missing google play services`() {
+    fun `check shows alert and logs exception for missing google play services`() {
         // Given
 
         every { googleApiAvailability.isGooglePlayServicesAvailable(activity) } returns INTERNAL_ERROR
@@ -81,7 +81,7 @@ internal class GooglePlayServicesAvailabilityCheckerTest {
             )
         }
         verify { launchCallBack(LoginError.MissingPlayServices) }
-        verify { Simber.e(ofType<MissingGooglePlayServices>()) }
+        verify { Simber.e(any(), ofType<MissingGooglePlayServices>()) }
     }
 
     @Test
@@ -111,11 +111,11 @@ internal class GooglePlayServicesAvailabilityCheckerTest {
             )
         }
         verify(exactly = 0) { launchCallBack(any()) }
-        verify(exactly = 0) { Simber.e(ofType<OutdatedGooglePlayServices>()) }
+        verify(exactly = 0) { Simber.e(any(), ofType<OutdatedGooglePlayServices>()) }
     }
 
     @Test
-    fun `check shows alert and logs OutdatedGooglePlayServices exception for outdated google play services and the user cancels the alert dialog`() {
+    fun `check shows alert and logs exception for outdated google play services and the user cancels the alert dialog`() {
         // Given
         every { googleApiAvailability.isGooglePlayServicesAvailable(activity) } returns SERVICE_VERSION_UPDATE_REQUIRED
         every { googleApiAvailability.isUserResolvableError(SERVICE_VERSION_UPDATE_REQUIRED) } returns true
@@ -144,6 +144,6 @@ internal class GooglePlayServicesAvailabilityCheckerTest {
             )
         }
         verify { launchCallBack(LoginError.OutdatedPlayServices) }
-        verify { Simber.e(ofType<OutdatedGooglePlayServices>()) }
+        verify { Simber.e(any(), ofType<OutdatedGooglePlayServices>()) }
     }
 }

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
@@ -264,7 +264,7 @@ internal class OrchestratorViewModel @Inject constructor(
                 type = object : TypeReference<ActionRequest>() {},
             )
         } catch (e: Exception) {
-            Simber.e(e)
+            Simber.e("Action request deserialization failed", e)
         }
     }
 
@@ -273,7 +273,7 @@ internal class OrchestratorViewModel @Inject constructor(
             JsonHelper.toJson(it, dbSerializationModule)
         }
     } catch (e: Exception) {
-        Simber.e(e)
+        Simber.e("Action request serialization failed", e)
         null
     }
 

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/CreateEnrolResponseUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/CreateEnrolResponseUseCase.kt
@@ -35,7 +35,7 @@ internal class CreateEnrolResponseUseCase @Inject constructor(
 
             AppEnrolResponse(subject.subjectId)
         } catch (e: Exception) {
-            Simber.e(e)
+            Simber.e("Error creating enrol response", e)
             AppErrorResponse(AppErrorReason.UNEXPECTED_ERROR)
         }
     }

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/CreateVerifyResponseUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/CreateVerifyResponseUseCase.kt
@@ -2,7 +2,7 @@ package com.simprints.feature.orchestrator.usecases.response
 
 import com.simprints.core.domain.response.AppErrorReason
 import com.simprints.infra.config.store.models.ProjectConfiguration
-import com.simprints.infra.logging.LoggingConstants.CrashReportTag
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MATCHING
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.orchestration.data.responses.AppErrorResponse
 import com.simprints.infra.orchestration.data.responses.AppMatchResult
@@ -24,7 +24,7 @@ internal class CreateVerifyResponseUseCase @Inject constructor() {
         ?.let { AppVerifyResponse(it) }
         ?: AppErrorResponse(AppErrorReason.UNEXPECTED_ERROR).also {
             // if subject enrolled with an SDK and the user tries to verify with another SDK
-            Simber.tag(CrashReportTag.MATCHING.name).e("No match results found")
+            Simber.tag(MATCHING.name).e("No match results found")
         }
 
     private fun getFingerprintMatchResults(

--- a/feature/select-subject/src/main/java/com/simprints/feature/selectsubject/screen/SelectSubjectViewModel.kt
+++ b/feature/select-subject/src/main/java/com/simprints/feature/selectsubject/screen/SelectSubjectViewModel.kt
@@ -48,7 +48,7 @@ internal class SelectSubjectViewModel @Inject constructor(
             _finish.send(true)
         } catch (t: Throwable) {
             // It doesn't matter if it was an error, we always return a result
-            Simber.tag(SESSION.name).e(t)
+            Simber.tag(SESSION.name).e("Failed to save Guid Selection Event", t)
             _finish.send(false)
         }
     }

--- a/feature/setup/src/main/java/com/simprints/feature/setup/location/StoreUserLocationIntoCurrentSessionWorker.kt
+++ b/feature/setup/src/main/java/com/simprints/feature/setup/location/StoreUserLocationIntoCurrentSessionWorker.kt
@@ -40,7 +40,7 @@ internal class StoreUserLocationIntoCurrentSessionWorker @AssistedInject constru
                     runCatching { saveUserLocation(location) }
                 }
         } catch (t: Throwable) {
-            Simber.e(t)
+            Simber.e("StoreUserLocationIntoCurrentSessionWorker failed", t)
             fail(t)
         }
         success()

--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
@@ -190,7 +190,7 @@ internal class FingerprintCaptureViewModel @Inject constructor(
             bioSdkWrapper.initialize()
             bioSdkConfiguration = configuration.getSdkConfiguration(fingerprintSdk)!!
         } catch (e: BioSdkException.BioSdkInitializationException) {
-            Simber.e(e)
+            Simber.e("Failed to initialise bio sdk: ${fingerprintSdk.name}", e)
             _invalidLicense.send()
         }
     }
@@ -529,13 +529,13 @@ internal class FingerprintCaptureViewModel @Inject constructor(
             }
 
             is NoFingerDetectedException -> {
-                Simber.i(e)
+                Simber.i("No finger detected", e)
                 handleNoFingerDetected()
             }
 
             else -> {
                 updateCaptureState { toNotCollected() }
-                Simber.e(e)
+                Simber.e("Unexpected finger capture exception", e)
                 _launchAlert.send()
             }
         }

--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/usecase/SaveImageUseCase.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/usecase/SaveImageUseCase.kt
@@ -35,7 +35,7 @@ internal class SaveImageUseCase @Inject constructor(
             un20SerialNumber = scannerInfo.un20SerialNumber,
         )
     } else if (collectedFinger.scanResult.image != null && captureEventId == null) {
-        Simber.e(FingerprintUnexpectedException("Could not save fingerprint image because of null capture ID"))
+        Simber.e("Image save failed", FingerprintUnexpectedException("Could not save fingerprint image because of null capture ID"))
         null
     } else {
         null
@@ -89,7 +89,7 @@ internal class SaveImageUseCase @Inject constructor(
             ),
         )
     } catch (t: Throwable) {
-        Simber.e(t)
+        Simber.e("Failed to determine path for captureId $captureEventId", t)
         null
     }
 

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ConnectScannerViewModel.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ConnectScannerViewModel.kt
@@ -119,7 +119,9 @@ internal class ConnectScannerViewModel @Inject constructor(
 
     fun handleBackPress() {
         when (backButtonBehaviour.value) {
-            BackButtonBehaviour.DISABLED, null -> { /* Do nothing */ }
+            BackButtonBehaviour.DISABLED, null -> { // Do nothing
+            }
+
             BackButtonBehaviour.EXIT_WITH_ERROR -> _finish.send(false)
             BackButtonBehaviour.EXIT_FORM -> {
                 _scannerConnected.send(false)
@@ -194,18 +196,20 @@ internal class ConnectScannerViewModel @Inject constructor(
         saveScannerConnectionEvents()
         _currentStep.postValue(Step.Finish)
 
-        Simber
-            .tag(AnalyticsUserProperties.MAC_ADDRESS, true)
-            .i(scannerManager.currentMacAddress ?: "")
-        Simber
-            .tag(AnalyticsUserProperties.SCANNER_ID, true)
-            .i(scannerManager.currentScannerId ?: "")
+        Simber.setUserProperty(
+            AnalyticsUserProperties.MAC_ADDRESS,
+            scannerManager.currentMacAddress.orEmpty(),
+        )
+        Simber.setUserProperty(
+            AnalyticsUserProperties.SCANNER_ID,
+            scannerManager.currentScannerId.orEmpty(),
+        )
 
         _scannerConnected.send(true)
     }
 
     private suspend fun manageVeroErrors(e: Throwable) {
-        Simber.i(e)
+        Simber.i("Vero connection issue", e)
         _scannerConnected.send(false)
 
         launchAlertOrScannerIssueOrShowDialog(e)
@@ -224,6 +228,7 @@ internal class ConnectScannerViewModel @Inject constructor(
             is ScannerDisconnectedException, is UnknownScannerIssueException -> ConnectScannerIssueScreen.ScannerError(
                 scannerManager.currentScannerId,
             )
+
             is ScannerNotPairedException, is MultiplePossibleScannersPairedException -> determineAppropriateScannerIssueForPairing()
             is ScannerLowBatteryException -> ConnectScannerIssueScreen.LowBattery
 

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ConnectScannerViewModel.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ConnectScannerViewModel.kt
@@ -23,8 +23,8 @@ import com.simprints.fingerprint.infra.scanner.exceptions.safe.ScannerNotPairedE
 import com.simprints.fingerprint.infra.scanner.exceptions.unexpected.UnknownScannerIssueException
 import com.simprints.infra.config.store.models.FingerprintConfiguration
 import com.simprints.infra.config.sync.ConfigManager
-import com.simprints.infra.logging.LoggingConstants
 import com.simprints.infra.logging.LoggingConstants.AnalyticsUserProperties
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SCANNER_SETUP
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.recent.user.activity.RecentUserActivityManager
 import com.simprints.infra.resources.R
@@ -253,7 +253,7 @@ internal class ConnectScannerViewModel @Inject constructor(
     }
 
     private fun logMessageForCrashReport(message: String) {
-        Simber.tag(LoggingConstants.CrashReportTag.SCANNER_SETUP.name).i(message)
+        Simber.tag(SCANNER_SETUP.name).i(message)
     }
 
     fun handleScannerDisconnectedYesClick() {

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ota/OtaViewModel.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ota/OtaViewModel.kt
@@ -133,7 +133,7 @@ internal class OtaViewModel @Inject constructor(
         e: Throwable,
         currentRetryAttempt: Int,
     ) {
-        Simber.e(e)
+        Simber.e("OTA update failed", e)
         if (e is BackendMaintenanceException) {
             _otaFailed.send(
                 FetchOtaResult(

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ota/recovery/OtaRecoveryViewModel.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ota/recovery/OtaRecoveryViewModel.kt
@@ -27,7 +27,7 @@ internal class OtaRecoveryViewModel @Inject constructor(
 
             _isConnectionSuccess.send(true)
         } catch (ex: Throwable) {
-            Simber.e(ex)
+            Simber.e("OTA recovery failed", ex)
             _isConnectionSuccess.send(false)
         }
     }

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/data/FirmwareRepository.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/data/FirmwareRepository.kt
@@ -47,7 +47,7 @@ class FirmwareRepository @Inject internal constructor(
         // issue with timber logging URLs when interpolated in kotlin, check out this article
         // https://proandroiddev.com/be-careful-what-you-log-it-could-crash-your-app-5fc67a44c842
         val versionString = downloadableFirmwares.joinToString()
-        Simber.d("Firmwares available for download: %s", versionString)
+        Simber.d("Firmwares available for download: $versionString")
 
         val cypressToDownload = downloadableFirmwares.getVersionToDownloadOrNull(Chip.CYPRESS)
         val stmToDownload = downloadableFirmwares.getVersionToDownloadOrNull(Chip.STM)

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/data/local/FirmwareLocalDataSource.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/data/local/FirmwareLocalDataSource.kt
@@ -39,7 +39,7 @@ internal class FirmwareLocalDataSource(
             try {
                 it.name
             } catch (e: Exception) {
-                Simber.e(e, "Error encountered when parsing firmware file name")
+                Simber.e("Error encountered when parsing firmware file name", e)
                 null
             }
         } ?: emptyList()

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/data/remote/FirmwareRemoteDataSource.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/data/remote/FirmwareRemoteDataSource.kt
@@ -18,7 +18,7 @@ internal class FirmwareRemoteDataSource @Inject constructor(
      */
     suspend fun downloadFirmware(firmwareVersion: DownloadableFirmwareVersion): ByteArray {
         val fileUrl = fingerprintFileDownloader.getFileUrl(firmwareVersion.toStringForApi())
-        Simber.d("Downloading firmware file at %s", fileUrl)
+        Simber.d("Downloading firmware file at $fileUrl")
         return fingerprintFileDownloader.download(fileUrl)
     }
 }

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/data/remote/network/FingerprintFileDownloader.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/data/remote/network/FingerprintFileDownloader.kt
@@ -32,7 +32,7 @@ internal class FingerprintFileDownloader @Inject constructor(
     suspend fun download(url: String): ByteArray = withContext(dispatcher) {
         // issue with timber logging URLs when interpolated in kotlin, check out this article
         // https://proandroiddev.com/be-careful-what-you-log-it-could-crash-your-app-5fc67a44c842
-        Simber.d("Downloading firmware file at %s", url)
+        Simber.d("Downloading firmware file at $url")
         URL(url).readBytes()
     }
 

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v1/MessageDispatcher.java
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v1/MessageDispatcher.java
@@ -111,7 +111,7 @@ class MessageDispatcher extends Thread {
             try {
                 pendingRequest.lock.wait(timeOutMs);
             } catch (InterruptedException e) {
-                Simber.d(e);
+                Simber.d("Message response timed out", e);
                 throw new RuntimeException();
             }
 
@@ -146,7 +146,7 @@ class MessageDispatcher extends Thread {
             try {
                 pendingRequest.lock.wait(timeOutMs);
             } catch (InterruptedException e) {
-                Simber.d(e);
+                Simber.d("Message response timed out", e);
                 return MESSAGE_STATUS.ERROR;
             }
 

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/WrapErrorFromScanner.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/WrapErrorFromScanner.kt
@@ -14,16 +14,16 @@ fun wrapErrorFromScanner(e: Throwable): Throwable = when (e) {
     is IOException,
     -> { // Disconnected or timed-out communications with Scanner
         Simber.d(
-            e,
             "IOException in ScannerWrapperV2, transformed to ScannerDisconnectedException",
+            e,
         )
         ScannerDisconnectedException()
     }
 
     is IllegalStateException, // We're calling scanner methods out of order somehow
     is IllegalArgumentException,
-    -> { // We've received unexpected/invalid bytes from the scanner
-        Simber.e(e)
+    -> {
+        Simber.e("Received unexpected/invalid bytes from the scanner", e)
         UnexpectedScannerException(throwable = e)
     }
 

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/reactive/RxInputStream.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/reactive/RxInputStream.kt
@@ -15,8 +15,8 @@ fun InputStream.toFlowable(bufferSize: Int = 1024): Flowable<ByteArray> = Flowab
             else -> emitter.onNext(buffer)
         }
     } catch (e: IOException) {
-        // IOExceptions should be ignored because it  is
-        // thrown when disconnecting the scanner and closing the input stream at the end of fingerprint collection process
-        Simber.i(e)
+        // IOExceptions should be ignored because it  is thrown when disconnecting the scanner
+        // and closing the input stream at the end of fingerprint collection process
+        Simber.i("Scanner disconnected", e)
     }
 }

--- a/id/src/main/java/com/simprints/id/Application.kt
+++ b/id/src/main/java/com/simprints/id/Application.kt
@@ -60,7 +60,7 @@ open class Application :
     open fun initApplication() {
         handleUndeliverableExceptionInRxJava()
         SimberBuilder.initialize(this)
-        Simber.tag(DEVICE_ID, true).i(deviceHardwareId)
+        Simber.setUserProperty(DEVICE_ID, deviceHardwareId)
         appScope.launch {
             syncOrchestrator.cleanupWorkers()
             syncOrchestrator.scheduleBackgroundWork()
@@ -79,8 +79,7 @@ open class Application :
             if (e is UndeliverableException) {
                 exceptionToPrint = e.cause
             }
-            Simber.e(e)
-            Simber.d("Undeliverable exception received", exceptionToPrint)
+            Simber.e("Undeliverable exception received", e)
             exceptionToPrint.printStackTrace()
         }
     }

--- a/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/Authenticator.kt
+++ b/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/Authenticator.kt
@@ -49,8 +49,8 @@ internal class Authenticator @Inject constructor(
             AuthenticateDataResult.Authenticated
         } catch (t: Throwable) {
             when (t) {
-                is NetworkConnectionException -> Simber.i(t)
-                else -> Simber.e(t)
+                is NetworkConnectionException -> Simber.i("Authentication failed due to network error", t)
+                else -> Simber.e("Authentication failed due to unknown error", t)
             }
 
             extractResultFromException(t).also { signInResult ->

--- a/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/Authenticator.kt
+++ b/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/Authenticator.kt
@@ -13,7 +13,7 @@ import com.simprints.infra.authstore.exceptions.AuthRequestInvalidCredentialsExc
 import com.simprints.infra.events.event.domain.models.AuthenticationEvent
 import com.simprints.infra.events.event.domain.models.AuthenticationEvent.AuthenticationPayload.UserInfo
 import com.simprints.infra.events.session.SessionEventRepository
-import com.simprints.infra.logging.LoggingConstants.CrashReportTag
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.LOGIN
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.exceptions.BackendMaintenanceException
 import com.simprints.infra.network.exceptions.NetworkConnectionException
@@ -77,7 +77,7 @@ internal class Authenticator @Inject constructor(
     }
 
     private fun logMessageForCrashReportWithNetworkTrigger(message: String) {
-        Simber.tag(CrashReportTag.LOGIN.name).i(message)
+        Simber.tag(LOGIN.name).i(message)
     }
 
     private suspend fun addEventAndUpdateProjectIdIfRequired(

--- a/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/SignerManager.kt
+++ b/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/authenticator/SignerManager.kt
@@ -9,7 +9,7 @@ import com.simprints.infra.enrolment.records.store.EnrolmentRecordRepository
 import com.simprints.infra.events.EventRepository
 import com.simprints.infra.images.ImageRepository
 import com.simprints.infra.license.LicenseRepository
-import com.simprints.infra.logging.LoggingConstants
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.LOGOUT
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.SimNetwork
 import com.simprints.infra.recent.user.activity.RecentUserActivityManager
@@ -67,6 +67,6 @@ internal class SignerManager @Inject constructor(
         authStore.cleanCredentials()
         authStore.clearFirebaseToken()
 
-        Simber.tag(LoggingConstants.CrashReportTag.LOGOUT.name).i("Signed out")
+        Simber.tag(LOGOUT.name).i("Signed out")
     }
 }

--- a/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/integrity/IntegrityTokenRequester.kt
+++ b/infra/auth-logic/src/main/java/com/simprints/infra/authlogic/integrity/IntegrityTokenRequester.kt
@@ -48,7 +48,7 @@ internal class IntegrityTokenRequester @Inject constructor(
                     ),
                 ).token()
         } catch (integrityServiceException: IntegrityServiceException) {
-            Simber.e(integrityServiceException)
+            Simber.e("Integrity token request failed", integrityServiceException)
             throw mapException(
                 integrityServiceException,
             )

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/db/FirebaseAuthManager.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/db/FirebaseAuthManager.kt
@@ -71,7 +71,7 @@ internal class FirebaseAuthManager @Inject constructor(
                 ?.getIdToken(false)
                 ?.await()
         } catch (ex: Exception) {
-            Simber.e(ex, "Failed to get access token")
+            Simber.e("Failed to get access token", ex)
             throw transformFirebaseExceptionIfNeeded(ex)
         }
 
@@ -128,7 +128,7 @@ internal class FirebaseAuthManager @Inject constructor(
         try {
             getCoreApp().delete()
         } catch (ex: IllegalStateException) {
-            Simber.d(ex)
+            Simber.d("Failed to delete core app", ex)
         }
     }
 

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/JwtTokenHelper.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/JwtTokenHelper.kt
@@ -19,7 +19,7 @@ internal class JwtTokenHelper {
                 throw Throwable("Impossible to parse jwt")
             }
         } catch (t: Throwable) {
-            Simber.e(t)
+            Simber.e("Failed to parse JWT", t)
             null
         }
 

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/ConfigRepositoryImpl.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/ConfigRepositoryImpl.kt
@@ -91,7 +91,7 @@ internal class ConfigRepositoryImpl @Inject constructor(
             localDataSource.storePrivacyNotice(projectId, language, privacyNotice)
             flowCollector.emit(Succeed(language, privacyNotice))
         } catch (t: Throwable) {
-            Simber.i(t)
+            Simber.i("Failed to download privacy notice", t)
             flowCollector.emit(
                 if (t is BackendMaintenanceException) {
                     FailedBecauseBackendMaintenance(language, t, t.estimatedOutage)

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigSharedPrefsMigration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigSharedPrefsMigration.kt
@@ -43,10 +43,10 @@ internal class ProjectConfigSharedPrefsMigration @Inject constructor(
         } catch (e: Exception) {
             if (e is JacksonException) {
                 // Return default value
-                Simber.i(e, "Invalid old configuration for project ${authStore.signedInProjectId}")
+                Simber.i("Invalid old configuration for project ${authStore.signedInProjectId}", e)
                 ProtoProjectConfiguration.getDefaultInstance()
             } else {
-                Simber.e(e)
+                Simber.e("Failed to migrate project configuration to Datastore", e)
                 throw e
             }
         }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/tokenization/TokenizationProcessor.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/tokenization/TokenizationProcessor.kt
@@ -31,7 +31,7 @@ class TokenizationProcessor @Inject constructor(
         return try {
             stringTokenizer.encrypt(decrypted.value, moduleKeyset).asTokenizableEncrypted()
         } catch (e: Exception) {
-            Simber.e(e)
+            Simber.e("Failed to encrypt tokenized value", e)
             decrypted
         }
     }
@@ -55,7 +55,7 @@ class TokenizationProcessor @Inject constructor(
         return try {
             stringTokenizer.decrypt(encrypted.value, moduleKeyset).asTokenizableRaw()
         } catch (e: Exception) {
-            Simber.e(e)
+            Simber.e("Failed to decrypt tokenized value", e)
             encrypted
         }
     }

--- a/infra/core/src/main/java/com/simprints/core/tools/exceptions/AppCoroutineExceptionHandler.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/exceptions/AppCoroutineExceptionHandler.kt
@@ -11,6 +11,6 @@ class AppCoroutineExceptionHandler : CoroutineExceptionHandler {
         context: CoroutineContext,
         exception: Throwable,
     ) {
-        Simber.tag("APP_SCOPE_ERROR").e(exception)
+        Simber.tag("APP_SCOPE_ERROR").e("Coroutine exception", exception)
     }
 }

--- a/infra/core/src/main/java/com/simprints/core/tools/exceptions/AppCoroutineExceptionHandler.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/exceptions/AppCoroutineExceptionHandler.kt
@@ -1,5 +1,6 @@
 package com.simprints.core.tools.exceptions
 
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.APP_SCOPE_ERROR
 import com.simprints.infra.logging.Simber
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlin.coroutines.CoroutineContext
@@ -11,6 +12,6 @@ class AppCoroutineExceptionHandler : CoroutineExceptionHandler {
         context: CoroutineContext,
         exception: Throwable,
     ) {
-        Simber.tag("APP_SCOPE_ERROR").e("Coroutine exception", exception)
+        Simber.tag(APP_SCOPE_ERROR.name).e("Coroutine exception", exception)
     }
 }

--- a/infra/core/src/main/java/com/simprints/core/tools/exceptions/ErrorHandlerHelper.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/exceptions/ErrorHandlerHelper.kt
@@ -5,6 +5,6 @@ import com.simprints.infra.logging.Simber
 suspend fun <T> ignoreException(block: suspend () -> T): T? = try {
     block()
 } catch (t: Throwable) {
-    Simber.d(t)
+    Simber.d("Ignored exception", t)
     null
 }

--- a/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
+++ b/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
@@ -70,9 +70,9 @@ abstract class SimCoroutineWorker(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
                 setForegroundException is ForegroundServiceStartNotAllowedException
             ) {
-                Simber.i(setForegroundException, "Worker notification service restricted")
+                Simber.i("Worker notification service restricted", setForegroundException)
             } else {
-                Simber.e(setForegroundException)
+                Simber.e("Failed to show notification", setForegroundException)
             }
         }
     }
@@ -116,10 +116,10 @@ abstract class SimCoroutineWorker(
     private fun logExceptionIfRequired(t: Throwable?) {
         t?.let {
             when (t) {
-                is CancellationException -> Simber.d(t)
+                is CancellationException -> Simber.d("Worker cancelled", t)
                 // Record network issues only in Analytics
-                is NetworkConnectionException -> Simber.i(t)
-                else -> Simber.e(t)
+                is NetworkConnectionException -> Simber.i("Worker network connection issues", t)
+                else -> Simber.e("Unexpected worker error", t)
             }
         }
     }

--- a/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
+++ b/infra/core/src/main/java/com/simprints/core/workers/SimCoroutineWorker.kt
@@ -14,7 +14,7 @@ import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
 import com.simprints.core.tools.utils.BatteryOptimizationUtils
-import com.simprints.infra.logging.LoggingConstants.CrashReportTag
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SYNC
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.exceptions.NetworkConnectionException
 import com.simprints.infra.resources.R
@@ -110,7 +110,7 @@ abstract class SimCoroutineWorker(
     }
 
     protected fun crashlyticsLog(message: String) {
-        Simber.tag(CrashReportTag.SYNC.name).i("$tag - $message".take(99))
+        Simber.tag(SYNC.name).i("$tag - $message".take(99))
     }
 
     private fun logExceptionIfRequired(t: Throwable?) {

--- a/infra/core/src/test/java/com/simprints/core/tools/exceptions/AppCoroutineExceptionHandlerTest.kt
+++ b/infra/core/src/test/java/com/simprints/core/tools/exceptions/AppCoroutineExceptionHandlerTest.kt
@@ -16,6 +16,6 @@ class AppCoroutineExceptionHandlerTest {
         mockkObject(Simber)
 
         appCoroutineExceptionHandler.handleException(coroutineContext, exception)
-        verify { Simber.e(exception) }
+        verify { Simber.e(any(), exception) }
     }
 }

--- a/infra/core/src/test/java/com/simprints/core/tools/exceptions/ErrorHandlerHelperTest.kt
+++ b/infra/core/src/test/java/com/simprints/core/tools/exceptions/ErrorHandlerHelperTest.kt
@@ -26,7 +26,7 @@ class ErrorHandlerHelperTest {
                 throw exception
             }
 
-            verify(exactly = 1) { this@spyk.d(exception) }
+            verify(exactly = 1) { this@spyk.d(any(), exception) }
         }
     }
 

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImpl.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImpl.kt
@@ -100,7 +100,7 @@ internal class EnrolmentRecordRepositoryImpl(
         } catch (e: Exception) {
             when (e) {
                 is RealmUninitialisedException -> Unit // AuthStore hasn't yet saved the project, no need to do anything
-                else -> Simber.e(e)
+                else -> Simber.e("Failed to tokenize existing records", e)
             }
         }
     }

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImpl.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImpl.kt
@@ -8,7 +8,7 @@ import com.simprints.infra.enrolment.records.store.domain.models.SubjectAction
 import com.simprints.infra.enrolment.records.store.domain.models.SubjectQuery
 import com.simprints.infra.enrolment.records.store.local.models.fromDbToDomain
 import com.simprints.infra.enrolment.records.store.local.models.fromDomainToDb
-import com.simprints.infra.logging.LoggingConstants.CrashReportTag
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.REALM_DB
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.realm.RealmWrapper
 import com.simprints.infra.realm.models.DbFaceSample
@@ -108,7 +108,7 @@ internal class EnrolmentRecordLocalDataSourceImpl @Inject constructor(
         // if there is no actions to perform return to avoid useless realm operations
         if (actions.isEmpty()) {
             Simber
-                .tag(CrashReportTag.REALM_DB.name)
+                .tag(REALM_DB.name)
                 .d("[SubjectLocalDataSourceImpl] No realm actions to perform ")
             return
         }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/EventRemoteDataSource.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/EventRemoteDataSource.kt
@@ -14,6 +14,7 @@ import com.simprints.infra.eventsync.event.remote.models.subject.ApiEnrolmentRec
 import com.simprints.infra.eventsync.event.remote.models.subject.fromApiToDomain
 import com.simprints.infra.eventsync.status.down.domain.EventDownSyncResult
 import com.simprints.infra.eventsync.status.up.domain.EventUpSyncResult
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SYNC
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.SimNetwork.SimApiClient
 import com.simprints.infra.network.exceptions.SyncCloudIntegrationException
@@ -74,7 +75,7 @@ internal class EventRemoteDataSource @Inject constructor(
         val eventCount = getEventCountFromHeader(response)
 
         val streaming = response.body()?.byteStream() ?: ByteArrayInputStream(byteArrayOf())
-        Simber.tag("SYNC").d("[EVENT_REMOTE_SOURCE] Stream taken")
+        Simber.tag(SYNC.name).d("[EVENT_REMOTE_SOURCE] Stream taken")
 
         EventDownSyncResult(
             totalCount = eventCount.exactCount,
@@ -99,7 +100,7 @@ internal class EventRemoteDataSource @Inject constructor(
         val parser: JsonParser = JsonFactory().createParser(streaming)
         check(parser.nextToken() == START_ARRAY) { "Expected an array" }
 
-        Simber.tag("SYNC").d("[EVENT_REMOTE_SOURCE] Start parsing stream")
+        Simber.tag(SYNC.name).d("[EVENT_REMOTE_SOURCE] Start parsing stream")
 
         try {
             while (parser.nextToken() == START_OBJECT) {

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/EventRemoteDataSource.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/EventRemoteDataSource.kt
@@ -111,7 +111,7 @@ internal class EventRemoteDataSource @Inject constructor(
             parser.close()
             channel.close()
         } catch (t: Throwable) {
-            Simber.d(t)
+            Simber.d("Event parsing stream failed", t)
             parser.close()
             channel.close(t)
         }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/EventSyncStateProcessor.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/EventSyncStateProcessor.kt
@@ -15,7 +15,6 @@ import com.simprints.infra.eventsync.status.models.EventSyncWorkerType.END_SYNC_
 import com.simprints.infra.eventsync.status.models.EventSyncWorkerType.START_SYNC_REPORTER
 import com.simprints.infra.eventsync.status.models.EventSyncWorkerType.UPLOADER
 import com.simprints.infra.eventsync.sync.common.EventSyncCache
-import com.simprints.infra.eventsync.sync.common.SYNC_LOG_TAG
 import com.simprints.infra.eventsync.sync.common.SyncWorkersLiveDataProvider
 import com.simprints.infra.eventsync.sync.common.didFailBecauseBackendMaintenance
 import com.simprints.infra.eventsync.sync.common.didFailBecauseCloudIntegration
@@ -29,6 +28,7 @@ import com.simprints.infra.eventsync.sync.down.workers.extractDownSyncProgress
 import com.simprints.infra.eventsync.sync.master.EventStartSyncReporterWorker.Companion.SYNC_ID_STARTED
 import com.simprints.infra.eventsync.sync.up.workers.extractUpSyncMaxCount
 import com.simprints.infra.eventsync.sync.up.workers.extractUpSyncProgress
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SYNC
 import com.simprints.infra.logging.Simber
 import javax.inject.Inject
 
@@ -57,7 +57,7 @@ internal class EventSyncStateProcessor @Inject constructor(
                 )
 
                 emit(syncState)
-                Simber.tag(SYNC_LOG_TAG).d("[PROCESSOR] Emitting for UI $syncState")
+                Simber.tag(SYNC.name).d("[PROCESSOR] Emitting for UI $syncState")
             }
         }
     }
@@ -65,7 +65,7 @@ internal class EventSyncStateProcessor @Inject constructor(
     private fun observerForLastSyncId(): LiveData<String> = syncWorkersLiveDataProvider
         .getStartSyncReportersLiveData()
         .switchMap { startSyncReporters ->
-            Simber.tag(SYNC_LOG_TAG).d("[PROCESSOR] Received updated from Master Scheduler")
+            Simber.tag(SYNC.name).d("[PROCESSOR] Received updated from Master Scheduler")
 
             val completedSyncMaster = completedWorkers(startSyncReporters)
             val mostRecentSyncMaster = completedSyncMaster.sortByScheduledTime().lastOrNull()
@@ -74,7 +74,7 @@ internal class EventSyncStateProcessor @Inject constructor(
                 if (mostRecentSyncMaster != null) {
                     val lastSyncId = mostRecentSyncMaster.outputData.getString(SYNC_ID_STARTED)
                     if (!lastSyncId.isNullOrBlank()) {
-                        Simber.tag(SYNC_LOG_TAG).d("[PROCESSOR] Received sync id: $lastSyncId")
+                        Simber.tag(SYNC.name).d("[PROCESSOR] Received sync id: $lastSyncId")
                         this.postValue(lastSyncId)
                     }
                 }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/common/EventSyncCache.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/common/EventSyncCache.kt
@@ -78,7 +78,7 @@ internal class EventSyncCache @Inject constructor(
             sharedForProgresses.edit().clear().commit()
             sharedForCounts.edit().clear().commit()
         } catch (ex: SecurityException) {
-            Simber.e(ex)
+            Simber.e("Crashed during event sync cleanup", ex)
         }
     }
 

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/common/SyncLogTag.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/common/SyncLogTag.kt
@@ -1,3 +1,0 @@
-package com.simprints.infra.eventsync.sync.common
-
-internal const val SYNC_LOG_TAG = "SYNC"

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/EventDownSyncTask.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/EventDownSyncTask.kt
@@ -27,7 +27,7 @@ import com.simprints.infra.eventsync.status.down.domain.EventDownSyncOperation.D
 import com.simprints.infra.eventsync.status.down.domain.EventDownSyncOperation.DownSyncState.FAILED
 import com.simprints.infra.eventsync.status.down.domain.EventDownSyncOperation.DownSyncState.RUNNING
 import com.simprints.infra.eventsync.status.down.domain.EventDownSyncResult
-import com.simprints.infra.eventsync.sync.common.SYNC_LOG_TAG
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SYNC
 import com.simprints.infra.logging.Simber
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -171,7 +171,7 @@ internal class EventDownSyncTask @Inject constructor(
 
         enrolmentRecordRepository.performActions(actions)
 
-        Simber.tag(SYNC_LOG_TAG).d("[DOWN_SYNC_HELPER] batch processed")
+        Simber.tag(SYNC.name).d("[DOWN_SYNC_HELPER] batch processed")
 
         return if (batchOfEventsToProcess.size > 0) {
             lastOperation.copy(

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/EventDownSyncTask.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/EventDownSyncTask.kt
@@ -102,7 +102,7 @@ internal class EventDownSyncTask @Inject constructor(
                 throw t
             }
 
-            Simber.d(t)
+            Simber.d("Down sync error", t)
             errorType = t.javaClass.simpleName
 
             lastOperation = processBatchedEvents(operation, batchOfEventsToProcess, lastOperation)

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/workers/EventDownSyncDownloaderWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/workers/EventDownSyncDownloaderWorker.kt
@@ -100,8 +100,8 @@ internal class EventDownSyncDownloaderWorker @AssistedInject constructor(
                 "Total downloaded: $count / $max",
             )
         } catch (t: Throwable) {
-            Simber.d(t)
-            Simber.tag(SYNC_LOG_TAG).d("[DOWNLOADER] Failed ${t.message}")
+            Simber.d("[DOWNLOADER] Unexpected error", t)
+            Simber.tag(SYNC_LOG_TAG).i("[DOWNLOADER] Failed ${t.message}")
             handleSyncException(t)
         }
     }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/workers/EventDownSyncDownloaderWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/workers/EventDownSyncDownloaderWorker.kt
@@ -19,13 +19,13 @@ import com.simprints.infra.eventsync.sync.common.OUTPUT_FAILED_BECAUSE_BACKEND_M
 import com.simprints.infra.eventsync.sync.common.OUTPUT_FAILED_BECAUSE_CLOUD_INTEGRATION
 import com.simprints.infra.eventsync.sync.common.OUTPUT_FAILED_BECAUSE_RELOGIN_REQUIRED
 import com.simprints.infra.eventsync.sync.common.OUTPUT_FAILED_BECAUSE_TOO_MANY_REQUESTS
-import com.simprints.infra.eventsync.sync.common.SYNC_LOG_TAG
 import com.simprints.infra.eventsync.sync.common.WorkerProgressCountReporter
 import com.simprints.infra.eventsync.sync.down.tasks.EventDownSyncTask
 import com.simprints.infra.eventsync.sync.down.workers.EventDownSyncDownloaderWorker.Companion.OUTPUT_DOWN_MAX_SYNC
 import com.simprints.infra.eventsync.sync.down.workers.EventDownSyncDownloaderWorker.Companion.OUTPUT_DOWN_SYNC
 import com.simprints.infra.eventsync.sync.down.workers.EventDownSyncDownloaderWorker.Companion.PROGRESS_DOWN_MAX_SYNC
 import com.simprints.infra.eventsync.sync.down.workers.EventDownSyncDownloaderWorker.Companion.PROGRESS_DOWN_SYNC
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SYNC
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.exceptions.BackendMaintenanceException
 import com.simprints.infra.network.exceptions.SyncCloudIntegrationException
@@ -75,7 +75,7 @@ internal class EventDownSyncDownloaderWorker @AssistedInject constructor(
     override suspend fun doWork(): Result = withContext(dispatcher) {
         try {
             showProgressNotification()
-            Simber.tag(SYNC_LOG_TAG).d("[DOWNLOADER] Started")
+            Simber.tag(SYNC.name).d("[DOWNLOADER] Started")
 
             val workerId = this@EventDownSyncDownloaderWorker.id.toString()
             var count = syncCache.readProgress(workerId)
@@ -91,7 +91,7 @@ internal class EventDownSyncDownloaderWorker @AssistedInject constructor(
                 reportCount(count, max)
             }
 
-            Simber.tag(SYNC_LOG_TAG).d("[DOWNLOADER] Done $count")
+            Simber.tag(SYNC.name).d("[DOWNLOADER] Done $count")
             success(
                 workDataOf(
                     OUTPUT_DOWN_SYNC to count,
@@ -101,7 +101,7 @@ internal class EventDownSyncDownloaderWorker @AssistedInject constructor(
             )
         } catch (t: Throwable) {
             Simber.d("[DOWNLOADER] Unexpected error", t)
-            Simber.tag(SYNC_LOG_TAG).i("[DOWNLOADER] Failed ${t.message}")
+            Simber.tag(SYNC.name).i("[DOWNLOADER] Failed ${t.message}")
             handleSyncException(t)
         }
     }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorker.kt
@@ -19,12 +19,12 @@ import com.simprints.infra.config.sync.ConfigManager
 import com.simprints.infra.events.EventRepository
 import com.simprints.infra.events.event.domain.models.scope.EventScopeType
 import com.simprints.infra.eventsync.sync.common.EventSyncCache
-import com.simprints.infra.eventsync.sync.common.SYNC_LOG_TAG
 import com.simprints.infra.eventsync.sync.common.getAllSubjectsSyncWorkersInfo
 import com.simprints.infra.eventsync.sync.common.getUniqueSyncId
 import com.simprints.infra.eventsync.sync.common.sortByScheduledTime
 import com.simprints.infra.eventsync.sync.down.EventDownSyncWorkersBuilder
 import com.simprints.infra.eventsync.sync.up.EventUpSyncWorkersBuilder
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SYNC
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.security.SecurityManager
 import dagger.assisted.Assisted
@@ -100,7 +100,7 @@ class EventSyncMasterWorker @AssistedInject internal constructor(
                         .buildUpSyncWorkerChain(
                             uniqueSyncId,
                             upSyncWorkerScopeId,
-                        ).also { Simber.tag(SYNC_LOG_TAG).d("Scheduled ${it.size} up workers") }
+                        ).also { Simber.tag(SYNC.name).d("Scheduled ${it.size} up workers") }
                 }
 
                 if (configuration.isEventDownSyncAllowed()) {
@@ -113,7 +113,7 @@ class EventSyncMasterWorker @AssistedInject internal constructor(
                         .buildDownSyncWorkerChain(
                             uniqueSyncId,
                             downSyncWorkerScopeId,
-                        ).also { Simber.tag(SYNC_LOG_TAG).d("Scheduled ${it.size} down workers") }
+                        ).also { Simber.tag(SYNC.name).d("Scheduled ${it.size} down workers") }
                 }
 
                 val endSyncReporterWorker =

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
@@ -31,8 +31,8 @@ import com.simprints.infra.eventsync.status.up.domain.EventUpSyncOperation.UpSyn
 import com.simprints.infra.eventsync.status.up.domain.EventUpSyncOperation.UpSyncState.FAILED
 import com.simprints.infra.eventsync.status.up.domain.EventUpSyncOperation.UpSyncState.RUNNING
 import com.simprints.infra.eventsync.status.up.domain.EventUpSyncResult
-import com.simprints.infra.eventsync.sync.common.SYNC_LOG_TAG
 import com.simprints.infra.eventsync.sync.up.EventUpSyncProgress
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SYNC
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.exceptions.NetworkConnectionException
 import kotlinx.coroutines.currentCoroutineContext
@@ -170,7 +170,7 @@ internal class EventUpSyncTask @Inject constructor(
         createUpSyncContentContent: (Int) -> EventUpSyncRequestEvent.UpSyncContent,
     ) = flow {
         Simber
-            .tag(SYNC_LOG_TAG)
+            .tag(SYNC.name)
             .d("Uploading event scope - $eventScopeTypeToUpload in batches of $batchSize")
 
         while (eventRepository.getClosedEventScopesCount(eventScopeTypeToUpload) > 0 && currentCoroutineContext().isActive) {
@@ -211,7 +211,7 @@ internal class EventUpSyncTask @Inject constructor(
                 }
             }
 
-            Simber.tag(SYNC_LOG_TAG).d("Deleting ${uploadedScopes.size} session scopes")
+            Simber.tag(SYNC.name).d("Deleting ${uploadedScopes.size} session scopes")
             eventRepository.deleteEventScopes(uploadedScopes)
         }
     }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/workers/EventUpSyncUploaderWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/workers/EventUpSyncUploaderWorker.kt
@@ -100,8 +100,8 @@ internal class EventUpSyncUploaderWorker @AssistedInject constructor(
                 "Total uploaded: $count / $max",
             )
         } catch (t: Throwable) {
-            Simber.d(t)
-            Simber.tag(SYNC_LOG_TAG).d("[UPLOADER] Failed ${t.message}")
+            Simber.d("[UPLOADER] Unexpected error", t)
+            Simber.tag(SYNC_LOG_TAG).i("[UPLOADER] Failed ${t.message}")
             retryOrFailIfCloudIntegrationOrBackendMaintenanceError(t)
         }
     }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/workers/EventUpSyncUploaderWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/workers/EventUpSyncUploaderWorker.kt
@@ -20,13 +20,13 @@ import com.simprints.infra.eventsync.sync.common.OUTPUT_ESTIMATED_MAINTENANCE_TI
 import com.simprints.infra.eventsync.sync.common.OUTPUT_FAILED_BECAUSE_BACKEND_MAINTENANCE
 import com.simprints.infra.eventsync.sync.common.OUTPUT_FAILED_BECAUSE_CLOUD_INTEGRATION
 import com.simprints.infra.eventsync.sync.common.OUTPUT_FAILED_BECAUSE_RELOGIN_REQUIRED
-import com.simprints.infra.eventsync.sync.common.SYNC_LOG_TAG
 import com.simprints.infra.eventsync.sync.common.WorkerProgressCountReporter
 import com.simprints.infra.eventsync.sync.up.tasks.EventUpSyncTask
 import com.simprints.infra.eventsync.sync.up.workers.EventUpSyncUploaderWorker.Companion.OUTPUT_UP_MAX_SYNC
 import com.simprints.infra.eventsync.sync.up.workers.EventUpSyncUploaderWorker.Companion.OUTPUT_UP_SYNC
 import com.simprints.infra.eventsync.sync.up.workers.EventUpSyncUploaderWorker.Companion.PROGRESS_UP_MAX_SYNC
 import com.simprints.infra.eventsync.sync.up.workers.EventUpSyncUploaderWorker.Companion.PROGRESS_UP_SYNC
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SYNC
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.exceptions.BackendMaintenanceException
 import com.simprints.infra.network.exceptions.SyncCloudIntegrationException
@@ -74,7 +74,7 @@ internal class EventUpSyncUploaderWorker @AssistedInject constructor(
     override suspend fun doWork(): Result = withContext(dispatcher) {
         try {
             showProgressNotification()
-            Simber.tag(SYNC_LOG_TAG).d("[UPLOADER] Started")
+            Simber.tag(SYNC.name).d("[UPLOADER] Started")
 
             val workerId = this@EventUpSyncUploaderWorker.id.toString()
             var count = eventSyncCache.readProgress(workerId)
@@ -86,12 +86,12 @@ internal class EventUpSyncUploaderWorker @AssistedInject constructor(
             upSyncTask.upSync(upSyncScope.operation, getEventScope()).collect {
                 count += it.progress
                 eventSyncCache.saveProgress(workerId, count)
-                Simber.tag(SYNC_LOG_TAG).d("[UPLOADER] Uploaded $count for batch : $it")
+                Simber.tag(SYNC.name).d("[UPLOADER] Uploaded $count for batch : $it")
 
                 reportCount(count, max)
             }
 
-            Simber.tag(SYNC_LOG_TAG).d("[UPLOADER] Done")
+            Simber.tag(SYNC.name).d("[UPLOADER] Done")
             success(
                 workDataOf(
                     OUTPUT_UP_SYNC to count,
@@ -101,7 +101,7 @@ internal class EventUpSyncUploaderWorker @AssistedInject constructor(
             )
         } catch (t: Throwable) {
             Simber.d("[UPLOADER] Unexpected error", t)
-            Simber.tag(SYNC_LOG_TAG).i("[UPLOADER] Failed ${t.message}")
+            Simber.tag(SYNC.name).i("[UPLOADER] Failed ${t.message}")
             retryOrFailIfCloudIntegrationOrBackendMaintenanceError(t)
         }
     }

--- a/infra/events/src/main/java/com/simprints/infra/events/EventRepositoryImpl.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/EventRepositoryImpl.kt
@@ -187,7 +187,7 @@ internal open class EventRepositoryImpl @Inject constructor(
                 eventLocalDataSource.saveEvent(event)
             }
         }
-        Simber.v("Save session event: ${event.type} = ${duration.inWholeMilliseconds}ms")
+        Simber.d("Save session event: ${event.type} = ${duration.inWholeMilliseconds}ms")
         return event
     }
 
@@ -198,9 +198,9 @@ internal open class EventRepositoryImpl @Inject constructor(
     } catch (t: Throwable) {
         // prevent crashlytics logging of duplicate guid-selection
         if (t is DuplicateGuidSelectEventValidatorException) {
-            Simber.d(t)
+            Simber.d("Duplicate guid exception", t)
         } else {
-            Simber.e(t)
+            Simber.e("Failed to save the event", t)
         }
 
         throw t

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/EventDatabaseFactory.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/EventDatabaseFactory.kt
@@ -23,7 +23,7 @@ internal class EventDatabaseFactory @Inject constructor(
                 DB_NAME,
             )
         } catch (t: Throwable) {
-            Simber.e(t)
+            Simber.e("Failed to create event database", t)
             throw t
         }
     }

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/EventLocalDataSource.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/EventLocalDataSource.kt
@@ -88,7 +88,7 @@ internal open class EventLocalDataSource @Inject constructor(
         // 2. Recreate the DB key
         eventDatabaseFactory.recreateDatabaseKey()
         // 3. Log exception after recreating the key so we get extra info
-        Simber.tag(DB_CORRUPTION.name).e(ex)
+        Simber.tag(DB_CORRUPTION.name).e("Rebuilt event DB due to error", ex)
         // 4. Rebuild database
         eventDao = eventDatabaseFactory.build().eventDao
         scopeDao = eventDatabaseFactory.build().scopeDao

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/EventRoomDatabase.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/EventRoomDatabase.kt
@@ -18,12 +18,12 @@ import com.simprints.infra.events.event.local.migrations.EventMigration2to3
 import com.simprints.infra.events.event.local.migrations.EventMigration3to4
 import com.simprints.infra.events.event.local.migrations.EventMigration4to5
 import com.simprints.infra.events.event.local.migrations.EventMigration5to6
+import com.simprints.infra.events.event.local.migrations.EventMigration6to7
 import com.simprints.infra.events.event.local.migrations.EventMigration7to8
 import com.simprints.infra.events.event.local.migrations.EventMigration8to9
 import com.simprints.infra.events.event.local.migrations.EventMigration9to10
 import com.simprints.infra.events.event.local.models.DbEvent
 import com.simprints.infra.events.event.local.models.DbEventScope
-import com.simprints.infra.events.local.migrations.EventMigration6to7
 import net.sqlcipher.database.SupportFactory
 
 @Database(

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration1to2.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration1to2.kt
@@ -27,7 +27,7 @@ internal class EventMigration1to2 : Migration(1, 2) {
             migrateSessionClosedInformation(database)
             Simber.d("Migration from schema 1 to schema 2 done.")
         } catch (t: Throwable) {
-            Simber.e(t)
+            Simber.e("Failed to migrate room db from schema 1 to schema 2.", t)
         }
     }
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration2to3.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration2to3.kt
@@ -29,8 +29,7 @@ internal class EventMigration2to3 : Migration(2, 3) {
              */
             updateTableToCloseClosedSessions(database)
         } catch (ex: Exception) {
-            Simber.e(ex)
-            throw ex
+            Simber.e("Failed to migrate room db from schema 2 to schema 3.", ex)
         }
     }
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration3to4.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration3to4.kt
@@ -19,7 +19,7 @@ internal class EventMigration3to4 : Migration(3, 4) {
             migrateConnectivityEvents(database)
             Simber.d("Migration from schema 3 to schema 4 done.")
         } catch (t: Throwable) {
-            Simber.e(t)
+            Simber.e("Failed to migrate room db from schema 3 to schema 4.", t)
         }
     }
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration5to6.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration5to6.kt
@@ -19,7 +19,7 @@ internal class EventMigration5to6 : Migration(5, 6) {
             migrateConnectivityEvents(database)
             Simber.d("Migration from schema 5 to schema 6 done.")
         } catch (t: Throwable) {
-            Simber.e(t)
+            Simber.e("Failed to migrate room db from schema 5 to schema 6.", t)
         }
     }
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration6to7.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration6to7.kt
@@ -1,4 +1,4 @@
-package com.simprints.infra.events.local.migrations
+package com.simprints.infra.events.event.local.migrations
 
 import android.database.Cursor
 import androidx.room.migration.Migration
@@ -18,7 +18,7 @@ internal class EventMigration6to7 : Migration(6, 7) {
             migrateOneToOneMatchEvents(database)
             Simber.d("Migration from schema 5 to schema 6 done.")
         } catch (t: Throwable) {
-            Simber.e(t)
+            Simber.e("Failed to migrate room db from schema 6 to schema 7.", t)
         }
     }
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration7to8.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration7to8.kt
@@ -32,10 +32,10 @@ internal class EventMigration7to8 : Migration(7, 8) {
                     migrateFingerprintCaptureEventPayloadType(it, database, id)
                 } catch (t: Throwable) {
                     Simber.e(
-                        t,
                         "Fail to migrate fingerprint capture ${
                             it.getStringWithColumnName(DB_ID_FIELD)
                         } in session ${it.getStringWithColumnName("sessionId")}",
+                        t,
                     )
                 }
             }
@@ -188,12 +188,12 @@ internal class EventMigration7to8 : Migration(7, 8) {
                     migrateFaceCaptureEventPayloadType(it, database, id)
                 } catch (t: Throwable) {
                     Simber.e(
-                        t,
                         "Fail to migrate face capture ${
                             it.getStringWithColumnName(
                                 DB_ID_FIELD,
                             )
                         } in session ${it.getStringWithColumnName("sessionId")}",
+                        t,
                     )
                 }
             }

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration6to7Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration6to7Test.kt
@@ -11,7 +11,6 @@ import com.google.common.truth.Truth.*
 import com.simprints.core.tools.extentions.getStringWithColumnName
 import com.simprints.core.tools.utils.randomUUID
 import com.simprints.infra.events.event.local.EventRoomDatabase
-import com.simprints.infra.events.local.migrations.EventMigration6to7
 import io.mockk.spyk
 import io.mockk.verify
 import org.json.JSONObject

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigrationTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigrationTest.kt
@@ -15,7 +15,6 @@ import com.simprints.core.tools.json.JsonHelper
 import com.simprints.infra.events.event.domain.models.Event
 import com.simprints.infra.events.event.domain.models.EventType
 import com.simprints.infra.events.event.local.EventRoomDatabase
-import com.simprints.infra.events.local.migrations.EventMigration6to7
 import org.json.JSONObject
 import org.junit.Rule
 import org.junit.Test

--- a/infra/images/src/main/java/com/simprints/infra/images/ImageRepositoryImpl.kt
+++ b/infra/images/src/main/java/com/simprints/infra/images/ImageRepositoryImpl.kt
@@ -44,7 +44,7 @@ internal class ImageRepositoryImpl @Inject internal constructor(
                 }
             } catch (t: Throwable) {
                 allImagesUploaded = false
-                Simber.e(t)
+                Simber.e("Failed to upload images", t)
             }
         }
 

--- a/infra/images/src/main/java/com/simprints/infra/images/local/ImageLocalDataSourceImpl.kt
+++ b/infra/images/src/main/java/com/simprints/infra/images/local/ImageLocalDataSourceImpl.kt
@@ -61,7 +61,7 @@ internal class ImageLocalDataSourceImpl @Inject constructor(
         try {
             encryptedFile.openFileInput()
         } catch (t: Throwable) {
-            Simber.d(t)
+            Simber.d("Image decryption failed", t)
             null
         }
     }

--- a/infra/license/src/main/java/com/simprints/infra/license/local/LicenseLocalDataSourceImpl.kt
+++ b/infra/license/src/main/java/com/simprints/infra/license/local/LicenseLocalDataSourceImpl.kt
@@ -88,7 +88,7 @@ internal class LicenseLocalDataSourceImpl @Inject constructor(
                 .openFileOutput()
                 .use { it.write(licenseData.toByteArray()) }
         } catch (t: Throwable) {
-            Simber.e(t)
+            Simber.e("Failed to save licence data for ${vendor.value}", t)
         }
     }
 
@@ -100,7 +100,7 @@ internal class LicenseLocalDataSourceImpl @Inject constructor(
         try {
             getExpirationFile(vendor, version).writeText(expirationDate)
         } catch (t: Throwable) {
-            Simber.e(t)
+            Simber.e("Failed to save licence expiration date for ${vendor.value}", t)
         }
     }
 
@@ -116,7 +116,7 @@ internal class LicenseLocalDataSourceImpl @Inject constructor(
             val deleted = File("$licenseDirectoryPath/${vendor.value}").deleteRecursively()
             Simber.d("Deleted cached licenses successfully = $deleted")
         } catch (t: Throwable) {
-            Simber.e(t)
+            Simber.e("Failed to delete cached licenses for ${vendor.value}", t)
         }
     }
 
@@ -125,7 +125,7 @@ internal class LicenseLocalDataSourceImpl @Inject constructor(
             val deleted = File(licenseDirectoryPath).deleteRecursively()
             Simber.d("Deleted all licenses successfully = $deleted")
         } catch (t: Throwable) {
-            Simber.e(t)
+            Simber.e("Failed to delete licenses", t)
         }
     }
 

--- a/infra/license/src/main/java/com/simprints/infra/license/remote/LicenseRemoteDataSourceImpl.kt
+++ b/infra/license/src/main/java/com/simprints/infra/license/remote/LicenseRemoteDataSourceImpl.kt
@@ -38,22 +38,22 @@ internal class LicenseRemoteDataSourceImpl @Inject constructor(
     } catch (t: Throwable) {
         when (t) {
             is NetworkConnectionException -> {
-                Simber.i(t)
+                Simber.i("Licence download failed due to network error", t)
                 ApiLicenseResult.Error(UNKNOWN_ERROR_CODE)
             }
 
             is BackendMaintenanceException -> {
-                Simber.i(t)
+                Simber.i("Licence download failed due to backend maintenance", t)
                 ApiLicenseResult.BackendMaintenanceError(t.estimatedOutage)
             }
 
             is SyncCloudIntegrationException -> {
-                Simber.e(t)
+                Simber.e("Licence download failed due to cloud integration error", t)
                 handleCloudException(t)
             }
 
             else -> {
-                Simber.e(t)
+                Simber.e("Licence download failed due to unknown error", t)
                 ApiLicenseResult.Error(UNKNOWN_ERROR_CODE)
             }
         }

--- a/infra/logging/src/main/java/com/simprints/infra/logging/LoggingConstants.kt
+++ b/infra/logging/src/main/java/com/simprints/infra/logging/LoggingConstants.kt
@@ -42,5 +42,6 @@ object LoggingConstants {
         REALM_DB,
         DB_CORRUPTION,
         ENROLMENT,
+        APP_SCOPE_ERROR,
     }
 }

--- a/infra/logging/src/main/java/com/simprints/infra/logging/Simber.kt
+++ b/infra/logging/src/main/java/com/simprints/infra/logging/Simber.kt
@@ -38,7 +38,7 @@ object Simber {
      * connected to a server. Basically use it to report events that we need to be
      * aware of.
      * DEBUG: Is sent to Log.i
-     * STAGING: Is sent to Log.i & sent to Firebase Analytics as an event, and Crashlytics as a breadcrumb
+     * STAGING: Is sent to Log.i and Crashlytics as a breadcrumb
      * RELEASE: Is sent to Firebase Analytics as an event, and Crashlytics as a breadcrumb
      */
     fun i(

--- a/infra/logging/src/main/java/com/simprints/infra/logging/trees/AnalyticsTree.kt
+++ b/infra/logging/src/main/java/com/simprints/infra/logging/trees/AnalyticsTree.kt
@@ -1,6 +1,5 @@
 package com.simprints.infra.logging.trees
 
-import android.os.Bundle
 import android.util.Log
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.simprints.infra.logging.LoggingConstants.AnalyticsUserProperties.USER_ID
@@ -27,16 +26,5 @@ internal class AnalyticsTree(
                 analytics.setUserProperty(originalTag, message)
             }
         }
-
-        if (priority == Log.INFO) {
-            val params = Bundle()
-            params.putString(tag ?: DEFAULT_TAG, message)
-            analytics.logEvent(tag ?: DEFAULT_TAG, params)
-        }
-    }
-
-    companion object {
-        // If for some reason there is no tag for the event
-        internal const val DEFAULT_TAG = "DEFAULT"
     }
 }

--- a/infra/logging/src/test/java/com/simprints/infra/logging/SimberTest.kt
+++ b/infra/logging/src/test/java/com/simprints/infra/logging/SimberTest.kt
@@ -27,8 +27,8 @@ class SimberTest {
     }
 
     @Test
-    fun `tag() sets correctly the user property tag`() {
-        Simber.tag("test", true)
+    fun `setUserProperty() sets correctly the user property tag`() {
+        Simber.setUserProperty("test", "value")
         verify(exactly = 1) { Timber.tag(USER_PROPERTY_TAG + "test") }
     }
 
@@ -49,7 +49,7 @@ class SimberTest {
     @Test
     fun `in debug mode tag() throws an exception for tags longer than 40 characters`() {
         val exception = kotlin.runCatching {
-            Simber.tag("01234567890123456789012345678901234567890", true)
+            Simber.setUserProperty("01234567890123456789012345678901234567890", "value")
         }
 
         assertEquals(IllegalArgumentException::class.java, exception.exceptionOrNull()?.javaClass)
@@ -57,100 +57,51 @@ class SimberTest {
     }
 
     @Test
-    fun `reports crash reporting when logging warnings`() {
-        Simber.w(IllegalStateException("Test"))
-        verify(exactly = 1) { Timber.Forest.w(any<Exception>()) }
-    }
-
-    @Test
     fun `reports crash reporting when logging warnings with message`() {
-        Simber.w(IllegalStateException("Test"), "test", null)
-        verify(exactly = 1) { Timber.Forest.w(any<Exception>(), any(), any()) }
-    }
-
-    @Test
-    fun `reports crash reporting when logging error`() {
-        Simber.e(IllegalStateException("Test"))
-        verify(exactly = 1) { Timber.Forest.e(any<Exception>()) }
+        Simber.w("test", IllegalStateException("Test"))
+        verify(exactly = 1) { Timber.Forest.w(any<Exception>(), any()) }
     }
 
     @Test
     fun `reports crash reporting when logging error with message`() {
-        Simber.e(IllegalStateException("Test"), "test", null)
-        verify(exactly = 1) { Timber.Forest.e(any<Exception>(), any(), any()) }
-    }
-
-    @Test
-    fun `skips false-positive crash reporting when logging warnings`() {
-        val list = getListOfSkippableExceptions()
-        list.forEach { Simber.w(it) }
-
-        verify(exactly = 0) { Timber.Forest.w(any<Exception>()) }
-        verify(exactly = list.size) { Timber.Forest.i(any<Exception>()) }
+        Simber.e("test", IllegalStateException("Test"))
+        verify(exactly = 1) { Timber.Forest.e(any<Exception>(), any()) }
     }
 
     @Test
     fun `skips false-positive crash reporting when logging warnings with message`() {
         val list = getListOfSkippableExceptions()
-        list.forEach { Simber.w(it, "test", null) }
+        list.forEach { Simber.w("test", it) }
 
-        verify(exactly = 0) { Timber.Forest.w(any<Exception>(), any(), any()) }
-        verify(exactly = list.size) { Timber.Forest.i(any<Exception>(), any(), any()) }
-    }
-
-    @Test
-    fun `skips false-positive crash reporting when logging error`() {
-        val list = getListOfSkippableExceptions()
-        list.forEach { Simber.e(it) }
-
-        verify(exactly = 0) { Timber.Forest.e(any<Exception>()) }
-        verify(exactly = list.size) { Timber.Forest.i(any<Exception>()) }
+        verify(exactly = 0) { Timber.Forest.w(any<Exception>(), any()) }
+        verify(exactly = list.size) { Timber.Forest.i(any<Exception>(), any()) }
     }
 
     @Test
     fun `skips false-positive crash reporting when logging error with message`() {
         val list = getListOfSkippableExceptions()
-        list.forEach { Simber.e(it, "test", null) }
+        list.forEach { Simber.e("test", it) }
 
-        verify(exactly = 0) { Timber.Forest.e(any<Exception>(), any(), any()) }
-        verify(exactly = list.size) { Timber.Forest.i(any<Exception>(), any(), any()) }
-    }
-
-    @Test
-    fun `skips false-positive cause crash reporting when logging warnings`() {
-        val list = getListOfSkippableExceptions().map { Throwable(cause = it) }
-
-        list.forEach { Simber.w(it) }
-
-        verify(exactly = 0) { Timber.Forest.w(any<Exception>()) }
-        verify(exactly = list.size) { Timber.Forest.i(any<Exception>()) }
+        verify(exactly = 0) { Timber.Forest.e(any<Exception>(), any()) }
+        verify(exactly = list.size) { Timber.Forest.i(any<Exception>(), any()) }
     }
 
     @Test
     fun `skips false-positive cause crash reporting when logging warnings with message`() {
         val list = getListOfSkippableExceptions().map { Throwable(cause = it) }
-        list.forEach { Simber.w(it, "test", null) }
+        list.forEach { Simber.w("test", it) }
 
-        verify(exactly = 0) { Timber.Forest.w(any<Exception>(), any(), any()) }
-        verify(exactly = list.size) { Timber.Forest.i(any<Exception>(), any(), any()) }
-    }
-
-    @Test
-    fun `skips false-positive cause crash reporting when logging error`() {
-        val list = getListOfSkippableExceptions().map { Throwable(cause = it) }
-        list.forEach { Simber.e(it) }
-
-        verify(exactly = 0) { Timber.Forest.e(any<Exception>()) }
-        verify(exactly = list.size) { Timber.Forest.i(any<Exception>()) }
+        verify(exactly = 0) { Timber.Forest.w(any<Exception>(), any()) }
+        verify(exactly = list.size) { Timber.Forest.i(any<Exception>(), any()) }
     }
 
     @Test
     fun `skips false-positive cause crash reporting when logging error with message`() {
         val list = getListOfSkippableExceptions().map { Throwable(cause = it) }
-        list.forEach { Simber.e(it, "test", null) }
+        list.forEach { Simber.e("test", it) }
 
-        verify(exactly = 0) { Timber.Forest.e(any<Exception>(), any(), any()) }
-        verify(exactly = list.size) { Timber.Forest.i(any<Exception>(), any(), any()) }
+        verify(exactly = 0) { Timber.Forest.e(any<Exception>(), any()) }
+        verify(exactly = list.size) { Timber.Forest.i(any<Exception>(), any()) }
     }
 
     private fun getListOfSkippableExceptions() = listOf(

--- a/infra/logging/src/test/java/com/simprints/infra/logging/trees/AnalyticsTreeTest.kt
+++ b/infra/logging/src/test/java/com/simprints/infra/logging/trees/AnalyticsTreeTest.kt
@@ -3,7 +3,6 @@ package com.simprints.infra.logging.trees
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.simprints.infra.logging.LoggingConstants.AnalyticsUserProperties.USER_ID
 import com.simprints.infra.logging.Simber
-import com.simprints.infra.logging.trees.AnalyticsTree.Companion.DEFAULT_TAG
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
@@ -20,24 +19,6 @@ class AnalyticsTreeTest {
         Simber.d("Test Message")
 
         verify(exactly = 0) { faMock.logEvent(any(), any()) }
-    }
-
-    @Test
-    fun `should log event on INFO priority`() {
-        val faMock = mockk<FirebaseAnalytics>(relaxed = true)
-        val spyAnalyticsTree = spyk(AnalyticsTree(faMock))
-
-        Timber.plant(spyAnalyticsTree)
-        Simber.i("Test Message")
-
-        verify {
-            faMock.logEvent(
-                DEFAULT_TAG,
-                withArg {
-                    it.getString(DEFAULT_TAG).contentEquals("Test Message")
-                },
-            )
-        }
     }
 
     @Test

--- a/infra/logging/src/test/java/com/simprints/infra/logging/trees/AnalyticsTreeTest.kt
+++ b/infra/logging/src/test/java/com/simprints/infra/logging/trees/AnalyticsTreeTest.kt
@@ -12,17 +12,6 @@ import timber.log.Timber
 
 class AnalyticsTreeTest {
     @Test
-    fun `should return on VERBOSE priority`() {
-        val faMock = mockk<FirebaseAnalytics>(relaxed = true)
-        val spyAnalyticsTree = spyk(AnalyticsTree(faMock))
-
-        Timber.plant(spyAnalyticsTree)
-        Simber.v("Test Message")
-
-        verify(exactly = 0) { faMock.logEvent(any(), any()) }
-    }
-
-    @Test
     fun `should return on DEBUG priority`() {
         val faMock = mockk<FirebaseAnalytics>(relaxed = true)
         val spyAnalyticsTree = spyk(AnalyticsTree(faMock))
@@ -57,7 +46,7 @@ class AnalyticsTreeTest {
         val spyAnalyticsTree = spyk(AnalyticsTree(faMock))
 
         Timber.plant(spyAnalyticsTree)
-        Simber.tag("Test_Tag", true).i("Test Message")
+        Simber.setUserProperty("Test_Tag", "Test Message")
 
         verify {
             faMock.setUserProperty("Test_Tag", "Test Message")
@@ -70,7 +59,7 @@ class AnalyticsTreeTest {
         val spyAnalyticsTree = spyk(AnalyticsTree(faMock))
 
         Timber.plant(spyAnalyticsTree)
-        Simber.tag(USER_ID, true).i("Test Message ID")
+        Simber.setUserProperty(USER_ID, "Test Message ID")
 
         verify {
             faMock.setUserId("Test Message ID")

--- a/infra/logging/src/test/java/com/simprints/infra/logging/trees/CrashReportingTreeTest.kt
+++ b/infra/logging/src/test/java/com/simprints/infra/logging/trees/CrashReportingTreeTest.kt
@@ -10,17 +10,6 @@ import timber.log.Timber
 
 class CrashReportingTreeTest {
     @Test
-    fun `should return on VERBOSE priority`() {
-        val crashMock = mockk<FirebaseCrashlytics>(relaxed = true)
-        val spyCrashReportingTree = spyk(CrashReportingTree(crashMock))
-
-        Timber.plant(spyCrashReportingTree)
-        Simber.v("Test Message")
-
-        verify(exactly = 0) { crashMock.log(any()) }
-    }
-
-    @Test
     fun `should return on DEBUG priority`() {
         val crashMock = mockk<FirebaseCrashlytics>(relaxed = true)
         val spyCrashReportingTree = spyk(CrashReportingTree(crashMock))
@@ -67,7 +56,7 @@ class CrashReportingTreeTest {
         val custException = Exception("Custom Exception")
 
         Timber.plant(spyCrashReportingTree)
-        Simber.w(custException, "Test Message")
+        Simber.w("Test Message", custException)
 
         verify {
             crashMock.log(withArg { it.contains("Test Message") })
@@ -102,7 +91,7 @@ class CrashReportingTreeTest {
         val custException = Exception("Custom Exception")
 
         Timber.plant(spyCrashReportingTree)
-        Simber.e(custException, "Test Message")
+        Simber.e("Test Message", custException)
 
         verify {
             crashMock.log(withArg { it.contains("Test Message") })
@@ -118,7 +107,7 @@ class CrashReportingTreeTest {
         val spyCrashReportingTree = spyk(CrashReportingTree(crashMock))
 
         Timber.plant(spyCrashReportingTree)
-        Simber.tag("Custom_Tag", true).i("Test Message")
+        Simber.setUserProperty("Custom_Tag", "Test Message")
 
         verify {
             crashMock.setCustomKey("Custom_Tag", "Test Message")

--- a/infra/realm/src/main/java/com/simprints/infra/realm/RealmWrapperImpl.kt
+++ b/infra/realm/src/main/java/com/simprints/infra/realm/RealmWrapperImpl.kt
@@ -63,7 +63,7 @@ class RealmWrapperImpl @Inject constructor(
                 // 2. Recreate the DB key
                 recreateLocalDbKey()
                 // 3. Log exception after recreating the key so we get extra info
-                Simber.tag(DB_CORRUPTION.name).e(ex)
+                Simber.tag(DB_CORRUPTION.name).e("Realm DB recreated due to corruption", ex)
                 // 4. Update Realm config with the new key
                 config = createAndSaveRealmConfig()
                 // 5. Delete "last sync" info and start new sync
@@ -101,7 +101,7 @@ class RealmWrapperImpl @Inject constructor(
             try {
                 securityManager.getLocalDbKeyOrThrow(it)
             } catch (ex: Exception) {
-                Simber.e(ex)
+                Simber.e("Failed to fetch local DB key", ex)
                 securityManager.recreateLocalDatabaseKey(it)
                 securityManager.getLocalDbKeyOrThrow(it)
             }
@@ -132,7 +132,7 @@ class RealmWrapperImpl @Inject constructor(
                 appContext.startService(intent)
             }
         } catch (ex: Exception) {
-            Simber.e(ex)
+            Simber.e("Unable to start sync reset service", ex)
         }
     }
 }

--- a/infra/security/src/main/java/com/simprints/infra/security/keyprovider/EncryptedSharedPreferencesBuilderImpl.kt
+++ b/infra/security/src/main/java/com/simprints/infra/security/keyprovider/EncryptedSharedPreferencesBuilderImpl.kt
@@ -29,7 +29,7 @@ internal class EncryptedSharedPreferencesBuilderImpl @Inject constructor(
         // Sometimes the master key has invalid tag (zero), and in such cases the process can be
         // recovered by physically removing the shared preferences file and trying to create
         // it once again
-        Simber.e(e, "Unable to create encrypted shared preferences")
+        Simber.e("Unable to create encrypted shared preferences", e)
         deleteEncryptedSharedPreferences(filename = filename)
         preferencesProvider.provideEncryptedSharedPreferences(
             filename = filename,
@@ -51,7 +51,7 @@ internal class EncryptedSharedPreferencesBuilderImpl @Inject constructor(
                 }
             }
         } catch (e: Exception) {
-            Simber.e(e, "Unable to delete encrypted shared preferences")
+            Simber.e("Unable to delete encrypted shared preferences", e)
         }
     }
 }

--- a/infra/security/src/main/java/com/simprints/infra/security/keyprovider/SecureLocalDbKeyProviderImpl.kt
+++ b/infra/security/src/main/java/com/simprints/infra/security/keyprovider/SecureLocalDbKeyProviderImpl.kt
@@ -76,7 +76,7 @@ internal class SecureLocalDbKeyProviderImpl @Inject constructor(
     }
 
     private fun logToCrashReport(message: Throwable) {
-        Simber.tag(DB_CORRUPTION.name).i(message)
+        Simber.tag(DB_CORRUPTION.name).i("Failed to recreate local database", message)
     }
 
     /**

--- a/infra/security/src/test/java/com/simprints/infra/security/keyprovider/SecureLocalDbKeyProviderImplTest.kt
+++ b/infra/security/src/test/java/com/simprints/infra/security/keyprovider/SecureLocalDbKeyProviderImplTest.kt
@@ -99,7 +99,7 @@ class SecureLocalDbKeyProviderImplTest {
         verify {
             dbKeyEditor.putString(KEY_NAME, any())
             keyHashEditor.putString(KEY_NAME, any())
-            Simber.i(ofType<MissingLocalDatabaseKeyHashException>())
+            Simber.i(any(), ofType<MissingLocalDatabaseKeyHashException>())
         }
     }
 
@@ -116,7 +116,7 @@ class SecureLocalDbKeyProviderImplTest {
         verify {
             dbKeyEditor.putString(KEY_NAME, any())
             keyHashEditor.putString(KEY_NAME, any())
-            Simber.i(ofType<MatchingLocalDatabaseKeyHashesException>())
+            Simber.i(any(), ofType<MatchingLocalDatabaseKeyHashesException>())
         }
     }
 
@@ -130,7 +130,7 @@ class SecureLocalDbKeyProviderImplTest {
         verify {
             dbKeyEditor.putString(KEY_NAME, any())
             keyHashEditor.putString(KEY_NAME, any())
-            Simber.i(ofType<MismatchingLocalDatabaseKeyHashesException>())
+            Simber.i(any(), ofType<MismatchingLocalDatabaseKeyHashesException>())
         }
     }
 
@@ -143,7 +143,7 @@ class SecureLocalDbKeyProviderImplTest {
         verify {
             dbKeyEditor.putString(KEY_NAME, any())
             keyHashEditor.putString(KEY_NAME, any())
-            Simber.i(ofType<MissingLocalDatabaseKeyException>())
+            Simber.i(any(), ofType<MissingLocalDatabaseKeyException>())
         }
     }
 

--- a/infra/sync/src/main/java/com/simprints/infra/sync/firmware/FirmwareFileUpdateWorker.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/firmware/FirmwareFileUpdateWorker.kt
@@ -38,10 +38,10 @@ class FirmwareFileUpdateWorker @AssistedInject constructor(
         } catch (e: Throwable) {
             when {
                 e.isCausedFromBadNetworkConnection() ->
-                    Simber.i(NetworkConnectionException(cause = e))
+                    Simber.i("FirmwareFileUpdateWorker failed due to network error", NetworkConnectionException(cause = e))
 
                 else ->
-                    Simber.e(e, "FirmwareFileUpdateWorker failed")
+                    Simber.e("FirmwareFileUpdateWorker failed due to unknown error", e)
             }
             Result.retry()
         }


### PR DESCRIPTION
While digging around our current log usage I found it to be unnecessarily complicated (mostly for historic reasons) and did a bit of API simplification. I did not want this work to get stale over the long holiday period so I decided to push it separately from the actual logging revamp.

**No new log messages were added and none were removed, this is only an API overhaul.** 

Notable changes: 

* Removed `vararg` arguments from the methods. In Kotlin string formatting is better done via interpolation on the caller side. It also removed several foot guns: 
  * there were multiple instances of w("message", exception) calls, where the message does not contain the required placeholder and therefore the exception is completely lost
  * limitLegth is called before formatting the string which can lead to either too long messages due to the insertion of a long string or truncation of placeholders within a formatted string (or both). 
* Removed `d/i/w/e(Throwable)` methods in favour of `d/i/w/e(String, Throwable?)` version. The old version enabled mindless dumping of stack traces without providing context with the message.
* Now there is a single method per level of logging with a mandatory message string and optional throwable arguments.
* Removed the `Verbose` level of logging as it is just a fancy name for `Debug` and was not used in any meaningful way.
* Moved the setting of user properties to a separate method. The combination of a tag, a flag and an info message was unintuitive.
* Cleaned up the tag usage to be consistent.
* Removed log message tracking as Firebase Analytics events to reduce duplication/clutter in breadcrumbs and cleanup the event for correct usage in future.

