### PR TITLE
Fix github action oddity that prevents parsing github vars in reusable workflows + Add deploy URL to Summary Page 

### DIFF
--- a/.github/workflows/deploy-dev-workflow.yml
+++ b/.github/workflows/deploy-dev-workflow.yml
@@ -1,4 +1,4 @@
-name: "Deploy: Main Workflow"
+name: "Deploy: Dev Workflow"
 
 on:
     workflow_dispatch:
@@ -12,4 +12,3 @@ jobs:
     deploy-to-dev:
         uses: ./.github/workflows/pipeline-deploy-to-dev.yml
         secrets: inherit
-        

--- a/.github/workflows/deploy-main-workflow.yml
+++ b/.github/workflows/deploy-main-workflow.yml
@@ -1,0 +1,17 @@
+name: "Deploy: Main Workflow"
+
+on:
+    push:
+        branches:
+            - main
+
+concurrency:
+    group: deploy-main-workflow
+    cancel-in-progress: true
+
+jobs:
+
+    deploy-to-dev:
+        uses: ./.github/workflows/pipeline-deploy-to-dev.yml
+        secrets: inherit
+       

--- a/.github/workflows/deploy-main-workflow.yml
+++ b/.github/workflows/deploy-main-workflow.yml
@@ -1,9 +1,7 @@
 name: "Deploy: Main Workflow"
 
 on:
-    push:
-        branches:
-            - main
+    workflow_dispatch:
 
 concurrency:
     group: deploy-main-workflow
@@ -14,4 +12,4 @@ jobs:
     deploy-to-dev:
         uses: ./.github/workflows/pipeline-deploy-to-dev.yml
         secrets: inherit
-       
+        

--- a/.github/workflows/reusable-build-apk.yml
+++ b/.github/workflows/reusable-build-apk.yml
@@ -6,6 +6,7 @@ on:
             build-environment:
                 type: string
                 required: true
+
         outputs:
             build-artifact:
                 description: "The artifact file name of the built APK"
@@ -56,10 +57,11 @@ jobs:
                     exit 1
 
             -   name: Check base version code
-                if: ${{ github.run_number * 100 >= env.BASE_VERSION_CODE }}
                 run: |
-                    echo "Github workflows now exceeds the base version code. Please remove the BASE_VERSION_CODE"
-                    echo "BASE_VERSION_CODE=0" >> $GITHUB_ENV
+                    if [ $(( ${{ github.run_number }} * 100 )) -ge $BASE_VERSION_CODE ]; then
+                      echo "Github workflows now exceeds the base version code..."
+                      echo "BASE_VERSION_CODE=0" >> $GITHUB_ENV
+                    fi
 
             -   name: Compute version variables
                 run: |

--- a/.github/workflows/reusable-deploy-to-firebase-distribution.yml
+++ b/.github/workflows/reusable-deploy-to-firebase-distribution.yml
@@ -48,8 +48,23 @@ jobs:
                 with:
                     name: ${{ inputs.upload-artifact }}
 
-            -   name: Distribution Summary
-                run: echo "### Deployed ${{ inputs.upload-artifact}} to Firebase Simprints ID ${{ inputs.build-environment }} :rocket:" >> $GITHUB_STEP_SUMMARY
-
             -   name: Deploy to Firebase App Distribution
-                run: firebase appdistribution:distribute ${{ inputs.upload-artifact }} --app ${{ vars.FIREBASE_DISTRIBUTION_APP_ID}} --groups "pre-release-testers"
+                id: firebase-deploy
+                run: |
+                    # Capture the entire output of the firebase command in a variable
+                    output="$(firebase appdistribution:distribute ${{ inputs.upload-artifact }} --app ${{ vars.FIREBASE_DISTRIBUTION_APP_ID}} --groups "pre-release-testers")"
+
+                    echo "$output"
+
+                    # The CLI prints a line like:
+                    #   "✔  View this release in the Firebase console: https://console.firebase.google.com/...."
+                    console_url="$(echo "$output" | grep -o 'https://console\.firebase\.google\.com[^[:space:]]*')"
+
+                    # Expose console_url as a step output using $GITHUB_OUTPUT
+                    echo "console_url=$console_url" >> "$GITHUB_OUTPUT"
+
+            -   name: Distribution Summary
+                run: |
+                    echo "### Deployed ${{ inputs.upload-artifact}} to Firebase Simprints ID ${{ inputs.build-environment }} :rocket:" >> $GITHUB_STEP_SUMMARY
+                    echo "✔ [View this release in the Firebase console](${{ steps.firebase-deploy.outputs.console_url }})" >> "$GITHUB_STEP_SUMMARY"
+


### PR DESCRIPTION
Context: https://simprints.slack.com/archives/GAW460V19/p1736868512985299

This PR 
1) Fixes a bug "referencing github.run_number directly in a reusable workflow’s expression (if:), which the Actions parser doesn’t allow at parse time."
2) Adds the deployment URL to the summary page so people don't dig into the steps console to get it. 