### PR TITLE
MS-802 Display timestamps in ISO format

### DIFF
--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/TroubleshootingModule.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/TroubleshootingModule.kt
@@ -1,0 +1,30 @@
+package com.simprints.feature.troubleshooting
+
+import android.os.Build
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class TroubleshootingModule {
+    @IsoDateTimeFormatter
+    @Singleton
+    @Provides
+    fun provideDateTimeFormatter(): SimpleDateFormat = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        // For some reason offset info is only available from API 24
+        SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS XXX", Locale.US)
+    } else {
+        SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+    }.also { it.timeZone = TimeZone.getDefault() }
+}
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IsoDateTimeFormatter

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/events/EventsLogViewModel.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/events/EventsLogViewModel.kt
@@ -4,17 +4,19 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.simprints.feature.troubleshooting.IsoDateTimeFormatter
 import com.simprints.feature.troubleshooting.adapter.TroubleshootingItemViewData
 import com.simprints.infra.events.EventRepository
 import com.simprints.infra.events.event.domain.models.Event
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import java.util.Date
+import java.text.SimpleDateFormat
 import javax.inject.Inject
 
 @HiltViewModel
 internal class EventsLogViewModel @Inject constructor(
     private val eventRepository: EventRepository,
+    @IsoDateTimeFormatter private val dateFormatter: SimpleDateFormat,
 ) : ViewModel() {
     private val _events = MutableLiveData<List<TroubleshootingItemViewData>>(emptyList())
     val events: LiveData<List<TroubleshootingItemViewData>>
@@ -43,5 +45,6 @@ internal class EventsLogViewModel @Inject constructor(
     private fun formatTimestampSubtitle(
         startMs: Long,
         endMs: Long? = null,
-    ): String = "Started: ${Date(startMs)}" + endMs?.let { "\nEnded: ${Date(it)}" }.orEmpty()
+    ): String = "Started: ${dateFormatter.format(startMs)}" +
+        endMs?.let { "\nEnded: ${dateFormatter.format(it)}" }.orEmpty()
 }

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/intents/IntentLogViewModel.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/intents/IntentLogViewModel.kt
@@ -4,17 +4,19 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.simprints.feature.troubleshooting.IsoDateTimeFormatter
 import com.simprints.feature.troubleshooting.adapter.TroubleshootingItemViewData
 import com.simprints.logging.persistent.LogEntryType
 import com.simprints.logging.persistent.PersistentLogger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import java.util.Date
+import java.text.SimpleDateFormat
 import javax.inject.Inject
 
 @HiltViewModel
 internal class IntentLogViewModel @Inject constructor(
     private val persistentLogger: PersistentLogger,
+    @IsoDateTimeFormatter private val dateFormatter: SimpleDateFormat,
 ) : ViewModel() {
     private val _logs = MutableLiveData<List<TroubleshootingItemViewData>>(emptyList())
     val logs: LiveData<List<TroubleshootingItemViewData>>
@@ -27,7 +29,7 @@ internal class IntentLogViewModel @Inject constructor(
                 .map {
                     TroubleshootingItemViewData(
                         title = it.title,
-                        subtitle = Date(it.timestampMs).toString(),
+                        subtitle = dateFormatter.format(it.timestampMs),
                         body = it.body,
                         navigationId = it.title,
                     )

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/networking/NetworkingLogViewModel.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/networking/NetworkingLogViewModel.kt
@@ -4,17 +4,19 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.simprints.feature.troubleshooting.IsoDateTimeFormatter
 import com.simprints.feature.troubleshooting.adapter.TroubleshootingItemViewData
 import com.simprints.logging.persistent.LogEntryType
 import com.simprints.logging.persistent.PersistentLogger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import java.util.Date
+import java.text.SimpleDateFormat
 import javax.inject.Inject
 
 @HiltViewModel
 internal class NetworkingLogViewModel @Inject constructor(
     private val persistentLogger: PersistentLogger,
+    @IsoDateTimeFormatter private val dateFormatter: SimpleDateFormat,
 ) : ViewModel() {
     private val _logs = MutableLiveData<List<TroubleshootingItemViewData>>(emptyList())
     val logs: LiveData<List<TroubleshootingItemViewData>>
@@ -27,7 +29,7 @@ internal class NetworkingLogViewModel @Inject constructor(
                 .map {
                     TroubleshootingItemViewData(
                         title = it.title,
-                        subtitle = Date(it.timestampMs).toString(),
+                        subtitle = dateFormatter.format(it.timestampMs),
                         body = it.body,
                     )
                 }.ifEmpty { listOf(TroubleshootingItemViewData(title = "No data")) }

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/workers/WorkerLogViewModel.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/workers/WorkerLogViewModel.kt
@@ -7,15 +7,17 @@ import androidx.lifecycle.viewModelScope
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkQuery
+import com.simprints.feature.troubleshooting.IsoDateTimeFormatter
 import com.simprints.feature.troubleshooting.adapter.TroubleshootingItemViewData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import java.util.Date
+import java.text.SimpleDateFormat
 import javax.inject.Inject
 
 @HiltViewModel
 internal class WorkerLogViewModel @Inject constructor(
     private val workManager: WorkManager,
+    @IsoDateTimeFormatter private val dateFormatter: SimpleDateFormat,
 ) : ViewModel() {
     private val _workers = MutableLiveData<List<TroubleshootingItemViewData>>(emptyList())
     val workers: LiveData<List<TroubleshootingItemViewData>>
@@ -43,7 +45,7 @@ internal class WorkerLogViewModel @Inject constructor(
             ?: info.id.toString(),
         subtitle = info.state.toString(),
         body = if (info.state == WorkInfo.State.ENQUEUED) {
-            "ID: ${info.id}\nNext run: ${Date(info.nextScheduleTimeMillis)}"
+            "ID: ${info.id}\nNext run: ${dateFormatter.format(info.nextScheduleTimeMillis)}"
         } else {
             "ID: ${info.id}\nOutput: ${info.outputData}"
         },

--- a/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/events/EventsLogViewModelTest.kt
+++ b/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/events/EventsLogViewModelTest.kt
@@ -8,11 +8,13 @@ import com.simprints.infra.events.sampledata.createAlertScreenEvent
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.text.SimpleDateFormat
 
 class EventsLogViewModelTest {
     @get:Rule
@@ -24,14 +26,19 @@ class EventsLogViewModelTest {
     @MockK
     private lateinit var eventRepository: EventRepository
 
+    @MockK
+    private lateinit var dateFormatter: SimpleDateFormat
+
     private lateinit var viewModel: EventsLogViewModel
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
+        every { dateFormatter.format(any()) } returns "date"
 
         viewModel = EventsLogViewModel(
             eventRepository = eventRepository,
+            dateFormatter = dateFormatter,
         )
     }
 

--- a/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/intents/IntentsLogViewModelTest.kt
+++ b/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/intents/IntentsLogViewModelTest.kt
@@ -9,13 +9,15 @@ import com.simprints.logging.persistent.PersistentLogger
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.text.SimpleDateFormat
 
-class NetworkingLogViewModelTest {
+class IntentsLogViewModelTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
 
@@ -25,14 +27,19 @@ class NetworkingLogViewModelTest {
     @MockK
     private lateinit var persistentLogger: PersistentLogger
 
+    @MockK
+    private lateinit var dateFormatter: SimpleDateFormat
+
     private lateinit var viewModel: IntentLogViewModel
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
+        every { dateFormatter.format(any()) } returns "date"
 
         viewModel = IntentLogViewModel(
             persistentLogger = persistentLogger,
+            dateFormatter = dateFormatter,
         )
     }
 

--- a/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/networking/NetworkingLogViewModelTest.kt
+++ b/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/networking/NetworkingLogViewModelTest.kt
@@ -9,11 +9,13 @@ import com.simprints.logging.persistent.PersistentLogger
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.text.SimpleDateFormat
 
 class NetworkingLogViewModelTest {
     @get:Rule
@@ -25,14 +27,19 @@ class NetworkingLogViewModelTest {
     @MockK
     private lateinit var persistentLogger: PersistentLogger
 
+    @MockK
+    private lateinit var dateFormatter: SimpleDateFormat
+
     private lateinit var viewModel: NetworkingLogViewModel
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
+        every { dateFormatter.format(any()) } returns "date"
 
         viewModel = NetworkingLogViewModel(
             persistentLogger = persistentLogger,
+            dateFormatter = dateFormatter,
         )
     }
 

--- a/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/workers/WorkerLogViewModelTest.kt
+++ b/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/workers/WorkerLogViewModelTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.text.SimpleDateFormat
 import java.util.UUID
 
 class WorkerLogViewModelTest {
@@ -28,14 +29,19 @@ class WorkerLogViewModelTest {
     @MockK
     private lateinit var workManager: WorkManager
 
+    @MockK
+    private lateinit var dateFormatter: SimpleDateFormat
+
     private lateinit var viewModel: WorkerLogViewModel
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
+        every { dateFormatter.format(any()) } returns "date"
 
         viewModel = WorkerLogViewModel(
             workManager = workManager,
+            dateFormatter = dateFormatter,
         )
     }
 


### PR DESCRIPTION
As suggested by @alex-vt - displaying the timestamps in troubleshooting in ISO format to make it easier to scan and also avoid issues with in different Locales.