### PR TITLE
MS-676 Sync config button upgrades

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/debug/DebugFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/debug/DebugFragment.kt
@@ -109,10 +109,6 @@ internal class DebugFragment : Fragment(R.layout.fragment_debug) {
             }
         }
 
-        binding.syncDevice.setOnClickListener {
-            syncOrchestrator.startDeviceSync()
-        }
-
         binding.printRoomDb.setOnClickListener {
             binding.logs.text = ""
             runBlocking {

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/debug/DebugFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/debug/DebugFragment.kt
@@ -14,7 +14,6 @@ import com.simprints.core.DispatcherIO
 import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentDebugBinding
 import com.simprints.infra.authstore.AuthStore
-import com.simprints.infra.config.sync.ConfigManager
 import com.simprints.infra.enrolment.records.store.local.EnrolmentRecordLocalDataSource
 import com.simprints.infra.events.EventRepository
 import com.simprints.infra.eventsync.EventSyncManager
@@ -32,9 +31,6 @@ import javax.inject.Inject
 internal class DebugFragment : Fragment(R.layout.fragment_debug) {
     @Inject
     lateinit var eventSyncManager: EventSyncManager
-
-    @Inject
-    lateinit var configManager: ConfigManager
 
     @Inject
     lateinit var syncOrchestrator: SyncOrchestrator
@@ -95,18 +91,6 @@ internal class DebugFragment : Fragment(R.layout.fragment_debug) {
         binding.clearFirebaseToken.setOnClickListener {
             authStore.clearFirebaseToken()
             binding.logs.append("\nFirebase token deleted")
-        }
-
-        binding.syncConfig.setOnClickListener {
-            binding.logs.append("\nGetting Configs from BFSID")
-            lifecycleScope.launch {
-                try {
-                    configManager.refreshProject(authStore.signedInProjectId)
-                    binding.logs.append("\nGot Configs from BFSID")
-                } catch (e: Exception) {
-                    binding.logs.append("\nFailed to refresh the project configuration")
-                }
-            }
         }
 
         binding.printRoomDb.setOnClickListener {

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
@@ -13,6 +13,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.simprints.core.livedata.LiveDataEventObserver
 import com.simprints.feature.dashboard.DashboardActivity
 import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentSettingsBinding
@@ -61,6 +62,17 @@ internal class SettingsFragment : PreferenceFragmentCompat() {
         viewModel.languagePreference.observe(viewLifecycleOwner) {
             loadSelectedLanguage(it)
         }
+        viewModel.configUpdated.observe(
+            viewLifecycleOwner,
+            LiveDataEventObserver {
+                Toast
+                    .makeText(
+                        requireContext(),
+                        IDR.string.dashboard_preference_update_config_finished,
+                        Toast.LENGTH_SHORT,
+                    ).show()
+            },
+        )
         bindClickListeners()
     }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
@@ -14,6 +14,7 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.simprints.core.livedata.LiveDataEventObserver
+import com.simprints.core.livedata.LiveDataEventWithContentObserver
 import com.simprints.feature.dashboard.DashboardActivity
 import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentSettingsBinding
@@ -71,6 +72,15 @@ internal class SettingsFragment : PreferenceFragmentCompat() {
                         IDR.string.dashboard_preference_update_config_finished,
                         Toast.LENGTH_SHORT,
                     ).show()
+            },
+        )
+        viewModel.sinceConfigLastUpdated.observe(
+            viewLifecycleOwner,
+            LiveDataEventWithContentObserver<String> { lastUpdated ->
+                getUpdateConfig()?.summary = getString(
+                    IDR.string.dashboard_preference_summary_update_config_last_updated,
+                    lastUpdated,
+                )
             },
         )
         bindClickListeners()
@@ -188,12 +198,7 @@ internal class SettingsFragment : PreferenceFragmentCompat() {
 
     private fun updateConfiguration() {
         viewModel.scheduleConfigUpdate()
-        Toast
-            .makeText(
-                requireContext(),
-                IDR.string.dashboard_preference_update_config_scheduled,
-                Toast.LENGTH_SHORT,
-            ).show()
+        getUpdateConfig()?.setSummary(IDR.string.dashboard_preference_update_config_scheduled)
     }
 
     private fun getLanguagePreference(): Preference? = findPreference(getString(R.string.preference_select_language_key))

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
@@ -98,7 +98,6 @@ internal class SettingsFragment : PreferenceFragmentCompat() {
                 viewModel.unlockSettings()
                 when (action) {
                     ACTION_LANGUAGE -> createLanguageSelectionDialog().show()
-                    ACTION_CONFIG_UPDATE -> updateConfiguration()
                 }
             },
         )
@@ -124,7 +123,7 @@ internal class SettingsFragment : PreferenceFragmentCompat() {
         }
 
         getUpdateConfig()?.setOnPreferenceClickListener {
-            showPasswordIfRequired(ACTION_CONFIG_UPDATE) { updateConfiguration() }
+            updateConfiguration()
             true
         }
 
@@ -213,6 +212,5 @@ internal class SettingsFragment : PreferenceFragmentCompat() {
 
     companion object {
         private const val ACTION_LANGUAGE = "language"
-        private const val ACTION_CONFIG_UPDATE = "configUpdate"
     }
 }

--- a/feature/dashboard/src/main/res/drawable/ic_config_update.xml
+++ b/feature/dashboard/src/main/res/drawable/ic_config_update.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <path
+        android:fillColor="@color/simprints_text_grey_light"
+        android:pathData="M24,40q-6.65,0 -11.325,-4.675Q8,30.65 8,24q0,-6.65 4.675,-11.325Q17.35,8 24,8q4.25,0 7.45,1.725T37,14.45V8h3v12.7H27.3v-3h8.4q-1.9,-3 -4.85,-4.85Q27.9,11 24,11q-5.45,0 -9.225,3.775Q11,18.55 11,24q0,5.45 3.775,9.225Q18.55,37 24,37q4.15,0 7.6,-2.375 3.45,-2.375 4.8,-6.275h3.1q-1.45,5.25 -5.75,8.45Q29.45,40 24,40Z" />
+</vector>

--- a/feature/dashboard/src/main/res/layout/fragment_debug.xml
+++ b/feature/dashboard/src/main/res/layout/fragment_debug.xml
@@ -48,14 +48,6 @@
                 tools:ignore="HardcodedText" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/syncDevice"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="4dp"
-                android:text="Sync Device"
-                tools:ignore="HardcodedText" />
-
-            <com.google.android.material.button.MaterialButton
                 android:id="@+id/syncStop"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/feature/dashboard/src/main/res/layout/fragment_debug.xml
+++ b/feature/dashboard/src/main/res/layout/fragment_debug.xml
@@ -40,14 +40,6 @@
                 tools:ignore="HardcodedText" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/syncConfig"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="4dp"
-                android:text="Sync Config"
-                tools:ignore="HardcodedText" />
-
-            <com.google.android.material.button.MaterialButton
                 android:id="@+id/syncStop"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/feature/dashboard/src/main/res/layout/view_settings_update_config_item.xml
+++ b/feature/dashboard/src/main/res/layout/view_settings_update_config_item.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <TextView
+        android:id="@android:id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textAppearance="?android:attr/textAppearanceListItem"
+        app:layout_constraintBottom_toTopOf="@android:id/summary"
+        app:layout_constraintEnd_toStartOf="@android:id/icon"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="title" />
+
+    <TextView
+        android:id="@android:id/summary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textAppearance="?android:attr/textAppearanceListItemSecondary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@android:id/title"
+        app:layout_constraintStart_toStartOf="@android:id/title"
+        app:layout_constraintTop_toBottomOf="@android:id/title"
+        tools:text="title" />
+
+    <ImageView
+        android:id="@android:id/icon"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:padding="8dp"
+        android:src="@drawable/ic_config_update"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="ContentDescription" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/dashboard/src/main/res/xml/preference_general.xml
+++ b/feature/dashboard/src/main/res/xml/preference_general.xml
@@ -26,6 +26,7 @@
             android:title="@string/dashboard_preference_enable_audio_on_scan_complete" />
 
         <Preference
+            android:widgetLayout="@layout/view_settings_update_config_item"
             android:key="@string/preference_update_config_key"
             android:summary="@string/dashboard_preference_summary_update_config"
             android:title="@string/dashboard_preference_update_config_title" />

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/SettingsViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/SettingsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.simprints.feature.dashboard.settings
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
+import com.jraska.livedata.test
 import com.simprints.infra.config.store.models.DeviceConfiguration
 import com.simprints.infra.config.store.models.GeneralConfiguration
 import com.simprints.infra.config.store.models.SettingsPasswordConfig
@@ -13,6 +14,7 @@ import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -84,11 +86,13 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `trigger device sync when called`() {
+    fun `trigger config refresh when called`() {
+        coEvery { syncOrchestrator.refreshConfiguration() } returns flowOf(Unit)
+
         viewModel.scheduleConfigUpdate()
 
-        verify { syncOrchestrator.startProjectSync() }
-        verify { syncOrchestrator.startDeviceSync() }
+        verify { syncOrchestrator.refreshConfiguration() }
+        viewModel.configUpdated.test().assertHasValue()
     }
 
     companion object {

--- a/feature/troubleshooting/build.gradle.kts
+++ b/feature/troubleshooting/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(project(":infra:auth-store"))
     implementation(project(":infra:events"))
     implementation(project(":infra:config-store"))
+    implementation(project(":infra:config-sync"))
     implementation(project(":infra:license"))
     implementation(project(":infra:network"))
     implementation(project(":infra:logging-persistent"))

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/overview/OverviewFragment.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/overview/OverviewFragment.kt
@@ -24,6 +24,9 @@ internal class OverviewFragment : Fragment(R.layout.fragment_troubleshooting_ove
         viewModel.projectIds.observe(viewLifecycleOwner) {
             binding.troubleshootOverviewIds.text = it.orEmpty()
         }
+        viewModel.configurationDetails.observe(viewLifecycleOwner) {
+            binding.troubleshootOverviewConfiguration.text = it.orEmpty()
+        }
         viewModel.licenseStates.observe(viewLifecycleOwner) {
             binding.troubleshootOverviewLicences.text = it.ifBlank { "No licenses found" }
         }

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/overview/OverviewViewModel.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/overview/OverviewViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.simprints.feature.troubleshooting.overview.usecase.CollectConfigurationDetailsUseCase
 import com.simprints.feature.troubleshooting.overview.usecase.CollectIdsUseCase
 import com.simprints.feature.troubleshooting.overview.usecase.CollectLicenceStatesUseCase
 import com.simprints.feature.troubleshooting.overview.usecase.CollectNetworkInformationUseCase
@@ -17,6 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 internal class OverviewViewModel @Inject constructor(
     private val collectIds: CollectIdsUseCase,
+    private val collectConfigurationDetails: CollectConfigurationDetailsUseCase,
     private val collectLicenseStates: CollectLicenceStatesUseCase,
     private val collectNetworkInformation: CollectNetworkInformationUseCase,
     private val doServerPing: PingServerUseCase,
@@ -25,6 +27,10 @@ internal class OverviewViewModel @Inject constructor(
     val projectIds: LiveData<String>
         get() = _projectIds
     private val _projectIds = MutableLiveData(PLACEHOLDER_TEXT)
+
+    val configurationDetails: LiveData<String>
+        get() = _configurationDetails
+    private val _configurationDetails = MutableLiveData(PLACEHOLDER_TEXT)
 
     val licenseStates: LiveData<String>
         get() = _licenseStates
@@ -44,6 +50,7 @@ internal class OverviewViewModel @Inject constructor(
 
     fun collectData() {
         _projectIds.postValue(collectIds())
+        viewModelScope.launch { _configurationDetails.postValue(collectConfigurationDetails()) }
         viewModelScope.launch { _licenseStates.postValue(collectLicenseStates()) }
         _networkStates.postValue(collectNetworkInformation())
         viewModelScope.launch { _scannerState.postValue(collectScannerState()) }

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/overview/usecase/CollectConfigurationDetailsUseCase.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/overview/usecase/CollectConfigurationDetailsUseCase.kt
@@ -1,0 +1,21 @@
+package com.simprints.feature.troubleshooting.overview.usecase
+
+import com.simprints.infra.config.store.ConfigRepository
+import com.simprints.infra.config.sync.ConfigSyncCache
+import javax.inject.Inject
+
+internal class CollectConfigurationDetailsUseCase @Inject constructor(
+    private val configManager: ConfigRepository,
+    private val configSyncCache: ConfigSyncCache,
+) {
+    suspend operator fun invoke(): String {
+        val config = configManager.getProjectConfiguration()
+        val lastUpdate = configSyncCache.sinceLastUpdateTime()
+
+        return """
+            Configuration ID: ${config.id}
+            Config updated on: ${config.updatedAt}
+            Since last configuration sync: $lastUpdate
+            """.trimIndent()
+    }
+}

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/overview/usecase/CollectNetworkInformationUseCase.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/overview/usecase/CollectNetworkInformationUseCase.kt
@@ -28,7 +28,7 @@ internal class CollectNetworkInformationUseCase @Inject constructor(
         return """ 
             $connectionType
             Strength: ${getSignalStrength(networkCapabilities)}
-            Internet access: $connectionValidated)}
+            Internet access: $connectionValidated
             Bandwidth up (kbps): ${networkCapabilities.linkUpstreamBandwidthKbps}
             Bandwidth down (kbps): ${networkCapabilities.linkDownstreamBandwidthKbps}
             """.trimIndent()

--- a/feature/troubleshooting/src/main/res/layout/fragment_troubleshooting_overview.xml
+++ b/feature/troubleshooting/src/main/res/layout/fragment_troubleshooting_overview.xml
@@ -26,6 +26,25 @@
             android:layout_marginTop="24dp"
             android:layout_marginBottom="16dp"
             android:lineSpacingMultiplier="1.5"
+            android:text="Configuration"
+            android:textIsSelectable="true" />
+
+        <TextView
+            android:id="@+id/troubleshootOverviewConfiguration"
+            style="@style/Text.Body1"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lineSpacingMultiplier="1.1"
+            android:textIsSelectable="true"
+            tools:text="@tools:sample/lorem" />
+
+        <TextView
+            style="@style/Text.Headline6.Accented"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:layout_marginBottom="16dp"
+            android:lineSpacingMultiplier="1.5"
             android:text="Licenses"
             android:textIsSelectable="true" />
 

--- a/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/overview/OverviewViewModelTest.kt
+++ b/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/overview/OverviewViewModelTest.kt
@@ -3,6 +3,7 @@ package com.simprints.feature.troubleshooting.overview
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import com.jraska.livedata.test
+import com.simprints.feature.troubleshooting.overview.usecase.CollectConfigurationDetailsUseCase
 import com.simprints.feature.troubleshooting.overview.usecase.CollectIdsUseCase
 import com.simprints.feature.troubleshooting.overview.usecase.CollectLicenceStatesUseCase
 import com.simprints.feature.troubleshooting.overview.usecase.CollectNetworkInformationUseCase
@@ -31,6 +32,9 @@ class OverviewViewModelTest {
     private lateinit var collectIdsUseCase: CollectIdsUseCase
 
     @MockK
+    private lateinit var collectConfigurationDetails: CollectConfigurationDetailsUseCase
+
+    @MockK
     private lateinit var collectLicencesUseCase: CollectLicenceStatesUseCase
 
     @MockK
@@ -50,6 +54,7 @@ class OverviewViewModelTest {
 
         viewModel = OverviewViewModel(
             collectIds = collectIdsUseCase,
+            collectConfigurationDetails = collectConfigurationDetails,
             collectLicenseStates = collectLicencesUseCase,
             collectNetworkInformation = collectNetworkInformationUseCase,
             doServerPing = pingServerUseCase,
@@ -60,10 +65,12 @@ class OverviewViewModelTest {
     @Test
     fun `sets when data collected`() = runTest {
         every { collectIdsUseCase() } returns "ids"
+        coEvery { collectConfigurationDetails() } returns "details"
         coEvery { collectLicencesUseCase() } returns "licences"
         every { collectNetworkInformationUseCase() } returns "network"
 
         val idsText = viewModel.projectIds.test()
+        val configText = viewModel.configurationDetails.test()
         val licenceText = viewModel.licenseStates.test()
         val networkText = viewModel.networkStates.test()
         val pingResult = viewModel.pingResult.test()
@@ -71,6 +78,7 @@ class OverviewViewModelTest {
         viewModel.collectData()
 
         assertThat(idsText.value()).isNotEmpty()
+        assertThat(configText.value()).isNotEmpty()
         assertThat(licenceText.value()).isNotEmpty()
         assertThat(networkText.value()).isNotEmpty()
         assertThat(pingResult.value()).isInstanceOf(PingResult.NotDone::class.java)

--- a/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/overview/usecase/CollectConfigurationDetailsUseCaseTest.kt
+++ b/feature/troubleshooting/src/test/java/com/simprints/feature/troubleshooting/overview/usecase/CollectConfigurationDetailsUseCaseTest.kt
@@ -1,0 +1,54 @@
+package com.simprints.feature.troubleshooting.overview.usecase
+
+import com.google.common.truth.Truth.assertThat
+import com.simprints.infra.config.store.ConfigRepository
+import com.simprints.infra.config.sync.ConfigSyncCache
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class CollectConfigurationDetailsUseCaseTest {
+    @MockK
+    private lateinit var configManager: ConfigRepository
+
+    @MockK
+    private lateinit var configSyncCache: ConfigSyncCache
+
+    private lateinit var useCase: CollectConfigurationDetailsUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        coEvery { configManager.getProjectConfiguration() } returns mockk {
+            every { id } returns CONFIG_ID
+            every { updatedAt } returns UPDATED_AT
+        }
+        coEvery { configSyncCache.sinceLastUpdateTime() } returns SINCE_LAST_UPDATE
+
+        useCase = CollectConfigurationDetailsUseCase(
+            configManager,
+            configSyncCache,
+        )
+    }
+
+    @Test
+    fun `result contains details from all sources`() = runTest {
+        val details = useCase()
+
+        assertThat(details).contains(CONFIG_ID)
+        assertThat(details).contains(UPDATED_AT)
+        assertThat(details).contains(SINCE_LAST_UPDATE)
+    }
+
+    companion object {
+        private const val CONFIG_ID = "configId"
+        private const val UPDATED_AT = "updateDate"
+        private const val SINCE_LAST_UPDATE = "sinceLastUpdate"
+    }
+}

--- a/infra/config-sync/src/main/java/com/simprints/infra/config/sync/ConfigManager.kt
+++ b/infra/config-sync/src/main/java/com/simprints/infra/config/sync/ConfigManager.kt
@@ -14,9 +14,11 @@ import javax.inject.Inject
 class ConfigManager @Inject constructor(
     private val configRepository: ConfigRepository,
     private val enrolmentRecordRepository: EnrolmentRecordRepository,
+    private val configSyncCache: ConfigSyncCache,
 ) {
     suspend fun refreshProject(projectId: String): ProjectWithConfig = configRepository.refreshProject(projectId).also {
         enrolmentRecordRepository.tokenizeExistingRecords(it.project)
+        configSyncCache.saveUpdateTime()
     }
 
     suspend fun getProject(projectId: String): Project = try {

--- a/infra/config-sync/src/main/java/com/simprints/infra/config/sync/ConfigSyncCache.kt
+++ b/infra/config-sync/src/main/java/com/simprints/infra/config/sync/ConfigSyncCache.kt
@@ -1,0 +1,36 @@
+package com.simprints.infra.config.sync
+
+import androidx.core.content.edit
+import com.simprints.core.DispatcherIO
+import com.simprints.core.tools.time.TimeHelper
+import com.simprints.core.tools.time.Timestamp
+import com.simprints.infra.security.SecurityManager
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class ConfigSyncCache @Inject constructor(
+    securityManager: SecurityManager,
+    private val timeHelper: TimeHelper,
+    @DispatcherIO private val dispatcher: CoroutineDispatcher,
+) {
+    private val sharedPrefs =
+        securityManager.buildEncryptedSharedPreferences(FILENAME_FOR_LAST_SYNC_TIME_SHARED_PREFS)
+
+    suspend fun saveUpdateTime() = withContext(dispatcher) {
+        sharedPrefs.edit { putLong(KEY_LAST_SYNC_TIME, timeHelper.now().ms) }
+    }
+
+    suspend fun sinceLastUpdateTime(): String = withContext(dispatcher) {
+        sharedPrefs
+            .getLong(KEY_LAST_SYNC_TIME, -1)
+            .takeIf { it >= 0 }
+            ?.let { timeHelper.readableBetweenNowAndTime(Timestamp(it)) }
+            .orEmpty()
+    }
+
+    companion object {
+        private const val FILENAME_FOR_LAST_SYNC_TIME_SHARED_PREFS = "CACHE_LAST_CONFIG_UPDATE_TIME"
+        private const val KEY_LAST_SYNC_TIME = "KEY_LAST_SYNC_TIME"
+    }
+}

--- a/infra/config-sync/src/test/java/com/simprints/infra/config/sync/ConfigManagerTest.kt
+++ b/infra/config-sync/src/test/java/com/simprints/infra/config/sync/ConfigManagerTest.kt
@@ -31,6 +31,9 @@ class ConfigManagerTest {
     private lateinit var enrolmentRecordRepository: EnrolmentRecordRepository
 
     @MockK
+    private lateinit var configSyncCache: ConfigSyncCache
+
+    @MockK
     private lateinit var projectWithConfig: ProjectWithConfig
 
     @MockK
@@ -48,6 +51,7 @@ class ConfigManagerTest {
         configManager = ConfigManager(
             configRepository = configRepository,
             enrolmentRecordRepository = enrolmentRecordRepository,
+            configSyncCache = configSyncCache,
         )
     }
 
@@ -57,6 +61,8 @@ class ConfigManagerTest {
 
         val refreshedProject = configManager.refreshProject(PROJECT_ID)
         assertThat(refreshedProject).isEqualTo(projectWithConfig)
+
+        coVerify { configSyncCache.saveUpdateTime() }
     }
 
     @Test

--- a/infra/config-sync/src/test/java/com/simprints/infra/config/sync/ConfigSyncCacheTest.kt
+++ b/infra/config-sync/src/test/java/com/simprints/infra/config/sync/ConfigSyncCacheTest.kt
@@ -1,0 +1,79 @@
+package com.simprints.infra.config.sync
+
+import android.content.SharedPreferences
+import com.google.common.truth.Truth.assertThat
+import com.simprints.core.tools.time.TimeHelper
+import com.simprints.core.tools.time.Timestamp
+import com.simprints.infra.security.SecurityManager
+import com.simprints.testtools.common.coroutines.TestCoroutineRule
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class ConfigSyncCacheTest {
+    @get:Rule
+    val testCoroutineRule = TestCoroutineRule()
+
+    @MockK
+    private lateinit var prefs: SharedPreferences
+
+    @MockK
+    private lateinit var securityManager: SecurityManager
+
+    @MockK
+    private lateinit var timeHelper: TimeHelper
+
+    private lateinit var configSyncCache: ConfigSyncCache
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        every { securityManager.buildEncryptedSharedPreferences(any()) } returns prefs
+        every { timeHelper.now() } returns Timestamp(1000)
+
+        configSyncCache = ConfigSyncCache(
+            securityManager,
+            timeHelper,
+            testCoroutineRule.testCoroutineDispatcher,
+        )
+    }
+
+    @Test
+    fun `calling saveUpdateTime stores current timestamp to prefs`() = runTest {
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        every { prefs.edit() } returns editor
+
+        configSyncCache.saveUpdateTime()
+
+        verify { editor.putLong(any(), 1000) }
+    }
+
+    @Test
+    fun `calling sinceLastUpdateTime fetches timestamp from prefs`() = runTest {
+        every { prefs.getLong(any(), any()) } returns 1000
+        every { timeHelper.readableBetweenNowAndTime(any()) } returns "0 minutes"
+
+        val result = configSyncCache.sinceLastUpdateTime()
+
+        verify { prefs.getLong(any(), any()) }
+        verify { timeHelper.readableBetweenNowAndTime(Timestamp(1000L)) }
+        assertThat(result).isEqualTo("0 minutes")
+    }
+
+    @Test
+    fun `returns empty stirng if no timestamp is found`() = runTest {
+        every { prefs.getLong(any(), any()) } returns -1
+
+        val result = configSyncCache.sinceLastUpdateTime()
+
+        verify { prefs.getLong(any(), any()) }
+        assertThat(result).isEmpty()
+    }
+}

--- a/infra/resources/src/main/res/values/strings.xml
+++ b/infra/resources/src/main/res/values/strings.xml
@@ -375,6 +375,7 @@
     <string name="dashboard_preference_summary_settings_fingers">View the fingers that will be scanned</string>
     <string name="dashboard_preference_summary_sync_information">Further details on sync</string>
     <string name="dashboard_preference_summary_update_config">Refresh device and project configuration</string>
+    <string name="dashboard_preference_summary_update_config_last_updated">Refresh device and project configuration\nLast updated: %s</string>
     <string name="dashboard_preference_summary_enable_audio_on_scan_complete">Audio alerts for scan completion, prompting the user to remove the subject’s finger from the scanner.</string>
     <string name="dashboard_preference_copied_to_clipboard">Copied to clipboard</string>
     <string name="dashboard_preference_update_config_scheduled">Configuration update started</string>

--- a/infra/resources/src/main/res/values/strings.xml
+++ b/infra/resources/src/main/res/values/strings.xml
@@ -378,6 +378,7 @@
     <string name="dashboard_preference_summary_enable_audio_on_scan_complete">Audio alerts for scan completion, prompting the user to remove the subject’s finger from the scanner.</string>
     <string name="dashboard_preference_copied_to_clipboard">Copied to clipboard</string>
     <string name="dashboard_preference_update_config_scheduled">Configuration update started</string>
+    <string name="dashboard_preference_update_config_finished">Configuration updated</string>
     <string name="dashboard_preference_enable_audio_on_scan_complete">Audio Alert</string>
 
     <!-- Dashboard - Sync info -->

--- a/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestrator.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestrator.kt
@@ -1,13 +1,17 @@
 package com.simprints.infra.sync
 
+import kotlinx.coroutines.flow.Flow
+
 interface SyncOrchestrator {
     suspend fun scheduleBackgroundWork()
 
     suspend fun cancelBackgroundWork()
 
-    fun startProjectSync()
-
-    fun startDeviceSync()
+    /**
+     * Trigger project and device configuration sync workers.
+     * Emits value when both sync workers are done.
+     */
+    fun refreshConfiguration(): Flow<Unit>
 
     fun rescheduleEventSync()
 


### PR DESCRIPTION
As per updated requirements:
* Added refresh icon (see video below).
* Added a toast notification after both sync workers finish. Since "start" and "end" toasts were shown way too quickly, I decided to change the description text under the preference instead of the "starting" toast (see video below).
* I added a subtitle with the time since the "last update." It is in relative format to keep it consistent with the "last sync" indicator.

https://github.com/user-attachments/assets/48f0b347-b75b-4eb9-9d1a-544d621f4b7e




* As a bonus, I have also added some details about the current configuration to the troubleshooting overview - config ID, config update data (in vulcan) and time since last config sync.

<img src="https://github.com/user-attachments/assets/d8ff08db-2eb6-4d6a-98ba-6f1730f4bdd7" width="480">


