### PR TITLE
MS-849 Do not use java date for "last sync" timestamp

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/ExecutionTracker.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/ExecutionTracker.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import com.simprints.core.tools.time.TimeHelper
+import com.simprints.core.tools.time.Timestamp
 import com.simprints.infra.logging.Simber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -21,7 +22,7 @@ internal class ExecutionTracker @Inject constructor(
      *
      * Limit for execution is set by the [executionTimeLimitSec] (in seconds).
      */
-    private var timestamp: Long = 0
+    private var timestamp: Timestamp = Timestamp(0)
 
     /**
      * ID of the [LifecycleOwner] that is considered the main executor.
@@ -36,7 +37,7 @@ internal class ExecutionTracker @Inject constructor(
         if (event == Lifecycle.Event.ON_CREATE) {
             if (currentLifecycleOwnerId == null || enoughTimePassedSinceLastLock()) {
                 currentLifecycleOwnerId = ownerId
-                timestamp = timeHelper.now().ms
+                timestamp = timeHelper.now()
                 Simber.i("Lifecycle owner [$ownerId] is set as main executor")
             } else {
                 Simber.i("Main executor already set, ignoring Lifecycle owner [$ownerId]")
@@ -44,7 +45,7 @@ internal class ExecutionTracker @Inject constructor(
         } else if (event == Lifecycle.Event.ON_DESTROY) {
             if (currentLifecycleOwnerId == ownerId) {
                 currentLifecycleOwnerId = null
-                timestamp = 0
+                timestamp = Timestamp(0)
                 Simber.i("Lifecycle owner [$ownerId] removed from main executor")
             }
         }

--- a/feature/validate-subject-pool/src/main/java/com/simprints/feature/validatepool/usecase/ShouldSuggestSyncUseCase.kt
+++ b/feature/validate-subject-pool/src/main/java/com/simprints/feature/validatepool/usecase/ShouldSuggestSyncUseCase.kt
@@ -22,7 +22,7 @@ internal class ShouldSuggestSyncUseCase @Inject constructor(
                 .let(Duration.Companion::parse)
                 .inWholeMilliseconds
 
-            timeHelper.msBetweenNowAndTime(it.time) > thresholdMs
+            timeHelper.msBetweenNowAndTime(it) > thresholdMs
         }
         ?: true
 }

--- a/feature/validate-subject-pool/src/test/java/com/simprints/feature/validatepool/usecase/ShouldSuggestSyncUseCaseTest.kt
+++ b/feature/validate-subject-pool/src/test/java/com/simprints/feature/validatepool/usecase/ShouldSuggestSyncUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.simprints.feature.validatepool.usecase
 
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.tools.time.TimeHelper
+import com.simprints.core.tools.time.Timestamp
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.eventsync.EventSyncManager
 import io.mockk.MockKAnnotations
@@ -10,7 +11,6 @@ import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
-import java.util.Date
 
 class ShouldSuggestSyncUseCaseTest {
     @MockK
@@ -40,7 +40,7 @@ class ShouldSuggestSyncUseCaseTest {
 
     @Test
     fun `returns true if not synced recently`() = runTest {
-        coEvery { syncManager.getLastSyncTime() } returns Date()
+        coEvery { syncManager.getLastSyncTime() } returns Timestamp(0)
         coEvery { timeHelper.msBetweenNowAndTime(any()) } returns WEEK_MS
         coEvery {
             configRepository
@@ -53,7 +53,7 @@ class ShouldSuggestSyncUseCaseTest {
 
     @Test
     fun `returns true if not synced recently with non ISO max age`() = runTest {
-        coEvery { syncManager.getLastSyncTime() } returns Date()
+        coEvery { syncManager.getLastSyncTime() } returns Timestamp(0)
         coEvery { timeHelper.msBetweenNowAndTime(any()) } returns WEEK_MS
         coEvery {
             configRepository
@@ -66,7 +66,7 @@ class ShouldSuggestSyncUseCaseTest {
 
     @Test
     fun `returns false if synced recently`() = runTest {
-        coEvery { syncManager.getLastSyncTime() } returns Date()
+        coEvery { syncManager.getLastSyncTime() } returns Timestamp(0)
         coEvery { timeHelper.msBetweenNowAndTime(any()) } returns HOUR_MS
         coEvery {
             configRepository

--- a/infra/core/src/main/java/com/simprints/core/tools/time/KronosTimeHelperImpl.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/time/KronosTimeHelperImpl.kt
@@ -29,10 +29,10 @@ class KronosTimeHelperImpl @Inject constructor(
         )
     }
 
-    override fun msBetweenNowAndTime(time: Long): Long = now().ms - time
+    override fun msBetweenNowAndTime(time: Timestamp): Long = now().ms - time.ms
 
-    override fun readableBetweenNowAndTime(date: Date): String =
-        getRelativeTimeSpanString(date.time, now().ms, MINUTE_IN_MILLIS, FORMAT_SHOW_DATE).toString()
+    override fun readableBetweenNowAndTime(date: Timestamp): String =
+        getRelativeTimeSpanString(date.ms, now().ms, MINUTE_IN_MILLIS, FORMAT_SHOW_DATE).toString()
 
     override fun getCurrentDateAsString(): String {
         val dateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM, Locale.getDefault())

--- a/infra/core/src/main/java/com/simprints/core/tools/time/TimeHelper.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/time/TimeHelper.kt
@@ -1,7 +1,6 @@
 package com.simprints.core.tools.time
 
 import androidx.annotation.Keep
-import java.util.Date
 
 @Keep
 interface TimeHelper {
@@ -9,9 +8,9 @@ interface TimeHelper {
 
     fun now(): Timestamp
 
-    fun msBetweenNowAndTime(time: Long): Long
+    fun msBetweenNowAndTime(time: Timestamp): Long
 
-    fun readableBetweenNowAndTime(date: Date): String
+    fun readableBetweenNowAndTime(date: Timestamp): String
 
     fun getCurrentDateAsString(): String
 

--- a/infra/core/src/test/java/com/simprints/core/tools/time/KronosTimeHelperImplTest.kt
+++ b/infra/core/src/test/java/com/simprints/core/tools/time/KronosTimeHelperImplTest.kt
@@ -52,7 +52,7 @@ class KronosTimeHelperImplTest {
         every { kronosClock.getCurrentTime() } returns KronosTime(3000L, 0L)
         every { kronosClock.getElapsedTimeMs() } returns 3L
 
-        val result = timeHelperImpl.msBetweenNowAndTime(1000L)
+        val result = timeHelperImpl.msBetweenNowAndTime(Timestamp(1000L))
 
         assertThat(result).isEqualTo(2000L)
     }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManager.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManager.kt
@@ -1,11 +1,11 @@
 package com.simprints.infra.eventsync
 
 import androidx.lifecycle.LiveData
+import com.simprints.core.tools.time.Timestamp
 import com.simprints.infra.events.event.domain.models.EventType
 import com.simprints.infra.eventsync.status.models.DownSyncCounts
 import com.simprints.infra.eventsync.status.models.EventSyncState
 import kotlinx.coroutines.flow.Flow
-import java.util.Date
 
 interface EventSyncManager {
     fun getPeriodicWorkTags(): List<String>
@@ -14,7 +14,7 @@ interface EventSyncManager {
 
     fun getAllWorkerTag(): String
 
-    suspend fun getLastSyncTime(): Date?
+    suspend fun getLastSyncTime(): Timestamp?
 
     fun getLastSyncState(): LiveData<EventSyncState>
 

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManagerImpl.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManagerImpl.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import com.simprints.core.DispatcherIO
 import com.simprints.core.domain.tokenization.values
 import com.simprints.core.tools.time.TimeHelper
+import com.simprints.core.tools.time.Timestamp
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.ProjectConfiguration
 import com.simprints.infra.events.EventRepository
@@ -28,7 +29,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
-import java.util.Date
 import javax.inject.Inject
 
 internal class EventSyncManagerImpl @Inject constructor(
@@ -43,7 +43,7 @@ internal class EventSyncManagerImpl @Inject constructor(
     private val configRepository: ConfigRepository,
     @DispatcherIO private val dispatcher: CoroutineDispatcher,
 ) : EventSyncManager {
-    override suspend fun getLastSyncTime(): Date? = eventSyncCache.readLastSuccessfulSyncTime()
+    override suspend fun getLastSyncTime(): Timestamp? = eventSyncCache.readLastSuccessfulSyncTime()
 
     override fun getLastSyncState(): LiveData<EventSyncState> = eventSyncStateProcessor.getLastSyncState()
 

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/common/EventSyncCache.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/common/EventSyncCache.kt
@@ -4,11 +4,11 @@ import android.annotation.SuppressLint
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import com.simprints.core.DispatcherIO
+import com.simprints.core.tools.time.Timestamp
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.security.SecurityManager
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -25,15 +25,17 @@ internal class EventSyncCache @Inject constructor(
     private val sharedForLastSyncTime =
         securityManager.buildEncryptedSharedPreferences(FILENAME_FOR_LAST_SYNC_TIME_SHARED_PREFS)
 
-    suspend fun readLastSuccessfulSyncTime(): Date? = withContext(dispatcher) {
-        val dateLong = sharedForLastSyncTime.getLong(PEOPLE_SYNC_CACHE_LAST_SYNC_TIME_KEY, -1)
-        if (dateLong > -1) Date(dateLong) else null
+    suspend fun readLastSuccessfulSyncTime(): Timestamp? = withContext(dispatcher) {
+        sharedForLastSyncTime
+            .getLong(PEOPLE_SYNC_CACHE_LAST_SYNC_TIME_KEY, -1)
+            .takeIf { it >= 0 }
+            ?.let { Timestamp(it) }
     }
 
-    suspend fun storeLastSuccessfulSyncTime(lastSyncTime: Date?): Unit = withContext(dispatcher) {
+    suspend fun storeLastSuccessfulSyncTime(lastSyncTime: Timestamp?): Unit = withContext(dispatcher) {
         sharedForLastSyncTime
             .edit()
-            .putLong(PEOPLE_SYNC_CACHE_LAST_SYNC_TIME_KEY, lastSyncTime?.time ?: -1)
+            .putLong(PEOPLE_SYNC_CACHE_LAST_SYNC_TIME_KEY, lastSyncTime?.ms ?: -1)
             .apply()
     }
 

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventEndSyncReporterWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventEndSyncReporterWorker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.hilt.work.HiltWorker
 import androidx.work.WorkerParameters
 import com.simprints.core.DispatcherBG
+import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.workers.SimCoroutineWorker
 import com.simprints.infra.events.EventRepository
 import com.simprints.infra.events.event.domain.models.scope.EventScopeEndCause
@@ -12,7 +13,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import java.util.Date
 
 /**
  * It's executed at the end of the sync, when all workers succeed (downloaders and uploaders).
@@ -24,6 +24,7 @@ internal class EventEndSyncReporterWorker @AssistedInject constructor(
     @Assisted params: WorkerParameters,
     private val syncCache: EventSyncCache,
     private val eventRepository: EventRepository,
+    private val timeHelper: TimeHelper,
     @DispatcherBG private val dispatcher: CoroutineDispatcher,
 ) : SimCoroutineWorker(appContext, params) {
     override val tag: String = EventEndSyncReporterWorker::class.java.simpleName
@@ -43,7 +44,7 @@ internal class EventEndSyncReporterWorker @AssistedInject constructor(
             }
 
             if (!syncId.isNullOrEmpty()) {
-                syncCache.storeLastSuccessfulSyncTime(Date())
+                syncCache.storeLastSuccessfulSyncTime(timeHelper.now())
                 success()
             } else {
                 throw IllegalArgumentException("SyncId missed")

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/common/EventSyncCacheTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/common/EventSyncCacheTest.kt
@@ -2,6 +2,7 @@ package com.simprints.infra.eventsync.sync.common
 
 import android.content.SharedPreferences
 import com.google.common.truth.Truth.assertThat
+import com.simprints.core.tools.time.Timestamp
 import com.simprints.infra.eventsync.sync.common.EventSyncCache.Companion.PEOPLE_SYNC_CACHE_LAST_SYNC_TIME_KEY
 import com.simprints.infra.security.SecurityManager
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
@@ -14,7 +15,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import java.util.Date
 
 class EventSyncCacheTest {
     companion object {
@@ -62,7 +62,7 @@ class EventSyncCacheTest {
         } returns 30
 
         val date = eventSyncCache.readLastSuccessfulSyncTime()
-        assertThat(date).isEqualTo(Date(30))
+        assertThat(date).isEqualTo(Timestamp(30))
     }
 
     @Test
@@ -83,7 +83,7 @@ class EventSyncCacheTest {
         val editor = mockk<SharedPreferences.Editor>(relaxed = true)
         every { sharedPrefsForLastSyncTime.edit() } returns editor
 
-        eventSyncCache.storeLastSuccessfulSyncTime(Date(30))
+        eventSyncCache.storeLastSuccessfulSyncTime(Timestamp(30))
         verify(exactly = 1) { editor.putLong(PEOPLE_SYNC_CACHE_LAST_SYNC_TIME_KEY, 30) }
     }
 

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/master/EventEndSyncReporterWorkerTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/master/EventEndSyncReporterWorkerTest.kt
@@ -3,6 +3,8 @@ package com.simprints.infra.eventsync.sync.master
 import androidx.work.ListenableWorker
 import androidx.work.workDataOf
 import com.google.common.truth.Truth.assertThat
+import com.simprints.core.tools.time.TimeHelper
+import com.simprints.core.tools.time.Timestamp
 import com.simprints.infra.events.EventRepository
 import com.simprints.infra.eventsync.sync.common.EventSyncCache
 import com.simprints.infra.eventsync.sync.master.EventEndSyncReporterWorker.Companion.EVENT_DOWN_SYNC_SCOPE_TO_CLOSE
@@ -23,6 +25,9 @@ internal class EventEndSyncReporterWorkerTest {
     val testCoroutineRule = TestCoroutineRule()
 
     @MockK
+    lateinit var timeHelper: TimeHelper
+
+    @MockK
     lateinit var syncCache: EventSyncCache
 
     @MockK
@@ -31,6 +36,7 @@ internal class EventEndSyncReporterWorkerTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
+        every { timeHelper.now() } returns Timestamp(1)
     }
 
     @Test
@@ -93,6 +99,7 @@ internal class EventEndSyncReporterWorkerTest {
         },
         syncCache,
         eventRepository,
+        timeHelper,
         testCoroutineRule.testCoroutineDispatcher,
     )
 }


### PR DESCRIPTION
* Replace the usage of the default `Date()` constructor with a Kronos timestamp to be consistent with other dates used in the sync process.
* Also check that we are not using the no-arg date constructor in other places.