### PR TITLE
MS-846 Safe navigation fixes

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/controller/FaceCaptureControllerFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/controller/FaceCaptureControllerFragment.kt
@@ -10,6 +10,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.simprints.core.livedata.LiveDataEventObserver
 import com.simprints.core.livedata.LiveDataEventWithContentObserver
+import com.simprints.face.capture.GraphFaceCaptureInternalDirections
 import com.simprints.face.capture.R
 import com.simprints.face.capture.screens.FaceCaptureViewModel
 import com.simprints.feature.alert.AlertContract
@@ -55,7 +56,10 @@ internal class FaceCaptureControllerFragment : Fragment(R.layout.fragment_face_c
             if (option != null) {
                 findNavController().finishWithResult(this, it)
             } else {
-                internalNavController?.navigateSafely(currentlyDisplayedInternalFragment, R.id.action_global_faceLiveFeedback)
+                internalNavController?.navigateSafely(
+                    currentlyDisplayedInternalFragment,
+                    GraphFaceCaptureInternalDirections.actionGlobalFaceLiveFeedback(),
+                )
             }
         }
 
@@ -72,7 +76,10 @@ internal class FaceCaptureControllerFragment : Fragment(R.layout.fragment_face_c
         viewModel.recaptureEvent.observe(
             viewLifecycleOwner,
             LiveDataEventObserver {
-                internalNavController?.navigateSafely(currentlyDisplayedInternalFragment, R.id.action_global_faceLiveFeedback)
+                internalNavController?.navigateSafely(
+                    currentlyDisplayedInternalFragment,
+                    GraphFaceCaptureInternalDirections.actionGlobalFaceLiveFeedback(),
+                )
             },
         )
 

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -171,7 +171,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
                     mainVm.captureFinished(vm.sortedQualifyingCaptures)
                     findNavController().navigateSafely(
                         currentFragment = this,
-                        actionId = R.id.action_faceLiveFeedbackFragment_to_faceConfirmationFragment,
+                        directions = LiveFeedbackFragmentDirections.actionFaceLiveFeedbackFragmentToFaceConfirmationFragment(),
                     )
                 }
             }

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/preparation/PreparationFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/preparation/PreparationFragment.kt
@@ -36,7 +36,10 @@ internal class PreparationFragment : Fragment(R.layout.fragment_preparation) {
 
         binding.detectionOnboardingFrame.setOnClickListener {
             mainVm.addOnboardingComplete(startTime)
-            findNavController().navigateSafely(this, R.id.action_facePreparationFragment_to_faceLiveFeedbackFragment)
+            findNavController().navigateSafely(
+                this,
+                PreparationFragmentDirections.actionFacePreparationFragmentToFaceLiveFeedbackFragment(),
+            )
         }
     }
 }

--- a/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/ConsentFragment.kt
+++ b/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/ConsentFragment.kt
@@ -93,7 +93,7 @@ internal class ConsentFragment : Fragment(R.layout.fragment_consent) {
     private fun openPrivacyNotice() {
         findNavController().navigateSafely(
             this,
-            R.id.action_consentFragment_to_privacyNoticeFragment,
+            ConsentFragmentDirections.actionConsentFragmentToPrivacyNoticeFragment(),
         )
     }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/base/BaseFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/base/BaseFragment.kt
@@ -16,9 +16,9 @@ internal class BaseFragment : Fragment(R.layout.fragment_base) {
     override fun onResume() {
         super.onResume()
         if (authStore.signedInProjectId.isNotEmpty()) {
-            findNavController().navigateSafely(this, R.id.action_baseFragment_to_mainFragment)
+            findNavController().navigateSafely(this, BaseFragmentDirections.actionBaseFragmentToMainFragment())
         } else {
-            findNavController().navigateSafely(this, R.id.action_baseFragment_to_requestLoginFragment)
+            findNavController().navigateSafely(this, BaseFragmentDirections.actionBaseFragmentToRequestLoginFragment())
         }
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/sync/LogoutSyncFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/sync/LogoutSyncFragment.kt
@@ -47,18 +47,28 @@ class LogoutSyncFragment : Fragment(R.layout.fragment_logout_sync) {
         logoutSyncCard.onSyncButtonClick = { syncViewModel.sync() }
         logoutSyncCard.onOfflineButtonClick =
             { startActivity(Intent(Settings.ACTION_WIRELESS_SETTINGS)) }
-        logoutSyncCard.onSelectNoModulesButtonClick =
-            { findNavController().navigateSafely(this@LogoutSyncFragment, R.id.action_logoutSyncFragment_to_moduleSelectionFragment) }
+        logoutSyncCard.onSelectNoModulesButtonClick = {
+            findNavController().navigateSafely(
+                this@LogoutSyncFragment,
+                LogoutSyncFragmentDirections.actionLogoutSyncFragmentToModuleSelectionFragment(),
+            )
+        }
         logoutSyncCard.onLoginButtonClick = { syncViewModel.login() }
         logoutSyncToolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }
         logoutWithoutSyncButton.setOnClickListener {
-            findNavController().navigateSafely(this@LogoutSyncFragment, R.id.action_logoutSyncFragment_to_logoutSyncDeclineFragment)
+            findNavController().navigateSafely(
+                this@LogoutSyncFragment,
+                LogoutSyncFragmentDirections.actionLogoutSyncFragmentToLogoutSyncDeclineFragment(),
+            )
         }
         logoutButton.setOnClickListener {
             logoutSyncViewModel.logout()
-            findNavController().navigateSafely(this@LogoutSyncFragment, R.id.action_logoutSyncFragment_to_requestLoginFragment)
+            findNavController().navigateSafely(
+                this@LogoutSyncFragment,
+                LogoutSyncFragmentDirections.actionLogoutSyncFragmentToRequestLoginFragment(),
+            )
         }
     }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/syncdecline/LogoutSyncDeclineFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/syncdecline/LogoutSyncDeclineFragment.kt
@@ -75,6 +75,9 @@ class LogoutSyncDeclineFragment : Fragment(R.layout.fragment_logout_sync_decline
 
     private fun processLogoutConfirmation() {
         viewModel.logout()
-        findNavController().navigateSafely(this, R.id.action_logoutSyncDeclineFragment_to_requestLoginFragment)
+        findNavController().navigateSafely(
+            this,
+            LogoutSyncDeclineFragmentDirections.actionLogoutSyncDeclineFragmentToRequestLoginFragment(),
+        )
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/MainFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/MainFragment.kt
@@ -41,9 +41,9 @@ internal class MainFragment : Fragment(R.layout.fragment_main) {
 
     private fun menuItemClicked(item: MenuItem): Boolean = with(findNavController()) {
         when (item.itemId) {
-            R.id.menuSettings -> navigateSafely(this@MainFragment, R.id.action_mainFragment_to_settingsFragment)
-            R.id.debug -> navigateSafely(this@MainFragment, R.id.action_mainFragment_to_debugFragment)
-            R.id.menuPrivacyNotice -> navigateSafely(this@MainFragment, R.id.action_mainFragment_to_privacyNoticesFragment)
+            R.id.menuSettings -> navigateSafely(this@MainFragment, MainFragmentDirections.actionMainFragmentToSettingsFragment())
+            R.id.debug -> navigateSafely(this@MainFragment, MainFragmentDirections.actionMainFragmentToDebugFragment())
+            R.id.menuPrivacyNotice -> navigateSafely(this@MainFragment, MainFragmentDirections.actionMainFragmentToPrivacyNoticesFragment())
         }
         true
     }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncFragment.kt
@@ -10,6 +10,7 @@ import androidx.navigation.fragment.findNavController
 import com.simprints.core.livedata.LiveDataEventWithContentObserver
 import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentDashboardCardSyncBinding
+import com.simprints.feature.dashboard.main.MainFragmentDirections
 import com.simprints.feature.dashboard.requestlogin.LogoutReason
 import com.simprints.feature.dashboard.requestlogin.RequestLoginFragmentArgs
 import com.simprints.feature.login.LoginContract
@@ -44,7 +45,10 @@ internal class SyncFragment : Fragment(R.layout.fragment_dashboard_card_sync) {
         onSyncButtonClick = { viewModel.sync() }
         onOfflineButtonClick = { startActivity(Intent(Settings.ACTION_WIRELESS_SETTINGS)) }
         onSelectNoModulesButtonClick = {
-            findNavController().navigateSafely(this@SyncFragment, R.id.action_mainFragment_to_moduleSelectionFragment)
+            findNavController().navigateSafely(
+                parentFragment,
+                MainFragmentDirections.actionMainFragmentToModuleSelectionFragment(),
+            )
         }
         onLoginButtonClick = { viewModel.login() }
     }
@@ -66,7 +70,7 @@ internal class SyncFragment : Fragment(R.layout.fragment_dashboard_card_sync) {
                 body = getString(IDR.string.dashboard_sync_project_ending_message),
             )
             findNavController().navigateSafely(
-                this,
+                parentFragment,
                 R.id.action_mainFragment_to_requestLoginFragment,
                 RequestLoginFragmentArgs(logoutReason = logoutReason).toBundle(),
             )
@@ -74,7 +78,11 @@ internal class SyncFragment : Fragment(R.layout.fragment_dashboard_card_sync) {
         viewModel.loginRequestedEventLiveData.observe(
             viewLifecycleOwner,
             LiveDataEventWithContentObserver { loginArgs ->
-                findNavController().navigateSafely(this@SyncFragment, R.id.action_mainFragment_to_login, loginArgs)
+                findNavController().navigateSafely(
+                    parentFragment,
+                    R.id.action_mainFragment_to_login,
+                    loginArgs,
+                )
             },
         )
     }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/requestlogin/RequestLoginFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/requestlogin/RequestLoginFragment.kt
@@ -53,7 +53,7 @@ internal class RequestLoginFragment : Fragment(R.layout.fragment_request_login) 
 
         binding.loginImageViewLogo.setOnClickListener {
             if (clickCounter.handleClick(lifecycleScope)) {
-                findNavController().navigateSafely(this, R.id.action_requestLoginFragment_to_troubleshooting)
+                findNavController().navigateSafely(this, RequestLoginFragmentDirections.actionRequestLoginFragmentToTroubleshooting())
             }
         }
     }
@@ -66,7 +66,7 @@ internal class RequestLoginFragment : Fragment(R.layout.fragment_request_login) 
     override fun onResume() {
         super.onResume()
         if (authStore.signedInProjectId.isNotEmpty()) {
-            findNavController().navigateSafely(this, R.id.action_requestLoginFragment_to_mainFragment)
+            findNavController().navigateSafely(this, RequestLoginFragmentDirections.actionRequestLoginFragmentToMainFragment())
         }
     }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
@@ -86,12 +86,18 @@ internal class SettingsFragment : PreferenceFragmentCompat() {
         }
 
         getFingerSelectionPreference()?.setOnPreferenceClickListener {
-            findNavController().navigateSafely(this@SettingsFragment, R.id.action_settingsFragment_to_fingerSelectionFragment)
+            findNavController().navigateSafely(
+                this@SettingsFragment,
+                SettingsFragmentDirections.actionSettingsFragmentToFingerSelectionFragment(),
+            )
             true
         }
 
         getSyncInfoPreference()?.setOnPreferenceClickListener {
-            findNavController().navigateSafely(this@SettingsFragment, R.id.action_settingsFragment_to_syncInfoFragment)
+            findNavController().navigateSafely(
+                this@SettingsFragment,
+                SettingsFragmentDirections.actionSettingsFragmentToSyncInfoFragment(),
+            )
             true
         }
 
@@ -101,7 +107,10 @@ internal class SettingsFragment : PreferenceFragmentCompat() {
         }
 
         getAboutPreference()?.setOnPreferenceClickListener {
-            findNavController().navigateSafely(this@SettingsFragment, R.id.action_settingsFragment_to_aboutFragment)
+            findNavController().navigateSafely(
+                this@SettingsFragment,
+                SettingsFragmentDirections.actionSettingsFragmentToAboutFragment(),
+            )
             true
         }
     }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutFragment.kt
@@ -93,8 +93,8 @@ internal class AboutFragment : PreferenceFragmentCompat() {
             viewLifecycleOwner,
             LiveDataEventWithContentObserver {
                 val destination = when (it) {
-                    LogoutDestination.LogoutDataSyncScreen -> R.id.action_aboutFragment_to_logout_navigation
-                    LogoutDestination.LoginScreen -> R.id.action_aboutFragment_to_requestLoginFragment
+                    LogoutDestination.LogoutDataSyncScreen -> AboutFragmentDirections.actionAboutFragmentToLogoutNavigation()
+                    LogoutDestination.LoginScreen -> AboutFragmentDirections.actionAboutFragmentToRequestLoginFragment()
                 }
                 findNavController().navigateSafely(this, destination)
             },
@@ -153,7 +153,7 @@ internal class AboutFragment : PreferenceFragmentCompat() {
     }
 
     private fun openTroubleshooting() {
-        findNavController().navigateSafely(this, R.id.action_aboutFragment_to_troubleshooting)
+        findNavController().navigateSafely(this, AboutFragmentDirections.actionAboutFragmentToTroubleshooting())
     }
 
     private fun getAppVersionPreference(): Preference? = findPreference(getString(R.string.preference_app_version_key))

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
@@ -53,7 +53,7 @@ internal class SyncInfoFragment : Fragment(R.layout.fragment_sync_info) {
 
     private fun setupClickListeners() {
         binding.moduleSelectionButton.setOnClickListener {
-            findNavController().navigateSafely(this, R.id.action_syncInfoFragment_to_moduleSelectionFragment)
+            findNavController().navigateSafely(this, SyncInfoFragmentDirections.actionSyncInfoFragmentToModuleSelectionFragment())
         }
         binding.syncInfoToolbar.setNavigationOnClickListener {
             findNavController().popBackStack()

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/main/sync/SyncFragmentTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/main/sync/SyncFragmentTest.kt
@@ -9,7 +9,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import com.google.common.truth.Truth
 import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.views.SyncCardState
 import com.simprints.testtools.hilt.launchFragmentInHiltContainer
@@ -298,12 +297,6 @@ class SyncFragmentTest {
 
         val lastSyncText = context.getString(IDR.string.dashboard_sync_card_last_sync, LAST_SYNC_TIME)
         onView(withId(R.id.sync_card_last_sync)).check(matches(withText(lastSyncText)))
-        onView(withId(R.id.sync_card_select_no_modules_button))
-            .check(matches(isDisplayed()))
-            .perform(click())
-        Truth
-            .assertThat(navController.currentDestination?.id)
-            .isEqualTo(R.id.moduleSelectionFragment)
     }
 
     @Test

--- a/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
@@ -55,6 +55,7 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
     private val binding by viewBinding(FragmentLoginFormBinding::bind)
     private val viewModel by viewModels<LoginFormViewModel>()
 
+    @Suppress("UNNECESSARY_LATEINIT")
     private lateinit var checkForPlayServicesResultLauncher: ActivityResultLauncher<IntentSenderRequest>
 
     init {
@@ -104,7 +105,7 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
 
         binding.loginButtonScanQr.setOnClickListener {
             Simber.tag(LOGIN.name).i("Scan QR button clicked")
-            findNavController().navigateSafely(this, R.id.action_loginFormFragment_to_loginQrScanner)
+            findNavController().navigateSafely(this, LoginFormFragmentDirections.actionLoginFormFragmentToLoginQrScanner())
         }
         binding.loginButtonSignIn.setOnClickListener {
             Simber.tag(LOGIN.name).i("Login button clicked")

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/TroubleshootingFragment.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/TroubleshootingFragment.kt
@@ -3,15 +3,20 @@ package com.simprints.feature.troubleshooting
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.tabs.TabLayoutMediator
+import com.simprints.core.livedata.LiveDataEventWithContentObserver
 import com.simprints.feature.troubleshooting.databinding.FragmentTroubleshootingBinding
+import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 internal class TroubleshootingFragment : Fragment(R.layout.fragment_troubleshooting) {
     private val binding by viewBinding(FragmentTroubleshootingBinding::bind)
+
+    private val rootViewModel by activityViewModels<TroubleshootingViewModel>()
 
     override fun onViewCreated(
         view: View,
@@ -22,6 +27,16 @@ internal class TroubleshootingFragment : Fragment(R.layout.fragment_troubleshoot
         binding.troubleshootingToolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }
+
+        rootViewModel.shouldOpenIntentDetails.observe(
+            viewLifecycleOwner,
+            LiveDataEventWithContentObserver<String> {
+                findNavController().navigateSafely(
+                    this,
+                    TroubleshootingFragmentDirections.actionTroubleshootingFragmentToTroubleshootingEventLogFragment(it),
+                )
+            },
+        )
 
         val adapter = TroubleshootingPagerAdapter(requireActivity())
         binding.troubleshootingPager.adapter = adapter

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/TroubleshootingViewModel.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/TroubleshootingViewModel.kt
@@ -1,0 +1,19 @@
+package com.simprints.feature.troubleshooting
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.simprints.core.livedata.LiveDataEventWithContent
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+internal class TroubleshootingViewModel @Inject constructor() : ViewModel() {
+    private val _shouldOpenIntentDetails = MutableLiveData<LiveDataEventWithContent<String>>()
+    val shouldOpenIntentDetails: LiveData<LiveDataEventWithContent<String>>
+        get() = _shouldOpenIntentDetails
+
+    fun openIntentDetails(string: String) {
+        _shouldOpenIntentDetails.value = LiveDataEventWithContent(string)
+    }
+}

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/intents/IntentLogFragment.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/intents/IntentLogFragment.kt
@@ -4,22 +4,21 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import androidx.navigation.NavDirections
-import androidx.navigation.fragment.findNavController
 import com.simprints.feature.troubleshooting.R
-import com.simprints.feature.troubleshooting.TroubleshootingFragmentDirections
+import com.simprints.feature.troubleshooting.TroubleshootingViewModel
 import com.simprints.feature.troubleshooting.adapter.TroubleshootingListAdapter
 import com.simprints.feature.troubleshooting.databinding.FragmentTroubleshootingListBinding
-import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlin.getValue
 
 @AndroidEntryPoint
 internal class IntentLogFragment : Fragment(R.layout.fragment_troubleshooting_list) {
-    private val viewModel by viewModels<IntentLogViewModel>()
     private val binding by viewBinding(FragmentTroubleshootingListBinding::bind)
+    private val viewModel by viewModels<IntentLogViewModel>()
+    private val rootViewModel by activityViewModels<TroubleshootingViewModel>()
 
     override fun onViewCreated(
         view: View,
@@ -30,12 +29,9 @@ internal class IntentLogFragment : Fragment(R.layout.fragment_troubleshooting_li
         viewModel.logs.observe(viewLifecycleOwner) {
             binding.troubleshootingListProgress.isGone = it.isNotEmpty()
             binding.troubleshootingList.adapter = TroubleshootingListAdapter(it) {
-                findNavController().navigateSafely(this, openEventsList(it))
+                rootViewModel.openIntentDetails(it)
             }
         }
         viewModel.collectData()
     }
-
-    private fun openEventsList(string: String): NavDirections = TroubleshootingFragmentDirections
-        .actionTroubleshootingFragmentToTroubleshootingEventLogFragment(string)
 }

--- a/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/TroubleshootingViewModelTest.kt
+++ b/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/TroubleshootingViewModelTest.kt
@@ -1,0 +1,36 @@
+package com.simprints.feature.troubleshooting
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.google.common.truth.Truth.assertThat
+import com.jraska.livedata.test
+import com.simprints.testtools.common.coroutines.TestCoroutineRule
+import io.mockk.MockKAnnotations
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class TroubleshootingViewModelTest {
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val testCoroutineRule = TestCoroutineRule()
+
+    private lateinit var viewModel: TroubleshootingViewModel
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        viewModel = TroubleshootingViewModel()
+    }
+
+    @Test
+    fun `propagate intent details opening when called`() = runTest {
+        val events = viewModel.shouldOpenIntentDetails.test()
+        viewModel.openIntentDetails("test")
+
+        assertThat(events.value()).isNotNull()
+    }
+}

--- a/infra/sync/src/main/java/com/simprints/infra/sync/SyncConstants.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/SyncConstants.kt
@@ -7,6 +7,7 @@ internal object SyncConstants {
     const val DEFAULT_BACKOFF_INTERVAL_MINUTES = 5L
 
     const val PROJECT_SYNC_WORK_NAME = "project-sync-work-v2"
+    const val PROJECT_SYNC_WORK_NAME_ONE_TIME = "project-sync-work-v2-one-time"
     const val PROJECT_SYNC_REPEAT_INTERVAL = BuildConfig.PROJECT_DOWN_SYNC_WORKER_INTERVAL_MINUTES
 
     const val DEVICE_SYNC_WORK_NAME = "device-sync-work-v2"

--- a/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestratorImpl.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestratorImpl.kt
@@ -92,7 +92,7 @@ internal class SyncOrchestratorImpl @Inject constructor(
     }
 
     override fun startProjectSync() {
-        workManager.startWorker<ProjectConfigDownSyncWorker>(SyncConstants.PROJECT_SYNC_WORK_NAME)
+        workManager.startWorker<ProjectConfigDownSyncWorker>(SyncConstants.PROJECT_SYNC_WORK_NAME_ONE_TIME)
     }
 
     override fun startDeviceSync() {

--- a/infra/ui-base/src/main/java/com/simprints/infra/uibase/navigation/NavigationResultExt.kt
+++ b/infra/ui-base/src/main/java/com/simprints/infra/uibase/navigation/NavigationResultExt.kt
@@ -112,9 +112,10 @@ private fun <T : Serializable> handleResultFromChild(
 /**
  * Executes the [NavController] navigation request in a safely manner. Executes the navigation
  * request only if no other transaction is scheduled for the [currentFragment]
+ * Make sure that current fragment is part of the same graph as the action.
  *
- *  @param currentFragment - currently displayed fragment in the [NavController]
- *  @param directions - [directions that describe this navigation operation
+ *  @param currentFragment - currently displayed fragment in the [NavController].
+ *  @param directions - directions that describe this navigation operation.
  *  @param navOptions - special options for this navigation operation
  */
 @ExcludedFromGeneratedTestCoverageReports("There is no reasonable way to test this")
@@ -130,6 +131,9 @@ fun NavController.navigateSafely(
 /**
  * Executes the [NavController] navigation request in a safely manner. Executes the navigation
  * request only if no other transaction is scheduled for the [currentFragment]
+ * Make sure that current fragment is part of the same graph as the action.
+ *
+ * **NOTE:** Use [navigateSafely(Fragment?, NavDirections, NavOptions?)] where possible.
  *
  *  @param currentFragment - currently displayed fragment in the [NavController]
  *  @param actionId - an action id or a destination id to navigate to


### PR DESCRIPTION
* Fixed the incorrect "current" fragment in sync/main fragment. Also checked the rest of `navigateSafely()` calls to ensure that the provided fragment matches the one used in the graph.
* Fixed a related issue in the troubleshooting fragment in a bit more complex way. Fragments created as a part of the pager adapter do not have proper access to the "parent/root" fragment, so the navigation is done via the shared view model instead.
* Switched to navigation using "directions" where possible to add a layer of type safety for the basic app navigation.

As a bonus, I have found and fixed a minor issue with the project config not scheduling a one-time worker due to using the name of the periodic one. 