### PR TITLE
MS-764 Tier deprecation in SID responses

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapper.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapper.kt
@@ -6,11 +6,11 @@ import com.simprints.core.domain.response.AppErrorReason
 import com.simprints.infra.orchestration.data.ActionResponse
 import com.simprints.libsimprints.Constants
 import com.simprints.libsimprints.contracts.VersionsList
+import com.simprints.libsimprints.contracts.data.ConfidenceBand
 import com.simprints.libsimprints.contracts.data.Enrolment
 import com.simprints.libsimprints.contracts.data.Identification
 import com.simprints.libsimprints.contracts.data.Identification.Companion.toJson
 import com.simprints.libsimprints.contracts.data.RefusalForm
-import com.simprints.libsimprints.contracts.data.Tier
 import com.simprints.libsimprints.contracts.data.Verification
 import javax.inject.Inject
 import com.simprints.libsimprints.Identification as LegacyIdentification
@@ -49,7 +49,7 @@ internal class LibSimprintsResponseMapper @Inject constructor() {
                 else -> putString(
                     Constants.SIMPRINTS_IDENTIFICATIONS,
                     response.identifications
-                        .map { Identification(it.guid, it.confidenceScore.toFloat(), Tier.valueOf(it.tier.name)) }
+                        .map { Identification(it.guid, it.confidenceScore.toFloat(), ConfidenceBand.valueOf(it.matchConfidence.name)) }
                         .toJson(),
                 )
             }
@@ -82,7 +82,7 @@ internal class LibSimprintsResponseMapper @Inject constructor() {
                     Verification(
                         guid = response.matchResult.guid,
                         confidence = response.matchResult.confidenceScore.toFloat(),
-                        tier = Tier.valueOf(response.matchResult.tier.name),
+                        confidenceBand = ConfidenceBand.valueOf(response.matchResult.matchConfidence.name),
                         isSuccess = response.matchResult.verificationSuccess == true,
                     ).toJson(),
                 )

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/CommCareResponseMapperTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/CommCareResponseMapperTest.kt
@@ -5,7 +5,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.response.AppErrorReason
 import com.simprints.core.domain.response.AppMatchConfidence
-import com.simprints.core.domain.response.AppResponseTier
 import com.simprints.feature.clientapi.mappers.request.requestFactories.ConfirmIdentityActionFactory
 import com.simprints.feature.clientapi.mappers.request.requestFactories.EnrolActionFactory
 import com.simprints.feature.clientapi.mappers.request.requestFactories.EnrolLastBiometricsActionFactory
@@ -50,13 +49,11 @@ class CommCareResponseMapperTest {
                     AppMatchResult(
                         guid = "guid-1",
                         confidenceScore = 100,
-                        tier = AppResponseTier.TIER_5,
                         matchConfidence = AppMatchConfidence.MEDIUM,
                     ),
                     AppMatchResult(
                         guid = "guid-2",
                         confidenceScore = 75,
-                        tier = AppResponseTier.TIER_3,
                         matchConfidence = AppMatchConfidence.LOW,
                     ),
                 ),
@@ -70,7 +67,7 @@ class CommCareResponseMapperTest {
             .isEqualTo(
                 ArrayList<LegacyIdentification>(
                     listOf(
-                        LegacyIdentification("guid-1", 100, LegacyTier.TIER_5),
+                        LegacyIdentification("guid-1", 100, LegacyTier.TIER_2),
                         LegacyIdentification("guid-2", 75, LegacyTier.TIER_3),
                     ),
                 ),
@@ -100,7 +97,6 @@ class CommCareResponseMapperTest {
                 matchResult = AppMatchResult(
                     guid = "guid",
                     confidenceScore = 50,
-                    tier = AppResponseTier.TIER_2,
                     matchConfidence = AppMatchConfidence.HIGH,
                     verificationSuccess = null,
                 ),
@@ -110,7 +106,7 @@ class CommCareResponseMapperTest {
         assertThat(extras.getString(CommCareConstants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_GUID_KEY)).isEqualTo("guid")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_CONFIDENCE_KEY)).isEqualTo("50")
-        assertThat(extras.getString(CommCareConstants.VERIFICATION_TIER_KEY)).isEqualTo("TIER_2")
+        assertThat(extras.getString(CommCareConstants.VERIFICATION_TIER_KEY)).isEqualTo("TIER_1")
         assertThat(extras.getString(CommCareConstants.BIOMETRICS_COMPLETE_CHECK_KEY)).isEqualTo("true")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_SUCCESS_KEY)).isNull()
     }
@@ -124,7 +120,6 @@ class CommCareResponseMapperTest {
                 matchResult = AppMatchResult(
                     guid = "guid",
                     confidenceScore = 50,
-                    tier = AppResponseTier.TIER_2,
                     matchConfidence = AppMatchConfidence.HIGH,
                     verificationSuccess = false,
                 ),
@@ -134,7 +129,7 @@ class CommCareResponseMapperTest {
         assertThat(extras.getString(CommCareConstants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_GUID_KEY)).isEqualTo("guid")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_CONFIDENCE_KEY)).isEqualTo("50")
-        assertThat(extras.getString(CommCareConstants.VERIFICATION_TIER_KEY)).isEqualTo("TIER_2")
+        assertThat(extras.getString(CommCareConstants.VERIFICATION_TIER_KEY)).isEqualTo("TIER_1")
         assertThat(extras.getString(CommCareConstants.BIOMETRICS_COMPLETE_CHECK_KEY)).isEqualTo("true")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_SUCCESS_KEY)).isEqualTo("false")
     }
@@ -148,7 +143,6 @@ class CommCareResponseMapperTest {
                 matchResult = AppMatchResult(
                     guid = "guid",
                     confidenceScore = 50,
-                    tier = AppResponseTier.TIER_2,
                     matchConfidence = AppMatchConfidence.HIGH,
                     verificationSuccess = true,
                 ),
@@ -158,7 +152,7 @@ class CommCareResponseMapperTest {
         assertThat(extras.getString(CommCareConstants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_GUID_KEY)).isEqualTo("guid")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_CONFIDENCE_KEY)).isEqualTo("50")
-        assertThat(extras.getString(CommCareConstants.VERIFICATION_TIER_KEY)).isEqualTo("TIER_2")
+        assertThat(extras.getString(CommCareConstants.VERIFICATION_TIER_KEY)).isEqualTo("TIER_1")
         assertThat(extras.getString(CommCareConstants.BIOMETRICS_COMPLETE_CHECK_KEY)).isEqualTo("true")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_SUCCESS_KEY)).isEqualTo("true")
     }

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapperTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapperTest.kt
@@ -4,7 +4,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.response.AppErrorReason
 import com.simprints.core.domain.response.AppMatchConfidence
-import com.simprints.core.domain.response.AppResponseTier
 import com.simprints.feature.clientapi.mappers.request.requestFactories.ConfirmIdentityActionFactory
 import com.simprints.feature.clientapi.mappers.request.requestFactories.EnrolActionFactory
 import com.simprints.feature.clientapi.mappers.request.requestFactories.EnrolLastBiometricsActionFactory
@@ -72,13 +71,11 @@ class LibSimprintsResponseMapperTest {
                     AppMatchResult(
                         guid = "guid-1",
                         confidenceScore = 100,
-                        tier = AppResponseTier.TIER_5,
                         matchConfidence = AppMatchConfidence.MEDIUM,
                     ),
                     AppMatchResult(
                         guid = "guid-2",
                         confidenceScore = 75,
-                        tier = AppResponseTier.TIER_3,
                         matchConfidence = AppMatchConfidence.LOW,
                     ),
                 ),
@@ -87,7 +84,7 @@ class LibSimprintsResponseMapperTest {
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extras.getParcelableArrayList<LegacyIdentification>(Constants.SIMPRINTS_IDENTIFICATIONS)).containsExactly(
-            LegacyIdentification("guid-1", 100, LegacyTier.TIER_5),
+            LegacyIdentification("guid-1", 100, LegacyTier.TIER_2),
             LegacyIdentification("guid-2", 75, LegacyTier.TIER_3),
         )
     }
@@ -104,7 +101,6 @@ class LibSimprintsResponseMapperTest {
                     AppMatchResult(
                         guid = "guid-1",
                         confidenceScore = 100,
-                        tier = AppResponseTier.TIER_5,
                         matchConfidence = AppMatchConfidence.MEDIUM,
                     ),
                 ),
@@ -114,7 +110,7 @@ class LibSimprintsResponseMapperTest {
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extras.getString(Constants.SIMPRINTS_IDENTIFICATIONS)).isEqualTo(
             """
-            [{"guid":"guid-1","tier":"TIER_5","confidence":100}]
+            [{"guid":"guid-1","tier":"TIER_2","confidence":100}]
             """.trimIndent(),
         )
         assertThat(extras.getBoolean(Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK)).isTrue()
@@ -143,7 +139,6 @@ class LibSimprintsResponseMapperTest {
                 matchResult = AppMatchResult(
                     guid = "guid",
                     confidenceScore = 50,
-                    tier = AppResponseTier.TIER_2,
                     matchConfidence = AppMatchConfidence.HIGH,
                     verificationSuccess = null,
                 ),
@@ -155,7 +150,7 @@ class LibSimprintsResponseMapperTest {
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extraVerification?.guid).isEqualTo("guid")
-        assertThat(extraVerification?.tier).isEqualTo(LegacyTier.TIER_2)
+        assertThat(extraVerification?.tier).isEqualTo(LegacyTier.TIER_1)
         assertThat(extraVerification?.getConfidence()).isEqualTo(50)
         assertThat(extras.getBoolean(Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK)).isTrue()
         assertThat(extras.getBoolean(Constants.SIMPRINTS_VERIFICATION_SUCCESS)).isFalse() // Default value
@@ -170,7 +165,6 @@ class LibSimprintsResponseMapperTest {
                 matchResult = AppMatchResult(
                     guid = "guid",
                     confidenceScore = 50,
-                    tier = AppResponseTier.TIER_2,
                     matchConfidence = AppMatchConfidence.HIGH,
                     verificationSuccess = false,
                 ),
@@ -182,7 +176,7 @@ class LibSimprintsResponseMapperTest {
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extraVerification?.guid).isEqualTo("guid")
-        assertThat(extraVerification?.tier).isEqualTo(LegacyTier.TIER_2)
+        assertThat(extraVerification?.tier).isEqualTo(LegacyTier.TIER_1)
         assertThat(extraVerification?.getConfidence()).isEqualTo(50)
         assertThat(extras.getBoolean(Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK)).isTrue()
         assertThat(extras.getBoolean(Constants.SIMPRINTS_VERIFICATION_SUCCESS)).isEqualTo(false)
@@ -197,7 +191,6 @@ class LibSimprintsResponseMapperTest {
                 matchResult = AppMatchResult(
                     guid = "guid",
                     confidenceScore = 50,
-                    tier = AppResponseTier.TIER_2,
                     matchConfidence = AppMatchConfidence.HIGH,
                     verificationSuccess = true,
                 ),
@@ -209,7 +202,7 @@ class LibSimprintsResponseMapperTest {
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extraVerification?.guid).isEqualTo("guid")
-        assertThat(extraVerification?.tier).isEqualTo(LegacyTier.TIER_2)
+        assertThat(extraVerification?.tier).isEqualTo(LegacyTier.TIER_1)
         assertThat(extraVerification?.getConfidence()).isEqualTo(50)
         // assertThat(extraVerification?.isSuccess).isTrue()
         assertThat(extras.getBoolean(Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK)).isTrue()
@@ -227,7 +220,6 @@ class LibSimprintsResponseMapperTest {
                 matchResult = AppMatchResult(
                     guid = "guid",
                     confidenceScore = 50,
-                    tier = AppResponseTier.TIER_2,
                     matchConfidence = AppMatchConfidence.HIGH,
                     verificationSuccess = true,
                 ),
@@ -237,7 +229,7 @@ class LibSimprintsResponseMapperTest {
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extras.getString(Constants.SIMPRINTS_VERIFICATION)).isEqualTo(
             """
-            {"guid":"guid","tier":"TIER_2","confidence":50,"isSuccess":true}
+            {"guid":"guid","tier":"TIER_1","confidence":50,"isSuccess":true}
             """.trimIndent(),
         )
         assertThat(extras.getBoolean(Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK)).isTrue()

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapperTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapperTest.kt
@@ -110,7 +110,7 @@ class LibSimprintsResponseMapperTest {
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extras.getString(Constants.SIMPRINTS_IDENTIFICATIONS)).isEqualTo(
             """
-            [{"guid":"guid-1","tier":"TIER_2","confidence":100}]
+            [{"guid":"guid-1","confidenceBand":"MEDIUM","confidence":100}]
             """.trimIndent(),
         )
         assertThat(extras.getBoolean(Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK)).isTrue()
@@ -229,7 +229,7 @@ class LibSimprintsResponseMapperTest {
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extras.getString(Constants.SIMPRINTS_VERIFICATION)).isEqualTo(
             """
-            {"guid":"guid","tier":"TIER_1","confidence":50,"isSuccess":true}
+            {"guid":"guid","confidenceBand":"HIGH","confidence":50,"isSuccess":true}
             """.trimIndent(),
         )
         assertThat(extras.getBoolean(Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK)).isTrue()

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/OdkResponseMapperTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/OdkResponseMapperTest.kt
@@ -4,7 +4,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.response.AppErrorReason
 import com.simprints.core.domain.response.AppMatchConfidence
-import com.simprints.core.domain.response.AppResponseTier
 import com.simprints.feature.clientapi.mappers.request.requestFactories.ConfirmIdentityActionFactory
 import com.simprints.feature.clientapi.mappers.request.requestFactories.EnrolActionFactory
 import com.simprints.feature.clientapi.mappers.request.requestFactories.EnrolLastBiometricsActionFactory
@@ -46,13 +45,11 @@ class OdkResponseMapperTest {
                     AppMatchResult(
                         guid = "guid-1",
                         confidenceScore = 100,
-                        tier = AppResponseTier.TIER_5,
                         matchConfidence = AppMatchConfidence.MEDIUM,
                     ),
                     AppMatchResult(
                         guid = "guid-2",
                         confidenceScore = 75,
-                        tier = AppResponseTier.TIER_3,
                         matchConfidence = AppMatchConfidence.LOW,
                     ),
                 ),
@@ -62,7 +59,7 @@ class OdkResponseMapperTest {
         assertThat(extras.getString(OdkConstants.ODK_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extras.getString(OdkConstants.ODK_GUIDS_KEY)).isEqualTo("guid-1 guid-2")
         assertThat(extras.getString(OdkConstants.ODK_CONFIDENCES_KEY)).isEqualTo("100 75")
-        assertThat(extras.getString(OdkConstants.ODK_TIERS_KEY)).isEqualTo("TIER_5 TIER_3")
+        assertThat(extras.getString(OdkConstants.ODK_TIERS_KEY)).isEqualTo("TIER_2 TIER_3")
         assertThat(extras.getString(OdkConstants.ODK_MATCH_CONFIDENCE_FLAGS_KEY)).isEqualTo("MEDIUM LOW")
         assertThat(extras.getString(OdkConstants.ODK_HIGHEST_MATCH_CONFIDENCE_FLAG_KEY)).isEqualTo("MEDIUM")
         assertThat(extras.getBoolean(OdkConstants.ODK_IDENTIFY_BIOMETRICS_COMPLETE)).isEqualTo(true)
@@ -104,7 +101,6 @@ class OdkResponseMapperTest {
                 matchResult = AppMatchResult(
                     guid = "guid",
                     confidenceScore = 50,
-                    tier = AppResponseTier.TIER_2,
                     matchConfidence = AppMatchConfidence.HIGH,
                     verificationSuccess = null,
                 ),
@@ -114,7 +110,7 @@ class OdkResponseMapperTest {
         assertThat(extras.getString(OdkConstants.ODK_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extras.getString(OdkConstants.ODK_GUIDS_KEY)).isEqualTo("guid")
         assertThat(extras.getString(OdkConstants.ODK_CONFIDENCES_KEY)).isEqualTo("50")
-        assertThat(extras.getString(OdkConstants.ODK_TIERS_KEY)).isEqualTo("TIER_2")
+        assertThat(extras.getString(OdkConstants.ODK_TIERS_KEY)).isEqualTo("TIER_1")
         assertThat(extras.getBoolean(OdkConstants.ODK_VERIFY_BIOMETRICS_COMPLETE)).isEqualTo(true)
         assertThat(extras.getBoolean(OdkConstants.ODK_VERIFICATION_SUCCESS_KEY)).isEqualTo(false) // default value
     }
@@ -128,7 +124,6 @@ class OdkResponseMapperTest {
                 matchResult = AppMatchResult(
                     guid = "guid",
                     confidenceScore = 50,
-                    tier = AppResponseTier.TIER_2,
                     matchConfidence = AppMatchConfidence.HIGH,
                     verificationSuccess = false,
                 ),
@@ -138,7 +133,7 @@ class OdkResponseMapperTest {
         assertThat(extras.getString(OdkConstants.ODK_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extras.getString(OdkConstants.ODK_GUIDS_KEY)).isEqualTo("guid")
         assertThat(extras.getString(OdkConstants.ODK_CONFIDENCES_KEY)).isEqualTo("50")
-        assertThat(extras.getString(OdkConstants.ODK_TIERS_KEY)).isEqualTo("TIER_2")
+        assertThat(extras.getString(OdkConstants.ODK_TIERS_KEY)).isEqualTo("TIER_1")
         assertThat(extras.getBoolean(OdkConstants.ODK_VERIFY_BIOMETRICS_COMPLETE)).isEqualTo(true)
         assertThat(extras.getBoolean(OdkConstants.ODK_VERIFICATION_SUCCESS_KEY)).isEqualTo(false)
     }
@@ -152,7 +147,6 @@ class OdkResponseMapperTest {
                 matchResult = AppMatchResult(
                     guid = "guid",
                     confidenceScore = 50,
-                    tier = AppResponseTier.TIER_2,
                     matchConfidence = AppMatchConfidence.HIGH,
                     verificationSuccess = true,
                 ),
@@ -162,7 +156,7 @@ class OdkResponseMapperTest {
         assertThat(extras.getString(OdkConstants.ODK_SESSION_ID)).isEqualTo("sessionId")
         assertThat(extras.getString(OdkConstants.ODK_GUIDS_KEY)).isEqualTo("guid")
         assertThat(extras.getString(OdkConstants.ODK_CONFIDENCES_KEY)).isEqualTo("50")
-        assertThat(extras.getString(OdkConstants.ODK_TIERS_KEY)).isEqualTo("TIER_2")
+        assertThat(extras.getString(OdkConstants.ODK_TIERS_KEY)).isEqualTo("TIER_1")
         assertThat(extras.getBoolean(OdkConstants.ODK_VERIFY_BIOMETRICS_COMPLETE)).isEqualTo(true)
         assertThat(extras.getBoolean(OdkConstants.ODK_VERIFICATION_SUCCESS_KEY)).isEqualTo(true)
     }

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/AddCallbackEventUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/AddCallbackEventUseCase.kt
@@ -2,7 +2,6 @@ package com.simprints.feature.orchestrator.usecases
 
 import com.simprints.core.SessionCoroutineScope
 import com.simprints.core.domain.response.AppMatchConfidence
-import com.simprints.core.domain.response.AppResponseTier
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.infra.events.event.domain.models.callback.CallbackComparisonScore
 import com.simprints.infra.events.event.domain.models.callback.ConfirmationCallbackEvent
@@ -61,7 +60,6 @@ internal class AddCallbackEventUseCase @Inject constructor(
     private fun buildComparisonScore(matchResult: AppMatchResult) = CallbackComparisonScore(
         matchResult.guid,
         matchResult.confidenceScore,
-        AppResponseTier.valueOf(matchResult.tier.name),
         AppMatchConfidence.valueOf(matchResult.matchConfidence.name),
     )
 

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/AddCallbackEventUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/AddCallbackEventUseCaseTest.kt
@@ -3,7 +3,6 @@ package com.simprints.feature.orchestrator.usecases
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.response.AppErrorReason
 import com.simprints.core.domain.response.AppMatchConfidence
-import com.simprints.core.domain.response.AppResponseTier
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.infra.events.event.domain.models.callback.ConfirmationCallbackEvent
 import com.simprints.infra.events.event.domain.models.callback.EnrolmentCallbackEvent
@@ -73,7 +72,7 @@ class AddCallbackEventUseCaseTest {
     fun `adds event for identification response`() {
         useCase(
             AppIdentifyResponse(
-                listOf(AppMatchResult("guid", 0, AppResponseTier.TIER_1, AppMatchConfidence.HIGH)),
+                listOf(AppMatchResult("guid", 0, AppMatchConfidence.HIGH)),
                 "sessionId",
             ),
         )
@@ -89,7 +88,7 @@ class AddCallbackEventUseCaseTest {
 
     @Test
     fun `adds event for verification response`() {
-        useCase(AppVerifyResponse(AppMatchResult("guid", 0, AppResponseTier.TIER_1, AppMatchConfidence.HIGH)))
+        useCase(AppVerifyResponse(AppMatchResult("guid", 0, AppMatchConfidence.HIGH)))
 
         coVerify {
             eventRepository.addOrUpdateEvent(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,7 +62,7 @@ protobuf_version = "4.26.1"
 circleImageView_version = "3.1.0"
 timber_version = "5.0.1"
 
-libsimprints_version = "2025.1.1-SNAPSHOT"
+libsimprints_version = "2025.1.2-SNAPSHOT"
 simmatcher_version = "1.2.0"
 roc_wrapper_version = "1.23.0"
 roc_wrapper-v3_version = "3.1.0"

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiTier.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiTier.kt
@@ -1,6 +1,8 @@
 package com.simprints.infra.eventsync.event.remote.models
 
 import androidx.annotation.Keep
+import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
+import com.simprints.core.domain.response.AppMatchConfidence
 
 @Keep
 internal enum class ApiTier {
@@ -9,4 +11,19 @@ internal enum class ApiTier {
     TIER_3,
     TIER_4,
     TIER_5,
+    ;
+
+    companion object {
+        /**
+         * Tiers have been removed, but for older version not to break required field rules
+         * we add a tier based on the match confidence.
+         */
+        @ExcludedFromGeneratedTestCoverageReports("Workaround to enable back-compatibility in old event versions")
+        fun fromConfidence(matchConfidence: AppMatchConfidence) = when (matchConfidence) {
+            AppMatchConfidence.NONE -> TIER_4
+            AppMatchConfidence.LOW -> TIER_3
+            AppMatchConfidence.MEDIUM -> TIER_2
+            AppMatchConfidence.HIGH -> TIER_1
+        }
+    }
 }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/callback/ApiCallbackComparisonScore.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/callback/ApiCallbackComparisonScore.kt
@@ -18,7 +18,6 @@ internal sealed class ApiCallbackComparisonScore {
     data class ApiCallbackComparisonScoreV2(
         val guid: String,
         val confidence: Int,
-        val tier: ApiTier,
         val confidenceMatch: ApiConfidenceMatch = ApiConfidenceMatch.NONE,
     ) : ApiCallbackComparisonScore()
 }
@@ -27,13 +26,12 @@ internal fun CallbackComparisonScore.fromDomainToApi(version: Int) = when (versi
     1 -> ApiCallbackComparisonScore.ApiCallbackComparisonScoreV1(
         guid,
         confidence,
-        ApiTier.valueOf(tier.name),
+        ApiTier.fromConfidence(confidenceMatch),
     )
 
     else -> ApiCallbackComparisonScore.ApiCallbackComparisonScoreV2(
         guid,
         confidence,
-        ApiTier.valueOf(tier.name),
         ApiConfidenceMatch.valueOf(confidenceMatch.name),
     )
 }

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/EventValidationUtils.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/EventValidationUtils.kt
@@ -84,8 +84,12 @@ fun verifyCallbackIdentificationApiModel(
         val score = jsonArray.getJSONObject(0)
 
         assertThat(score.getString("guid")).isNotNull()
-        assertThat(score.getString("tier")).isNotNull()
         assertThat(score.getString("confidence")).isNotNull()
+
+        when (version) {
+            1 -> assertThat(score.getString("tier")).isNotNull()
+            else -> {}
+        }
 
         when (version) {
             2 -> assertThat(score.has("confidenceMatch")).isFalse()
@@ -104,7 +108,11 @@ fun verifyCallbackVerificationApiModel(
     json.getJSONObject("score").let { score ->
         assertThat(score.getString("guid")).isNotNull()
         assertThat(score.getString("confidence")).isNotNull()
-        assertThat(score.getString("tier")).isNotNull()
+
+        when (version) {
+            1 -> assertThat(score.getString("tier")).isNotNull()
+            else -> {}
+        }
 
         when (version) {
             2 -> assertThat(score.has("confidenceMatch")).isFalse()

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/callback/ApiCallbackComparisonScoreTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/callback/ApiCallbackComparisonScoreTest.kt
@@ -2,7 +2,6 @@ package com.simprints.infra.eventsync.event.remote.models.callback
 
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.response.AppMatchConfidence
-import com.simprints.core.domain.response.AppResponseTier
 import com.simprints.infra.events.event.domain.models.callback.CallbackComparisonScore
 import com.simprints.infra.eventsync.event.remote.models.ApiConfidenceMatch
 import com.simprints.infra.eventsync.event.remote.models.ApiTier
@@ -14,7 +13,6 @@ class ApiCallbackComparisonScoreTest {
         val apiModel = CallbackComparisonScore(
             guid = "guid",
             confidence = 1,
-            tier = AppResponseTier.TIER_1,
             confidenceMatch = AppMatchConfidence.HIGH,
         ).fromDomainToApi(1) as ApiCallbackComparisonScore.ApiCallbackComparisonScoreV1
 
@@ -26,11 +24,9 @@ class ApiCallbackComparisonScoreTest {
         val apiModel = CallbackComparisonScore(
             guid = "guid",
             confidence = 1,
-            tier = AppResponseTier.TIER_1,
             confidenceMatch = AppMatchConfidence.HIGH,
         ).fromDomainToApi(2) as ApiCallbackComparisonScore.ApiCallbackComparisonScoreV2
 
-        assertThat(apiModel.tier).isEqualTo(ApiTier.TIER_1)
         assertThat(apiModel.confidenceMatch).isEqualTo(ApiConfidenceMatch.HIGH)
     }
 }

--- a/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
+++ b/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
@@ -3,7 +3,6 @@ package com.simprints.infra.events.sampledata
 import android.os.Build
 import com.simprints.core.domain.fingerprint.IFingerIdentifier.LEFT_THUMB
 import com.simprints.core.domain.response.AppMatchConfidence.MEDIUM
-import com.simprints.core.domain.response.AppResponseTier.TIER_1
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.core.tools.utils.SimNetworkUtils
 import com.simprints.core.tools.utils.SimNetworkUtils.Connection
@@ -161,7 +160,7 @@ fun createErrorCallbackEvent() = ErrorCallbackEvent(
 fun createIdentificationCallbackEvent() = IdentificationCallbackEvent(
     CREATED_AT,
     GUID1,
-    listOf(CallbackComparisonScore(GUID1, 1, TIER_1, MEDIUM)),
+    listOf(CallbackComparisonScore(GUID1, 1, MEDIUM)),
 )
 
 fun createRefusalCallbackEvent() = RefusalCallbackEvent(
@@ -172,12 +171,12 @@ fun createRefusalCallbackEvent() = RefusalCallbackEvent(
 
 fun createVerificationCallbackEventV1() = VerificationCallbackEvent(
     CREATED_AT,
-    CallbackComparisonScore(GUID1, 1, TIER_1, MEDIUM),
+    CallbackComparisonScore(GUID1, 1, MEDIUM),
 )
 
 fun createVerificationCallbackEventV2() = VerificationCallbackEvent(
     CREATED_AT,
-    CallbackComparisonScore(GUID1, 1, TIER_1, MEDIUM),
+    CallbackComparisonScore(GUID1, 1, MEDIUM),
 )
 
 fun createConfirmationCalloutEvent() = ConfirmationCalloutEvent(

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/CallbackComparisonScore.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/CallbackComparisonScore.kt
@@ -2,12 +2,10 @@ package com.simprints.infra.events.event.domain.models.callback
 
 import androidx.annotation.Keep
 import com.simprints.core.domain.response.AppMatchConfidence
-import com.simprints.core.domain.response.AppResponseTier
 
 @Keep
 data class CallbackComparisonScore(
     val guid: String,
     val confidence: Int,
-    val tier: AppResponseTier,
     val confidenceMatch: AppMatchConfidence = AppMatchConfidence.NONE,
 )

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/EventPayloadTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/EventPayloadTest.kt
@@ -3,7 +3,6 @@ package com.simprints.infra.events.event.domain.models
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.fingerprint.IFingerIdentifier
 import com.simprints.core.domain.response.AppMatchConfidence
-import com.simprints.core.domain.response.AppResponseTier.TIER_1
 import com.simprints.core.tools.utils.SimNetworkUtils
 import com.simprints.core.tools.utils.SimNetworkUtils.Connection
 import com.simprints.infra.events.event.domain.models.AlertScreenEvent.AlertScreenPayload.AlertScreenEventType.BLUETOOTH_NOT_ENABLED
@@ -77,12 +76,12 @@ class EventPayloadTest {
         IdentificationCallbackEvent(
             createdAt = CREATED_AT,
             sessionId = GUID1,
-            scores = listOf(CallbackComparisonScore(GUID1, 1, TIER_1, AppMatchConfidence.NONE)),
+            scores = listOf(CallbackComparisonScore(GUID1, 1, AppMatchConfidence.NONE)),
         ),
         RefusalCallbackEvent(CREATED_AT, "some_reason", "some_extra"),
         VerificationCallbackEvent(
             createdAt = CREATED_AT,
-            score = CallbackComparisonScore(GUID1, 1, TIER_1, AppMatchConfidence.NONE),
+            score = CallbackComparisonScore(GUID1, 1, AppMatchConfidence.NONE),
         ),
         ConfirmationCalloutEvent(CREATED_AT, DEFAULT_PROJECT_ID, GUID1, GUID2),
         EnrolmentCalloutEvent(

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/callback/IdentificationCallbackEventTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/callback/IdentificationCallbackEventTest.kt
@@ -2,7 +2,6 @@ package com.simprints.infra.events.event.domain.models.callback
 
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.response.AppMatchConfidence
-import com.simprints.core.domain.response.AppResponseTier.TIER_1
 import com.simprints.infra.events.event.domain.models.EventType.CALLBACK_IDENTIFICATION
 import com.simprints.infra.events.event.domain.models.callback.IdentificationCallbackEvent.Companion.EVENT_VERSION
 import com.simprints.infra.events.sampledata.SampleDefaults.CREATED_AT
@@ -12,7 +11,7 @@ import org.junit.Test
 class IdentificationCallbackEventTest {
     @Test
     fun create_IdentificationCallbackEvent() {
-        val comparisonScore = CallbackComparisonScore(GUID1, 1, TIER_1, AppMatchConfidence.NONE)
+        val comparisonScore = CallbackComparisonScore(GUID1, 1, AppMatchConfidence.NONE)
 
         val event = IdentificationCallbackEvent(CREATED_AT, GUID1, listOf(comparisonScore))
         assertThat(event.id).isNotNull()

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/callback/VerificationCallbackEventTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/callback/VerificationCallbackEventTest.kt
@@ -2,7 +2,6 @@ package com.simprints.infra.events.event.domain.models.callback
 
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.response.AppMatchConfidence
-import com.simprints.core.domain.response.AppResponseTier.TIER_1
 import com.simprints.infra.events.event.domain.models.EventType.CALLBACK_VERIFICATION
 import com.simprints.infra.events.event.domain.models.callback.VerificationCallbackEvent.Companion.EVENT_VERSION
 import com.simprints.infra.events.sampledata.SampleDefaults.CREATED_AT
@@ -12,7 +11,7 @@ import org.junit.Test
 class VerificationCallbackEventTest {
     @Test
     fun create_VerificationCallbackEvent() {
-        val comparisonScore = CallbackComparisonScore(GUID1, 1, TIER_1, AppMatchConfidence.NONE)
+        val comparisonScore = CallbackComparisonScore(GUID1, 1, AppMatchConfidence.NONE)
 
         val event = VerificationCallbackEvent(CREATED_AT, comparisonScore)
         assertThat(event.id).isNotNull()

--- a/infra/orchestrator-data/src/main/java/com/simprints/infra/orchestration/data/responses/AppMatchResult.kt
+++ b/infra/orchestrator-data/src/main/java/com/simprints/infra/orchestration/data/responses/AppMatchResult.kt
@@ -12,10 +12,18 @@ import kotlinx.parcelize.Parcelize
 data class AppMatchResult(
     val guid: String,
     val confidenceScore: Int,
-    val tier: AppResponseTier,
     val matchConfidence: AppMatchConfidence,
     val verificationSuccess: Boolean? = null,
 ) : Parcelable {
+    // Temporarily using match confidence as a proxy for tiers.
+    val tier: AppResponseTier
+        get() = when (matchConfidence) {
+            AppMatchConfidence.NONE -> AppResponseTier.TIER_4
+            AppMatchConfidence.LOW -> AppResponseTier.TIER_3
+            AppMatchConfidence.MEDIUM -> AppResponseTier.TIER_2
+            AppMatchConfidence.HIGH -> AppResponseTier.TIER_1
+        }
+
     constructor(
         guid: String,
         confidenceScore: Float,
@@ -24,20 +32,11 @@ data class AppMatchResult(
     ) : this(
         guid = guid,
         confidenceScore = confidenceScore.toInt(),
-        tier = computeTier(confidenceScore),
         matchConfidence = computeMatchConfidence(confidenceScore.toInt(), decisionPolicy),
         verificationSuccess = computeVerificationSuccess(confidenceScore.toInt(), verificationMatchThreshold),
     )
 
     companion object {
-        fun computeTier(score: Float) = when {
-            score < 20f -> AppResponseTier.TIER_5
-            score < 35f -> AppResponseTier.TIER_4
-            score < 50f -> AppResponseTier.TIER_3
-            score < 75f -> AppResponseTier.TIER_2
-            else -> AppResponseTier.TIER_1
-        }
-
         fun computeMatchConfidence(
             confidenceScore: Int,
             policy: DecisionPolicy,

--- a/infra/orchestrator-data/src/test/java/com/simprints/infra/orchestration/data/responses/AppMatchResultTest.kt
+++ b/infra/orchestrator-data/src/test/java/com/simprints/infra/orchestration/data/responses/AppMatchResultTest.kt
@@ -19,7 +19,6 @@ class AppMatchResultTest {
             AppMatchResult(
                 guid = "guid",
                 confidenceScore = 25,
-                tier = AppResponseTier.TIER_4,
                 matchConfidence = AppMatchConfidence.MEDIUM,
             ),
         )
@@ -28,20 +27,25 @@ class AppMatchResultTest {
     @Test
     fun testComputeTier() {
         mapOf(
-            0.0f to AppResponseTier.TIER_5,
-            10.0f to AppResponseTier.TIER_5,
-            20.0f to AppResponseTier.TIER_4,
-            30.0f to AppResponseTier.TIER_4,
-            35.0f to AppResponseTier.TIER_3,
-            40.0f to AppResponseTier.TIER_3,
+            0.0f to AppResponseTier.TIER_4,
+            10.0f to AppResponseTier.TIER_4,
+            // low
+            20.0f to AppResponseTier.TIER_3,
+            30.0f to AppResponseTier.TIER_3,
+            // medium
+            40.0f to AppResponseTier.TIER_2,
             50.0f to AppResponseTier.TIER_2,
-            60.0f to AppResponseTier.TIER_2,
-            70.0f to AppResponseTier.TIER_2,
-            75.0f to AppResponseTier.TIER_1,
-            80.0f to AppResponseTier.TIER_1,
-            90.0f to AppResponseTier.TIER_1,
+            // high
+            60.0f to AppResponseTier.TIER_1,
+            70.0f to AppResponseTier.TIER_1,
         ).forEach { (score, expected) ->
-            assertThat(AppMatchResult.computeTier(score)).isEqualTo(expected)
+            assertThat(
+                AppMatchResult(
+                    guid = "guid",
+                    confidenceScore = score,
+                    decisionPolicy = DecisionPolicy(low = 20, medium = 40, high = 60),
+                ).tier,
+            ).isEqualTo(expected)
         }
     }
 


### PR DESCRIPTION
* Removed hardcoded tier definitions and values passed around in match result data classes.
* For backwards compatibility tier is being mapped from a match quality (high->tier1, medium->tier2, low->tier3, none->tier4).


A small note on `ApiTier` changes - it is currently implemented on an educated assumption of how the cloud team will update the request body schema and versions.