### PR TITLE
MS-579 Switch to navigating safely in the dashboard

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/base/BaseFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/base/BaseFragment.kt
@@ -4,6 +4,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.simprints.feature.dashboard.R
 import com.simprints.infra.authstore.AuthStore
+import com.simprints.infra.uibase.navigation.navigateSafely
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -15,9 +16,9 @@ internal class BaseFragment : Fragment(R.layout.fragment_base) {
     override fun onResume() {
         super.onResume()
         if (authStore.signedInProjectId.isNotEmpty()) {
-            findNavController().navigate(R.id.action_baseFragment_to_mainFragment)
+            findNavController().navigateSafely(this, R.id.action_baseFragment_to_mainFragment)
         } else {
-            findNavController().navigate(R.id.action_baseFragment_to_requestLoginFragment)
+            findNavController().navigateSafely(this, R.id.action_baseFragment_to_requestLoginFragment)
         }
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/sync/LogoutSyncFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/sync/LogoutSyncFragment.kt
@@ -18,6 +18,7 @@ import com.simprints.feature.dashboard.views.SyncCardState
 import com.simprints.feature.login.LoginContract
 import com.simprints.feature.login.LoginResult
 import com.simprints.infra.uibase.navigation.handleResult
+import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -47,17 +48,17 @@ class LogoutSyncFragment : Fragment(R.layout.fragment_logout_sync) {
         logoutSyncCard.onOfflineButtonClick =
             { startActivity(Intent(Settings.ACTION_WIRELESS_SETTINGS)) }
         logoutSyncCard.onSelectNoModulesButtonClick =
-            { findNavController().navigate(R.id.action_logoutSyncFragment_to_moduleSelectionFragment) }
+            { findNavController().navigateSafely(this@LogoutSyncFragment, R.id.action_logoutSyncFragment_to_moduleSelectionFragment) }
         logoutSyncCard.onLoginButtonClick = { syncViewModel.login() }
         logoutSyncToolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }
         logoutWithoutSyncButton.setOnClickListener {
-            findNavController().navigate(R.id.action_logoutSyncFragment_to_logoutSyncDeclineFragment)
+            findNavController().navigateSafely(this@LogoutSyncFragment, R.id.action_logoutSyncFragment_to_logoutSyncDeclineFragment)
         }
         logoutButton.setOnClickListener {
             logoutSyncViewModel.logout()
-            findNavController().navigate(R.id.action_logoutSyncFragment_to_requestLoginFragment)
+            findNavController().navigateSafely(this@LogoutSyncFragment, R.id.action_logoutSyncFragment_to_requestLoginFragment)
         }
     }
 
@@ -72,7 +73,8 @@ class LogoutSyncFragment : Fragment(R.layout.fragment_logout_sync) {
         syncViewModel.loginRequestedEventLiveData.observe(
             viewLifecycleOwner,
             LiveDataEventWithContentObserver { loginArgs ->
-                findNavController().navigate(
+                findNavController().navigateSafely(
+                    this@LogoutSyncFragment,
                     R.id.action_logOutSyncFragment_to_login,
                     loginArgs,
                 )

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/syncdecline/LogoutSyncDeclineFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/syncdecline/LogoutSyncDeclineFragment.kt
@@ -12,6 +12,7 @@ import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentLogoutSyncDeclineBinding
 import com.simprints.feature.dashboard.logout.LogoutSyncViewModel
 import com.simprints.feature.dashboard.settings.password.SettingsPasswordDialogFragment
+import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import com.simprints.infra.resources.R as IDR
@@ -74,6 +75,6 @@ class LogoutSyncDeclineFragment : Fragment(R.layout.fragment_logout_sync_decline
 
     private fun processLogoutConfirmation() {
         viewModel.logout()
-        findNavController().navigate(R.id.action_logoutSyncDeclineFragment_to_requestLoginFragment)
+        findNavController().navigateSafely(this, R.id.action_logoutSyncDeclineFragment_to_requestLoginFragment)
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/MainFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/MainFragment.kt
@@ -9,6 +9,7 @@ import androidx.navigation.fragment.findNavController
 import com.simprints.feature.dashboard.BuildConfig
 import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentMainBinding
+import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -40,9 +41,9 @@ internal class MainFragment : Fragment(R.layout.fragment_main) {
 
     private fun menuItemClicked(item: MenuItem): Boolean = with(findNavController()) {
         when (item.itemId) {
-            R.id.menuSettings -> navigate(R.id.action_mainFragment_to_settingsFragment)
-            R.id.debug -> navigate(R.id.action_mainFragment_to_debugFragment)
-            R.id.menuPrivacyNotice -> navigate(R.id.action_mainFragment_to_privacyNoticesFragment)
+            R.id.menuSettings -> navigateSafely(this@MainFragment, R.id.action_mainFragment_to_settingsFragment)
+            R.id.debug -> navigateSafely(this@MainFragment, R.id.action_mainFragment_to_debugFragment)
+            R.id.menuPrivacyNotice -> navigateSafely(this@MainFragment, R.id.action_mainFragment_to_privacyNoticesFragment)
         }
         true
     }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncFragment.kt
@@ -15,6 +15,7 @@ import com.simprints.feature.dashboard.requestlogin.RequestLoginFragmentArgs
 import com.simprints.feature.login.LoginContract
 import com.simprints.feature.login.LoginResult
 import com.simprints.infra.uibase.navigation.handleResult
+import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import com.simprints.infra.resources.R as IDR
@@ -42,8 +43,9 @@ internal class SyncFragment : Fragment(R.layout.fragment_dashboard_card_sync) {
     private fun initViews() = with(binding.dashboardSyncCard) {
         onSyncButtonClick = { viewModel.sync() }
         onOfflineButtonClick = { startActivity(Intent(Settings.ACTION_WIRELESS_SETTINGS)) }
-        onSelectNoModulesButtonClick =
-            { findNavController().navigate(R.id.action_mainFragment_to_moduleSelectionFragment) }
+        onSelectNoModulesButtonClick = {
+            findNavController().navigateSafely(this@SyncFragment, R.id.action_mainFragment_to_moduleSelectionFragment)
+        }
         onLoginButtonClick = { viewModel.login() }
     }
 
@@ -63,7 +65,8 @@ internal class SyncFragment : Fragment(R.layout.fragment_dashboard_card_sync) {
                 title = getString(IDR.string.dashboard_sync_project_ending_alert_title),
                 body = getString(IDR.string.dashboard_sync_project_ending_message),
             )
-            findNavController().navigate(
+            findNavController().navigateSafely(
+                this,
                 R.id.action_mainFragment_to_requestLoginFragment,
                 RequestLoginFragmentArgs(logoutReason = logoutReason).toBundle(),
             )
@@ -71,10 +74,7 @@ internal class SyncFragment : Fragment(R.layout.fragment_dashboard_card_sync) {
         viewModel.loginRequestedEventLiveData.observe(
             viewLifecycleOwner,
             LiveDataEventWithContentObserver { loginArgs ->
-                findNavController().navigate(
-                    R.id.action_mainFragment_to_login,
-                    loginArgs,
-                )
+                findNavController().navigateSafely(this@SyncFragment, R.id.action_mainFragment_to_login, loginArgs)
             },
         )
     }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/requestlogin/RequestLoginFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/requestlogin/RequestLoginFragment.kt
@@ -13,6 +13,7 @@ import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentRequestLoginBinding
 import com.simprints.feature.troubleshooting.AutoResettingClickCounter
 import com.simprints.infra.authstore.AuthStore
+import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -52,7 +53,7 @@ internal class RequestLoginFragment : Fragment(R.layout.fragment_request_login) 
 
         binding.loginImageViewLogo.setOnClickListener {
             if (clickCounter.handleClick(lifecycleScope)) {
-                findNavController().navigate(R.id.action_requestLoginFragment_to_troubleshooting)
+                findNavController().navigateSafely(this, R.id.action_requestLoginFragment_to_troubleshooting)
             }
         }
     }
@@ -65,7 +66,7 @@ internal class RequestLoginFragment : Fragment(R.layout.fragment_request_login) 
     override fun onResume() {
         super.onResume()
         if (authStore.signedInProjectId.isNotEmpty()) {
-            findNavController().navigate(R.id.action_requestLoginFragment_to_mainFragment)
+            findNavController().navigateSafely(this, R.id.action_requestLoginFragment_to_mainFragment)
         }
     }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
@@ -19,6 +19,7 @@ import com.simprints.feature.dashboard.databinding.FragmentSettingsBinding
 import com.simprints.feature.dashboard.settings.password.SettingsPasswordDialogFragment
 import com.simprints.infra.config.store.models.GeneralConfiguration
 import com.simprints.infra.config.store.models.GeneralConfiguration.Modality.FINGERPRINT
+import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import com.simprints.infra.resources.R as IDR
@@ -85,12 +86,12 @@ internal class SettingsFragment : PreferenceFragmentCompat() {
         }
 
         getFingerSelectionPreference()?.setOnPreferenceClickListener {
-            findNavController().navigate(R.id.action_settingsFragment_to_fingerSelectionFragment)
+            findNavController().navigateSafely(this@SettingsFragment, R.id.action_settingsFragment_to_fingerSelectionFragment)
             true
         }
 
         getSyncInfoPreference()?.setOnPreferenceClickListener {
-            findNavController().navigate(R.id.action_settingsFragment_to_syncInfoFragment)
+            findNavController().navigateSafely(this@SettingsFragment, R.id.action_settingsFragment_to_syncInfoFragment)
             true
         }
 
@@ -100,7 +101,7 @@ internal class SettingsFragment : PreferenceFragmentCompat() {
         }
 
         getAboutPreference()?.setOnPreferenceClickListener {
-            findNavController().navigate(R.id.action_settingsFragment_to_aboutFragment)
+            findNavController().navigateSafely(this@SettingsFragment, R.id.action_settingsFragment_to_aboutFragment)
             true
         }
     }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutFragment.kt
@@ -19,6 +19,7 @@ import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentSettingsAboutBinding
 import com.simprints.feature.dashboard.settings.password.SettingsPasswordDialogFragment
 import com.simprints.infra.config.store.models.GeneralConfiguration.Modality.FINGERPRINT
+import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.system.Clipboard
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -95,7 +96,7 @@ internal class AboutFragment : PreferenceFragmentCompat() {
                     LogoutDestination.LogoutDataSyncScreen -> R.id.action_aboutFragment_to_logout_navigation
                     LogoutDestination.LoginScreen -> R.id.action_aboutFragment_to_requestLoginFragment
                 }
-                findNavController().navigate(destination)
+                findNavController().navigateSafely(this, destination)
             },
         )
         viewModel.openTroubleshooting.observe(
@@ -152,7 +153,7 @@ internal class AboutFragment : PreferenceFragmentCompat() {
     }
 
     private fun openTroubleshooting() {
-        findNavController().navigate(R.id.action_aboutFragment_to_troubleshooting)
+        findNavController().navigateSafely(this, R.id.action_aboutFragment_to_troubleshooting)
     }
 
     private fun getAppVersionPreference(): Preference? = findPreference(getString(R.string.preference_app_version_key))

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
@@ -19,6 +19,7 @@ import com.simprints.infra.config.store.models.SynchronizationConfiguration
 import com.simprints.infra.config.store.models.canSyncDataToSimprints
 import com.simprints.infra.config.store.models.isEventDownSyncAllowed
 import com.simprints.infra.uibase.navigation.handleResult
+import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import com.simprints.infra.resources.R as IDR
@@ -52,7 +53,7 @@ internal class SyncInfoFragment : Fragment(R.layout.fragment_sync_info) {
 
     private fun setupClickListeners() {
         binding.moduleSelectionButton.setOnClickListener {
-            findNavController().navigate(R.id.action_syncInfoFragment_to_moduleSelectionFragment)
+            findNavController().navigateSafely(this, R.id.action_syncInfoFragment_to_moduleSelectionFragment)
         }
         binding.syncInfoToolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
@@ -120,7 +121,8 @@ internal class SyncInfoFragment : Fragment(R.layout.fragment_sync_info) {
         viewModel.loginRequestedEventLiveData.observe(
             viewLifecycleOwner,
             LiveDataEventWithContentObserver { loginArgs ->
-                findNavController().navigate(
+                findNavController().navigateSafely(
+                    this,
                     R.id.action_syncInfoFragment_to_login,
                     loginArgs,
                 )

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/intents/IntentLogFragment.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/intents/IntentLogFragment.kt
@@ -11,6 +11,7 @@ import com.simprints.feature.troubleshooting.R
 import com.simprints.feature.troubleshooting.TroubleshootingFragmentDirections
 import com.simprints.feature.troubleshooting.adapter.TroubleshootingListAdapter
 import com.simprints.feature.troubleshooting.databinding.FragmentTroubleshootingListBinding
+import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlin.getValue
@@ -29,7 +30,7 @@ internal class IntentLogFragment : Fragment(R.layout.fragment_troubleshooting_li
         viewModel.logs.observe(viewLifecycleOwner) {
             binding.troubleshootingListProgress.isGone = it.isNotEmpty()
             binding.troubleshootingList.adapter = TroubleshootingListAdapter(it) {
-                findNavController().navigate(openEventsList(it))
+                findNavController().navigateSafely(this, openEventsList(it))
             }
         }
         viewModel.collectData()


### PR DESCRIPTION
* Replaced all the regular `navigate()` calls with the safer version to avoid navigation exceptions in the dashboard. 
* Clicked through all of the navigation actions and it seems to be working correctly.