### PR TITLE
[CORE-3132] Add protection to avoid trying to access view when it's null

### DIFF
--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/serialentrypair/SerialEntryPairFragment.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/serialentrypair/SerialEntryPairFragment.kt
@@ -147,7 +147,7 @@ internal class SerialEntryPairFragment : Fragment(R.layout.fragment_serial_entry
                 viewModel.scannerNumber.orEmpty(),
             )
             viewModel.startPairing(serialNumber)
-        } catch (e: NumberFormatException) {
+        } catch (_: NumberFormatException) {
             context?.showToast(IDR.string.fingerprint_connect_serial_entry_pair_toast_invalid)
         }
     }
@@ -168,17 +168,19 @@ internal class SerialEntryPairFragment : Fragment(R.layout.fragment_serial_entry
 
     private fun handlePairingAttemptFailed(pairingRejected: Boolean) {
         determineWhetherPairingWasSuccessfulJob?.cancel()
-        viewModel.awaitingToPairToMacAddress.value?.let { macAddressEvent ->
-            binding.serialEntryPairProgressBar.visibility = View.INVISIBLE
-            binding.serialEntryOkButton.visibility = View.VISIBLE
-            binding.serialEntryPairInstructionsDetailTextView.visibility = View.INVISIBLE
-            binding.serialEntryPairInstructionsTextView.text = if (pairingRejected) {
-                getString(IDR.string.fingerprint_connect_serial_entry_pair_rejected)
-            } else {
-                getString(
-                    IDR.string.fingerprint_connect_serial_entry_pair_failed,
-                    serialNumberConverter.convertMacAddressToSerialNumber(macAddressEvent.peekContent()),
-                )
+        if (isAdded && view != null) {
+            viewModel.awaitingToPairToMacAddress.value?.let { macAddressEvent ->
+                binding.serialEntryPairProgressBar.visibility = View.INVISIBLE
+                binding.serialEntryOkButton.visibility = View.VISIBLE
+                binding.serialEntryPairInstructionsDetailTextView.visibility = View.INVISIBLE
+                binding.serialEntryPairInstructionsTextView.text = if (pairingRejected) {
+                    getString(IDR.string.fingerprint_connect_serial_entry_pair_rejected)
+                } else {
+                    getString(
+                        IDR.string.fingerprint_connect_serial_entry_pair_failed,
+                        serialNumberConverter.convertMacAddressToSerialNumber(macAddressEvent.peekContent()),
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
This issue was considered fixed but continues to happen from time to time on all versions (including 2024.2.2).
Looks like there's more than one path to it - probably some async stuff that's hard to debug. So I just added protection to avoid crashing when we don't need to update the UI anyway.