### PR TITLE
[MS-716] Face auto-capture

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/FaceCaptureContract.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/FaceCaptureContract.kt
@@ -6,5 +6,8 @@ import com.simprints.face.capture.screens.controller.FaceCaptureControllerFragme
 object FaceCaptureContract {
     val DESTINATION = R.id.faceCaptureControllerFragment
 
-    fun getArgs(samplesToCapture: Int): Bundle = FaceCaptureControllerFragmentArgs(samplesToCapture).toBundle()
+    fun getArgs(
+        samplesToCapture: Int,
+        isAutoCapture: Boolean,
+    ): Bundle = FaceCaptureControllerFragmentArgs(samplesToCapture, isAutoCapture).toBundle()
 }

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/controller/FaceCaptureControllerFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/controller/FaceCaptureControllerFragment.kt
@@ -121,7 +121,13 @@ internal class FaceCaptureControllerFragment : Fragment(R.layout.fragment_face_c
             }
         }
 
-        internalNavController?.setGraph(R.navigation.graph_face_capture_internal)
+        internalNavController?.setGraph(
+            if (args.isAutoCapture) {
+                R.navigation.graph_face_capture_auto_internal
+            } else {
+                R.navigation.graph_face_capture_internal
+            }
+        )
     }
 
     private fun initFaceBioSdk() {

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragment.kt
@@ -1,0 +1,367 @@
+package com.simprints.face.capture.screens.livefeedbackautocapture
+
+import android.Manifest
+import android.content.Intent
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Bundle
+import android.provider.Settings
+import android.util.Size
+import android.view.View
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector.DEFAULT_BACK_CAMERA
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.lifecycle.awaitInstance
+import androidx.core.content.ContextCompat
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import com.simprints.core.domain.permission.PermissionStatus
+import com.simprints.core.tools.extentions.hasPermission
+import com.simprints.core.tools.extentions.permissionFromResult
+import com.simprints.face.capture.R
+import com.simprints.face.capture.databinding.FragmentLiveFeedbackBinding
+import com.simprints.face.capture.models.FaceDetection
+import com.simprints.face.capture.screens.FaceCaptureViewModel
+import com.simprints.face.capture.screens.livefeedback.CropToTargetOverlayAnalyzer
+import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.navigation.navigateSafely
+import com.simprints.infra.uibase.view.setCheckedWithLeftDrawable
+import com.simprints.infra.uibase.viewbinding.viewBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import com.simprints.infra.resources.R as IDR
+
+/**
+ * As the user is capturing subject's face, they are presented with this fragment, which displays
+ * live information about distance and whether the face is ready to be captured or not.
+ * It also displays the capture process of the face and then sends this result to
+ * [com.simprints.face.capture.screens.confirmation.ConfirmationFragment]
+ */
+@AndroidEntryPoint
+internal class LiveFeedbackAutoCaptureFragment : Fragment(R.layout.fragment_live_feedback_auto_capture) {
+    /** Blocking camera operations are performed using this executor */
+    private lateinit var cameraExecutor: ExecutorService
+
+    private val mainVm: FaceCaptureViewModel by activityViewModels()
+
+    private val vm: LiveFeedbackAutoCaptureFragmentViewModel by viewModels()
+    private val binding by viewBinding(FragmentLiveFeedbackBinding::bind)
+
+    private lateinit var screenSize: Size
+    private lateinit var targetResolution: Size
+
+    private val launchPermissionRequest = registerForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        when (requireActivity().permissionFromResult(Manifest.permission.CAMERA, granted)) {
+            PermissionStatus.Granted -> setUpCamera()
+            PermissionStatus.Denied -> renderNoPermission(false)
+            PermissionStatus.DeniedNeverAskAgain -> renderNoPermission(true)
+        }
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        initFragment()
+    }
+
+    private fun initFragment() {
+        screenSize = with(resources.displayMetrics) { Size(widthPixels, widthPixels) }
+        bindViewModel()
+        binding.captureProgress.max = 1 // normalized progress
+
+        // Wait till the views gets its final size then init frame processor and setup the camera
+        binding.faceCaptureCamera.post {
+            if (view != null) {
+                vm.initCapture(mainVm.samplesToCapture, mainVm.attemptNumber)
+            }
+        }
+    }
+
+    /** Initialize CameraX, and prepare to bind the camera use cases  */
+    private fun setUpCamera() = lifecycleScope.launch {
+        if (::cameraExecutor.isInitialized && !cameraExecutor.isShutdown) {
+            return@launch
+        }
+        vm.startPreparationDelay()
+
+        // Initialize our background executor
+        cameraExecutor = Executors.newSingleThreadExecutor()
+        // ImageAnalysis
+        // Todo choose accurate output image resolution that respects quality,performance and face analysis SDKs https://simprints.atlassian.net/browse/CORE-2569
+        if (!::targetResolution.isInitialized) {
+            targetResolution = Size(binding.captureOverlay.width, binding.captureOverlay.height)
+        }
+
+        val imageAnalyzer = ImageAnalysis
+            .Builder()
+            .setTargetResolution(targetResolution)
+            .setOutputImageRotationEnabled(true)
+            .setOutputImageFormat(OUTPUT_IMAGE_FORMAT_RGBA_8888)
+            .build()
+        val cropAnalyzer = CropToTargetOverlayAnalyzer(binding.captureOverlay, ::analyze)
+
+        imageAnalyzer.setAnalyzer(cameraExecutor, cropAnalyzer)
+
+        // Preview
+        val preview = Preview.Builder().setTargetResolution(targetResolution).build()
+        val cameraProvider = ProcessCameraProvider.awaitInstance(requireContext())
+        cameraProvider.unbindAll()
+        cameraProvider.bindToLifecycle(
+            this@LiveFeedbackAutoCaptureFragment,
+            DEFAULT_BACK_CAMERA,
+            preview,
+            imageAnalyzer,
+        )
+        // Attach the view's surface provider to preview use case
+        preview.surfaceProvider = binding.faceCaptureCamera.surfaceProvider
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        when {
+            requireActivity().hasPermission(Manifest.permission.CAMERA) -> setUpCamera()
+            mainVm.shouldCheckCameraPermissions.getAndSet(false) -> {
+                // Check permission in onResume() so that if user left the app to go to Settings
+                // and give the permission, it's reflected when they come back to SID
+                if (requireActivity().hasPermission(Manifest.permission.CAMERA)) {
+                    setUpCamera()
+                } else {
+                    launchPermissionRequest.launch(Manifest.permission.CAMERA)
+                }
+            }
+
+            else -> mainVm.shouldCheckCameraPermissions.set(true)
+        }
+    }
+
+    override fun onStop() {
+        // Shut down our background executor
+        if (::cameraExecutor.isInitialized) {
+            cameraExecutor.shutdown()
+        }
+        super.onStop()
+    }
+
+    private fun bindViewModel() {
+        vm.currentDetection.observe(viewLifecycleOwner) {
+            renderCurrentDetection(it)
+        }
+
+        vm.capturingState.observe(viewLifecycleOwner) {
+            @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") when (it) {
+                LiveFeedbackAutoCaptureFragmentViewModel.CapturingState.NOT_STARTED -> renderCapturingNotStarted()
+
+                LiveFeedbackAutoCaptureFragmentViewModel.CapturingState.CAPTURING -> renderCapturing()
+
+                LiveFeedbackAutoCaptureFragmentViewModel.CapturingState.FINISHED -> {
+                    mainVm.captureFinished(vm.sortedQualifyingCaptures)
+                    findNavController().navigateSafely(
+                        currentFragment = this,
+                        directions = LiveFeedbackAutoCaptureFragmentDirections.actionFaceLiveFeedbackFragmentToFaceConfirmationFragment(),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun analyze(image: Bitmap) {
+        try {
+            vm.process(croppedBitmap = image)
+        } catch (t: Throwable) {
+            Simber.e("Image analysis crashed", t)
+            // Image analysis is running in bg thread
+            lifecycleScope.launch {
+                mainVm.submitError(t)
+            }
+        }
+    }
+
+    private fun renderCurrentDetection(faceDetection: FaceDetection) {
+        when (faceDetection.status) {
+            FaceDetection.Status.NOFACE -> renderNoFace()
+            FaceDetection.Status.OFFYAW -> renderFaceNotStraight()
+            FaceDetection.Status.OFFROLL -> renderFaceNotStraight()
+            FaceDetection.Status.TOOCLOSE -> renderFaceTooClose()
+            FaceDetection.Status.TOOFAR -> renderFaceTooFar()
+            FaceDetection.Status.BAD_QUALITY -> renderBadQuality()
+            FaceDetection.Status.VALID -> renderValidFace()
+            FaceDetection.Status.VALID_CAPTURING -> renderValidCapturingFace()
+        }
+    }
+
+    private fun renderCapturingStateColors() {
+        with(binding) {
+            captureOverlay.drawWhiteTarget()
+            captureFeedbackTxtExplanation.setTextColor(
+                ContextCompat.getColor(requireContext(), IDR.color.simprints_blue_grey),
+            )
+        }
+    }
+
+    private fun renderCapturingNotStarted() {
+        binding.apply {
+            captureOverlay.drawSemiTransparentTarget()
+            captureFeedbackBtn.setText(IDR.string.face_capture_title_previewing)
+            captureFeedbackBtn.isVisible = true
+            captureFeedbackPermissionButton.isGone = true
+        }
+    }
+
+    private fun renderCapturing() {
+        renderCapturingStateColors()
+        binding.apply {
+            captureProgress.isVisible = true
+            captureFeedbackBtn.setText(IDR.string.face_capture_prep_begin_button_capturing)
+            captureFeedbackBtn.isVisible = true
+            captureFeedbackPermissionButton.isGone = true
+        }
+    }
+
+    private fun renderValidFace() {
+        binding.apply {
+            captureFeedbackBtn.setText(IDR.string.face_capture_prep_begin_button_capturing)
+            captureFeedbackTxtExplanation.text = null
+            captureFeedbackBtn.isVisible = true
+            captureFeedbackPermissionButton.isGone = true
+
+            captureFeedbackBtn.setCheckedWithLeftDrawable(
+                true,
+                ContextCompat.getDrawable(requireContext(), R.drawable.ic_checked_white_18dp),
+            )
+        }
+    }
+
+    private fun renderValidCapturingFace() {
+        binding.apply {
+            captureFeedbackBtn.setText(IDR.string.face_capture_prep_begin_button_capturing)
+            captureFeedbackTxtExplanation.setText(IDR.string.face_capture_hold)
+            captureFeedbackBtn.isVisible = true
+            captureFeedbackPermissionButton.isGone = true
+
+            captureFeedbackBtn.setCheckedWithLeftDrawable(
+                true,
+                ContextCompat.getDrawable(requireContext(), R.drawable.ic_checked_white_18dp),
+            )
+        }
+
+        renderProgressBar(true)
+    }
+
+    private fun renderFaceTooFar() {
+        binding.apply {
+            captureFeedbackBtn.setText(IDR.string.face_capture_title_too_far)
+            captureFeedbackTxtExplanation.setText(IDR.string.face_capture_error_too_far)
+            captureFeedbackBtn.isVisible = true
+            captureFeedbackPermissionButton.isGone = true
+
+            captureFeedbackBtn.setCheckedWithLeftDrawable(false)
+        }
+
+        renderProgressBar(false)
+    }
+
+    private fun renderFaceTooClose() {
+        binding.apply {
+            captureFeedbackBtn.setText(IDR.string.face_capture_title_too_close)
+            captureFeedbackTxtExplanation.setText(IDR.string.face_capture_error_too_close)
+            captureFeedbackBtn.isVisible = true
+            captureFeedbackPermissionButton.isGone = true
+
+            captureFeedbackBtn.setCheckedWithLeftDrawable(false)
+        }
+
+        renderProgressBar(false)
+    }
+
+    private fun renderNoFace() {
+        binding.apply {
+            captureFeedbackBtn.setText(IDR.string.face_capture_title_no_face)
+            captureFeedbackTxtExplanation.setText(IDR.string.face_capture_error_no_face)
+            captureFeedbackBtn.isVisible = true
+            captureFeedbackPermissionButton.isGone = true
+
+            captureFeedbackBtn.setCheckedWithLeftDrawable(false)
+        }
+
+        renderProgressBar(false)
+    }
+
+    private fun renderFaceNotStraight() {
+        binding.apply {
+            captureFeedbackBtn.setText(IDR.string.face_capture_title_look_straight)
+            captureFeedbackTxtExplanation.setText(IDR.string.face_capture_error_look_straight)
+            captureFeedbackBtn.isVisible = true
+            captureFeedbackPermissionButton.isGone = true
+
+            captureFeedbackBtn.setCheckedWithLeftDrawable(false)
+        }
+
+        renderProgressBar(false)
+    }
+
+    private fun renderBadQuality() {
+        binding.apply {
+            captureFeedbackBtn.setText(IDR.string.face_capture_title_bad_quality)
+            captureFeedbackTxtExplanation.setText(IDR.string.face_capture_error_bad_quality)
+            captureFeedbackBtn.isVisible = true
+            captureFeedbackPermissionButton.isGone = true
+
+            captureFeedbackBtn.setCheckedWithLeftDrawable(false)
+        }
+
+        renderProgressBar(false)
+    }
+
+    private fun renderProgressBar(valid: Boolean) {
+        binding.apply {
+            val progressColor = if (valid) {
+                IDR.color.simprints_green_light
+            } else {
+                IDR.color.simprints_blue_grey_light
+            }
+
+            captureProgress.progressColor = ContextCompat.getColor(
+                requireContext(),
+                progressColor,
+            )
+
+            captureProgress.value = vm.getAutoCaptureImagingProgressNormalized()
+        }
+    }
+
+    private fun renderNoPermission(shouldOpenSettings: Boolean) {
+        binding.apply {
+            captureOverlay.drawSemiTransparentTarget()
+            captureFeedbackTxtExplanation.setText(IDR.string.face_capture_permission_denied)
+            captureFeedbackBtn.isGone = true
+            captureFeedbackPermissionButton.isVisible = true
+            captureFeedbackPermissionButton.setOnClickListener {
+                if (shouldOpenSettings) {
+                    requireActivity().startActivity(
+                        Intent(
+                            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                            Uri.parse("package:${requireActivity().packageName}"),
+                        ),
+                    )
+                } else {
+                    launchPermissionRequest.launch(Manifest.permission.CAMERA)
+                }
+            }
+        }
+    }
+}

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragmentViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragmentViewModel.kt
@@ -1,0 +1,261 @@
+package com.simprints.face.capture.screens.livefeedbackautocapture
+
+import android.graphics.Bitmap
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.simprints.core.tools.extentions.area
+import com.simprints.core.tools.time.TimeHelper
+import com.simprints.core.tools.time.Timestamp
+import com.simprints.face.capture.models.FaceDetection
+import com.simprints.face.capture.models.FaceTarget
+import com.simprints.face.capture.models.SymmetricTarget
+import com.simprints.face.capture.usecases.SimpleCaptureEventReporter
+import com.simprints.face.infra.basebiosdk.detection.Face
+import com.simprints.face.infra.basebiosdk.detection.FaceDetector
+import com.simprints.face.infra.biosdkresolver.ResolveFaceBioSdkUseCase
+import com.simprints.infra.config.store.models.experimental
+import com.simprints.infra.config.sync.ConfigManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+
+@HiltViewModel
+internal class LiveFeedbackAutoCaptureFragmentViewModel @Inject constructor(
+    private val resolveFaceBioSdk: ResolveFaceBioSdkUseCase,
+    private val configManager: ConfigManager,
+    private val eventReporter: SimpleCaptureEventReporter,
+    private val timeHelper: TimeHelper,
+) : ViewModel() {
+    private var attemptNumber: Int = 1
+    private var samplesToKeep: Int = 1
+    private var qualityThreshold: Float = 0f
+    private var singleQualityFallbackCaptureRequired: Boolean = false
+
+    private val faceTarget = FaceTarget(
+        SymmetricTarget(VALID_YAW_DELTA),
+        SymmetricTarget(VALID_ROLL_DELTA),
+        0.20f..0.5f,
+    )
+    private val fallbackCaptureEventStartTime = timeHelper.now()
+    private var shouldSendFallbackCaptureEvent: AtomicBoolean = AtomicBoolean(true)
+    private var fallbackCapture: FaceDetection? = null
+
+    val userCaptures = mutableListOf<FaceDetection>()
+    var sortedQualifyingCaptures = listOf<FaceDetection>()
+    val currentDetection = MutableLiveData<FaceDetection>()
+    val capturingState = MutableLiveData(CapturingState.NOT_STARTED)
+    private var autoCaptureInitialDelayJob: Job = viewModelScope.launch {
+        delay(AUTO_CAPTURE_VIEWFINDER_RESUME_DELAY_MS)
+    }
+    private lateinit var faceDetector: FaceDetector
+
+    fun startPreparationDelay() {
+        if (capturingState.value != CapturingState.NOT_STARTED) {
+            return // too late - imaging has already started
+        }
+        capturingState.value = CapturingState.NOT_STARTED // reset view
+        autoCaptureInitialDelayJob.cancel()
+        autoCaptureInitialDelayJob = viewModelScope.launch {
+            delay(AUTO_CAPTURE_VIEWFINDER_RESUME_DELAY_MS)
+        }
+    }
+
+    /**
+     * Processes the image
+     *
+     * @param image is the camera frame
+     */
+    fun process(croppedBitmap: Bitmap) {
+        val captureStartTime = timeHelper.now()
+        val potentialFace = faceDetector.analyze(croppedBitmap)
+
+        val faceDetection = getFaceDetectionFromPotentialFace(croppedBitmap, potentialFace)
+        faceDetection.detectionStartTime = captureStartTime
+        faceDetection.detectionEndTime = timeHelper.now()
+
+        if (autoCaptureInitialDelayJob.isCompleted) {
+            currentDetection.postValue(faceDetection)
+            if (faceDetection.status == FaceDetection.Status.VALID
+                    && capturingState.value == CapturingState.NOT_STARTED) {
+                capturingState.postValue(CapturingState.CAPTURING)
+            }
+        }
+
+        when (capturingState.value) {
+            CapturingState.NOT_STARTED -> updateFallbackCaptureIfValid(faceDetection)
+            CapturingState.CAPTURING -> {
+                if (isEligibleForImagingSample(currentTimestamp = captureStartTime)) {
+                    userCaptures += faceDetection
+                    if (userCaptures.size == AUTO_CAPTURE_SAMPLE_COUNT) {
+                        finishCapture(attemptNumber)
+                    }
+                }
+            }
+
+            else -> { // no-op
+            }
+        }
+    }
+
+    fun initCapture(
+        samplesToKeep: Int,
+        attemptNumber: Int,
+    ) {
+        this.samplesToKeep = samplesToKeep
+        this.attemptNumber = attemptNumber
+        viewModelScope.launch {
+            faceDetector = resolveFaceBioSdk().detector
+
+            val config = configManager.getProjectConfiguration()
+            qualityThreshold = config.face?.qualityThreshold ?: 0f
+            singleQualityFallbackCaptureRequired = config.experimental().singleQualityFallbackRequired
+        }
+    }
+
+    fun getAutoCaptureImagingProgressNormalized(): Float =
+        userCaptures.firstOrNull()?.detectionStartTime?.ms?.let { detectionStartTime ->
+            (timeHelper.now().ms - detectionStartTime).toFloat() / AUTO_CAPTURE_IMAGING_DURATION_MS
+        } ?: 0f
+
+    private fun isEligibleForImagingSample(currentTimestamp: Timestamp): Boolean {
+        if (userCaptures.isEmpty()) {
+            return true
+        }
+        if (userCaptures.size >= AUTO_CAPTURE_SAMPLE_COUNT) {
+            return false
+        }
+        val samplingStepMillis = AUTO_CAPTURE_IMAGING_DURATION_MS.toDouble() / AUTO_CAPTURE_SAMPLE_COUNT
+        val minNextSampleTimeMillis = userCaptures.first().detectionStartTime.ms + samplingStepMillis * userCaptures.size
+        return currentTimestamp.ms >= minNextSampleTimeMillis
+    }
+
+    /**
+     * If any of the user captures are good, use them. If not, use the fallback capture.
+     */
+    private fun finishCapture(attemptNumber: Int) {
+        viewModelScope.launch {
+            sortedQualifyingCaptures = userCaptures
+                .filter { it.hasValidStatus() }
+                .sortedByDescending { it.face?.quality }
+                .take(samplesToKeep)
+                .ifEmpty { listOfNotNull(fallbackCapture) }
+
+            sendQualifyingAndFallbackCaptureEvents(attemptNumber)
+
+            capturingState.postValue(CapturingState.FINISHED)
+        }
+    }
+
+    private fun getFaceDetectionFromPotentialFace(
+        bitmap: Bitmap,
+        potentialFace: Face?,
+    ): FaceDetection = if (potentialFace == null) {
+        bitmap.recycle()
+        FaceDetection(
+            bitmap = bitmap,
+            face = null,
+            status = FaceDetection.Status.NOFACE,
+            detectionStartTime = timeHelper.now(),
+            detectionEndTime = timeHelper.now(),
+        )
+    } else {
+        getFaceDetection(bitmap, potentialFace)
+    }
+
+    private fun getFaceDetection(
+        bitmap: Bitmap,
+        potentialFace: Face,
+    ): FaceDetection {
+        val areaOccupied = potentialFace.relativeBoundingBox.area()
+        val status = when {
+            areaOccupied < faceTarget.areaRange.start -> FaceDetection.Status.TOOFAR
+            areaOccupied > faceTarget.areaRange.endInclusive -> FaceDetection.Status.TOOCLOSE
+            potentialFace.yaw !in faceTarget.yawTarget -> FaceDetection.Status.OFFYAW
+            potentialFace.roll !in faceTarget.rollTarget -> FaceDetection.Status.OFFROLL
+            shouldCheckQuality() && potentialFace.quality < qualityThreshold -> FaceDetection.Status.BAD_QUALITY
+            capturingState.value == CapturingState.CAPTURING -> FaceDetection.Status.VALID_CAPTURING
+            else -> FaceDetection.Status.VALID
+        }
+
+        return FaceDetection(
+            bitmap = bitmap,
+            face = potentialFace,
+            status = status,
+            detectionStartTime = timeHelper.now(),
+            detectionEndTime = timeHelper.now(),
+        )
+    }
+
+    private fun shouldCheckQuality() = !singleQualityFallbackCaptureRequired || fallbackCapture == null
+
+    /**
+     * While the user has not started the capture flow, we save fallback images. If the capture doesn't
+     * get any good images, at least one good image will be saved
+     */
+    private fun updateFallbackCaptureIfValid(faceDetection: FaceDetection) {
+        val fallbackQuality = fallbackCapture?.face?.quality ?: -1f // To ensure that detection is better with defaults
+        val detectionQuality = faceDetection.face?.quality ?: 0f
+
+        if (faceDetection.hasValidStatus() && detectionQuality >= fallbackQuality) {
+            fallbackCapture = faceDetection.apply { isFallback = true }
+            createFirstFallbackCaptureEvent(faceDetection)
+        }
+    }
+
+    /**
+     * Send a fallback capture event only once
+     */
+    private fun createFirstFallbackCaptureEvent(faceDetection: FaceDetection) {
+        if (shouldSendFallbackCaptureEvent.getAndSet(false)) {
+            eventReporter.addFallbackCaptureEvent(
+                fallbackCaptureEventStartTime,
+                faceDetection.detectionEndTime,
+            )
+        }
+    }
+
+    /**
+     * Since events are saved in a blocking way in [SimpleCaptureEventReporter.addCaptureEvents],
+     * to speed things up this method creates multiple async jobs and run them all in parallel.
+     *
+     * Auto-capture generates a number of sample captures that typically significantly exceeds samplesToKeep.
+     * Thus the non-qualifying samples are excluded to avoid excessive event data.
+     */
+    private fun sendQualifyingAndFallbackCaptureEvents(attemptNumber: Int) = runBlocking {
+        userCaptures
+            .asSequence()
+            .filter { it.hasValidStatus() }
+            .sortedByDescending { it.face?.quality }
+            .take(samplesToKeep)
+            .sortedBy { it.detectionStartTime }
+            .map { async { sendCaptureEvent(it, attemptNumber) } }
+            .plus(async { sendCaptureEvent(fallbackCapture, attemptNumber) })
+            .toList()
+            .awaitAll()
+    }
+
+    private suspend fun sendCaptureEvent(
+        faceDetection: FaceDetection?,
+        attemptNumber: Int,
+    ) {
+        if (faceDetection == null) return
+        eventReporter.addCaptureEvents(faceDetection, attemptNumber, qualityThreshold)
+    }
+
+    enum class CapturingState { NOT_STARTED, CAPTURING, FINISHED }
+
+    companion object {
+        private const val VALID_ROLL_DELTA = 15f
+        private const val VALID_YAW_DELTA = 30f
+        private const val AUTO_CAPTURE_VIEWFINDER_RESUME_DELAY_MS = 2000L
+        private const val AUTO_CAPTURE_IMAGING_DURATION_MS = 2000L
+        private const val AUTO_CAPTURE_SAMPLE_COUNT = 25
+    }
+}

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragmentViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragmentViewModel.kt
@@ -83,7 +83,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModel @Inject constructor(
         if (autoCaptureInitialDelayJob.isCompleted) {
             currentDetection.postValue(faceDetection)
             if (faceDetection.status == FaceDetection.Status.VALID
-                    && capturingState.value == CapturingState.NOT_STARTED) {
+                && capturingState.value == CapturingState.NOT_STARTED) {
                 capturingState.postValue(CapturingState.CAPTURING)
             }
         }
@@ -246,7 +246,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModel @Inject constructor(
         attemptNumber: Int,
     ) {
         if (faceDetection == null) return
-        eventReporter.addCaptureEvents(faceDetection, attemptNumber, qualityThreshold)
+        eventReporter.addCaptureEvents(faceDetection, attemptNumber, qualityThreshold, isAutoCapture = true)
     }
 
     enum class CapturingState { NOT_STARTED, CAPTURING, FINISHED }

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/README.md
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/README.md
@@ -1,0 +1,11 @@
+# Face auto-capture
+
+This `livefeedbackautocapture` package is similar to the manual capture [livefeedback](../livefeedback/README.md) one, except:
+* Auto-capture has a preparation period from the moment `LiveFeedbackAutoCaptureFragment` becomes visible and for `LiveFeedbackAutoCaptureFragmentViewModel.AUTO_CAPTURE_VIEWFINDER_RESUME_DELAY_MS` amount of time. This helps prevent startling the user with a too early start of auto-capture - before the user would aim the viewfinder at a face.
+* The auto-capture imaging progress starts when a qualifying face image appears in the viewfinder, and lasts for `LiveFeedbackAutoCaptureFragmentViewModel.AUTO_CAPTURE_IMAGING_DURATION_MS` amount of time.
+* The number of images auto-captured is limited to `LiveFeedbackAutoCaptureFragmentViewModel.AUTO_CAPTURE_SAMPLE_COUNT`. Imaging is done by sampling the frames over even periods of time within the auto-capture imaging time period.
+* The number of images to accept is `LiveFeedbackAutoCaptureFragmentViewModel.samplesToKeep` - similarly to `LiveFeedbackFragmentViewModel.samplesToCapture`. The best quality sampled images are selected to keep.
+* The kept sampled images and the fallback image are included in the capture events - unlike in `LiveFeedbackFragmentViewModel` where all conventionally captured and the fallback images are included.
+* The capture events have an `isAutoCapture` flag value of `true`.
+
+The reason for having this package as a near-copy of `livefeedback` is to keep both implementations independent but similar. The layout for `LiveFeedbackAutoCaptureFragment` is `fragment_live_feedback_auto_capture.xml`.

--- a/face/capture/src/main/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporter.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporter.kt
@@ -51,6 +51,7 @@ internal class SimpleCaptureEventReporter @Inject constructor(
         faceDetection: FaceDetection,
         attempt: Int,
         qualityThreshold: Float,
+        isAutoCapture: Boolean = false,
     ) {
         val faceCaptureEvent = FaceCaptureEvent(
             faceDetection.detectionStartTime,
@@ -58,6 +59,7 @@ internal class SimpleCaptureEventReporter @Inject constructor(
             attempt,
             qualityThreshold,
             mapDetectionStatusToPayloadResult(faceDetection),
+            isAutoCapture = isAutoCapture,
             faceDetection.isFallback,
             mapDetectionToCapturePayloadFace(faceDetection),
             payloadId = faceDetection.id,

--- a/face/capture/src/main/res/layout-land/fragment_live_feedback_auto_capture.xml
+++ b/face/capture/src/main/res/layout-land/fragment_live_feedback_auto_capture.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clipChildren="false"
+    tools:background="#66000000"
+    tools:ignore="ContentDescription">
+
+    <androidx.camera.view.PreviewView
+        android:id="@+id/face_capture_camera"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:keepScreenOn="true" />
+
+    <com.simprints.face.capture.screens.livefeedback.views.CameraTargetOverlay
+        android:id="@+id/capture_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <com.simprints.face.capture.screens.livefeedback.views.DashedCircularProgress
+        android:id="@+id/capture_progress"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:indeterminate="false"
+        android:visibility="gone"
+        app:dcp_color="@color/simprints_green_light"
+        app:dcp_max="10"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintHeight_percent="@dimen/capture_target_size_percent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="@dimen/margin_default"
+        android:layout_marginHorizontal="@dimen/margin_default"
+        android:gravity="center|bottom"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/capture_progress">
+
+        <TextView
+            android:id="@+id/capture_feedback_txt_explanation"
+            style="@style/Text.Headline5.White"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_default"
+            android:gravity="center"
+            tools:text="Move closer" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/capture_feedback_btn"
+            style="@style/Text.Headline6.Bold"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/margin_default"
+            android:background="@drawable/feedback_chip_white"
+            android:checkable="true"
+            android:gravity="center"
+            android:padding="@dimen/padding_default"
+            android:text="@string/face_capture_title_previewing"
+            android:textAlignment="center"
+            android:textColor="@color/feedback_chip_text"
+            app:backgroundTint="@null"
+            app:iconGravity="textStart"
+            app:iconTint="@null" />
+    </LinearLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/capture_feedback_permission_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="@string/face_capture_permission_action"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/face/capture/src/main/res/layout/fragment_live_feedback_auto_capture.xml
+++ b/face/capture/src/main/res/layout/fragment_live_feedback_auto_capture.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clipChildren="false"
+    tools:background="#66000000"
+    tools:ignore="ContentDescription">
+
+    <androidx.camera.view.PreviewView
+        android:id="@+id/face_capture_camera"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:keepScreenOn="true" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/capture_guide_frame"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="@dimen/guideline_margin_percent" />
+
+    <com.simprints.face.capture.screens.livefeedback.views.CameraTargetOverlay
+        android:id="@+id/capture_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <com.simprints.face.capture.screens.livefeedback.views.DashedCircularProgress
+        android:id="@+id/capture_progress"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:indeterminate="false"
+        android:visibility="invisible"
+        app:dcp_color="@color/simprints_green_light"
+        app:dcp_max="10"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/capture_guide_frame"
+        app:layout_constraintWidth_percent="@dimen/capture_target_size_percent"
+        tools:visibility="visible" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/capture_feedback_btn"
+        style="@style/Text.Headline6.Bold"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin_huge"
+        android:background="@drawable/feedback_chip_white"
+        android:checkable="true"
+        android:padding="@dimen/padding_default"
+        android:text="@string/face_capture_title_previewing"
+        android:textAlignment="center"
+        android:textColor="@color/feedback_chip_text"
+        app:backgroundTint="@null"
+        app:iconGravity="textStart"
+        app:iconTint="@null"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/capture_progress" />
+
+    <TextView
+        android:id="@+id/capture_feedback_txt_explanation"
+        style="@style/Text.Headline5.White"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:gravity="center"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/capture_feedback_btn"
+        tools:text="Move closer" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/capture_feedback_permission_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/face_capture_permission_action"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/capture_feedback_txt_explanation"
+        tools:visibility="visible" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/face/capture/src/main/res/navigation/graph_face_capture.xml
+++ b/face/capture/src/main/res/navigation/graph_face_capture.xml
@@ -11,6 +11,9 @@
         <argument
             android:name="samplesToCapture"
             app:argType="integer" />
+        <argument
+            android:name="isAutoCapture"
+            app:argType="boolean" />
     </fragment>
 
     <include app:graph="@navigation/graph_alert" />

--- a/face/capture/src/main/res/navigation/graph_face_capture_auto_internal.xml
+++ b/face/capture/src/main/res/navigation/graph_face_capture_auto_internal.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/graph_face_capture_auto_internal"
+    app:startDestination="@id/facePreparationFragment">
+
+    <fragment
+        android:id="@+id/facePreparationFragment"
+        android:name="com.simprints.face.capture.screens.preparation.PreparationFragment"
+        android:label="fragment_preparation"
+        tools:layout="@layout/fragment_preparation">
+        <action
+            android:id="@+id/action_facePreparationFragment_to_faceLiveFeedbackFragment"
+            app:destination="@id/faceLiveFeedbackFragment"
+            app:popUpTo="@+id/graph_face_capture_auto_internal"
+            app:popUpToInclusive="true" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/faceLiveFeedbackFragment"
+        android:name="com.simprints.face.capture.screens.livefeedbackautocapture.LiveFeedbackAutoCaptureFragment"
+        android:label="FaceDetectionAutoCaptureFragment"
+        tools:layout="@layout/fragment_live_feedback_auto_capture">
+        <action
+            android:id="@+id/action_faceLiveFeedbackFragment_to_faceConfirmationFragment"
+            app:destination="@id/faceConfirmationFragment"
+            app:popUpTo="@+id/graph_face_capture_auto_internal"
+            app:popUpToInclusive="true" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/faceConfirmationFragment"
+        android:name="com.simprints.face.capture.screens.confirmation.ConfirmationFragment"
+        android:label="ConfirmationFragment"
+        tools:layout="@layout/fragment_confirmation">
+        <action
+            android:id="@+id/action_faceConfirmationFragment_to_faceLiveFeedbackFragment"
+            app:destination="@id/faceLiveFeedbackFragment"
+            app:popUpTo="@+id/graph_face_capture_auto_internal"
+            app:popUpToInclusive="true" />
+    </fragment>
+
+    <action
+        android:id="@+id/action_global_faceLiveFeedback"
+        app:destination="@+id/faceLiveFeedbackFragment"
+        app:popUpTo="@+id/graph_face_capture_auto_internal"
+        app:popUpToInclusive="true" />
+
+</navigation>

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
@@ -1,0 +1,256 @@
+package com.simprints.face.capture.screens.livefeedbackautocapture
+
+import android.graphics.Bitmap
+import android.graphics.Rect
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.simprints.core.tools.time.TimeHelper
+import com.simprints.core.tools.time.Timestamp
+import com.simprints.face.capture.models.FaceDetection
+import com.simprints.face.capture.usecases.SimpleCaptureEventReporter
+import com.simprints.face.infra.basebiosdk.detection.Face
+import com.simprints.face.infra.basebiosdk.detection.FaceDetector
+import com.simprints.face.infra.biosdkresolver.ResolveFaceBioSdkUseCase
+import com.simprints.infra.config.store.models.experimental
+import com.simprints.infra.config.sync.ConfigManager
+import com.simprints.testtools.common.coroutines.TestCoroutineRule
+import com.simprints.testtools.common.livedata.testObserver
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.justRun
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.random.Random
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val testCoroutineRule = TestCoroutineRule()
+
+    @MockK
+    lateinit var faceDetector: FaceDetector
+
+    @MockK
+    lateinit var frame: Bitmap
+
+    @MockK
+    lateinit var previewFrame: Bitmap
+
+    @MockK
+    lateinit var configManager: ConfigManager
+
+    @MockK
+    lateinit var eventReporter: SimpleCaptureEventReporter
+
+    @MockK
+    lateinit var timeHelper: TimeHelper
+
+    private lateinit var viewModel: LiveFeedbackAutoCaptureFragmentViewModel
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        coEvery { configManager.getProjectConfiguration().face?.qualityThreshold } returns QUALITY_THRESHOLD
+        coEvery { configManager.getProjectConfiguration().experimental().singleQualityFallbackRequired } returns false
+        every { timeHelper.now() } returnsMany (0..100L)
+            .map { Timestamp(it * AUTO_CAPTURE_IMAGING_DURATION_MS / AUTO_CAPTURE_SAMPLE_COUNT) }
+        justRun { previewFrame.recycle() }
+        val resolveFaceBioSdkUseCase = mockk<ResolveFaceBioSdkUseCase> {
+            coEvery { this@mockk.invoke() } returns mockk {
+                every { detector } returns faceDetector
+            }
+        }
+
+        viewModel = LiveFeedbackAutoCaptureFragmentViewModel(
+            resolveFaceBioSdkUseCase,
+            configManager,
+            eventReporter,
+            timeHelper,
+        )
+    }
+
+    @Test
+    fun `Process fallback image when valid face correctly but not started capture`() = runTest {
+        coEvery { faceDetector.analyze(frame) } returns getFace()
+
+        viewModel.initCapture(1, 0)
+        viewModel.process(frame) // a fallback image frame before the preparation delay elapses
+        advanceTimeBy(AUTO_CAPTURE_VIEWFINDER_RESUME_DELAY_MS + 1)
+        viewModel.process(frame)
+
+        val currentDetection = viewModel.currentDetection.testObserver()
+        assertThat(currentDetection.observedValues.last()?.hasValidStatus()).isEqualTo(true)
+
+        coVerify { eventReporter.addFallbackCaptureEvent(any(), any()) }
+    }
+
+    @Test
+    fun `Process valid face correctly`() = runTest {
+        coEvery { faceDetector.analyze(frame) } returns getFace()
+
+        viewModel.initCapture(1, 0)
+        advanceTimeBy(AUTO_CAPTURE_VIEWFINDER_RESUME_DELAY_MS + 1)
+        viewModel.process(frame)
+        // imaging frame pacing
+        (1..AUTO_CAPTURE_SAMPLE_COUNT).forEach {
+            viewModel.process(frame)
+            advanceTimeBy(AUTO_CAPTURE_IMAGING_DURATION_MS / AUTO_CAPTURE_SAMPLE_COUNT)
+        }
+
+        val currentDetection = viewModel.currentDetection.testObserver()
+        assertThat(currentDetection.observedValues.last()?.hasValidStatus()).isEqualTo(true)
+
+        coVerify { eventReporter.addCaptureEvents(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `Process invalid faces correctly`() = runTest {
+        val smallFace: Face = getFace(Rect(0, 0, 30, 30))
+        val bigFace: Face = getFace(Rect(0, 0, 80, 80))
+        val yawedFace: Face = getFace(yaw = 45f)
+        val rolledFace: Face = getFace(roll = 45f)
+        val badQuality: Face = getFace(quality = -2f)
+        val noFace = null
+
+        every { faceDetector.analyze(frame) } returnsMany listOf(
+            smallFace,
+            bigFace,
+            yawedFace,
+            rolledFace,
+            badQuality,
+            noFace,
+        )
+
+        val detections = viewModel.currentDetection.testObserver()
+        viewModel.initCapture(2, 0)
+        advanceTimeBy(AUTO_CAPTURE_VIEWFINDER_RESUME_DELAY_MS + 1)
+
+        viewModel.process(frame)
+        viewModel.process(frame)
+        viewModel.process(frame)
+        viewModel.process(frame)
+        viewModel.process(frame)
+        viewModel.process(frame)
+
+        detections.observedValues.let {
+            assertThat(it[0]?.status).isEqualTo(FaceDetection.Status.TOOFAR)
+            assertThat(it[1]?.status).isEqualTo(FaceDetection.Status.TOOCLOSE)
+            assertThat(it[2]?.status).isEqualTo(FaceDetection.Status.OFFYAW)
+            assertThat(it[3]?.status).isEqualTo(FaceDetection.Status.OFFROLL)
+            assertThat(it[4]?.status).isEqualTo(FaceDetection.Status.BAD_QUALITY)
+            assertThat(it[5]?.status).isEqualTo(FaceDetection.Status.NOFACE)
+        }
+
+        coVerify(exactly = 0) { eventReporter.addCaptureEvents(any(), any(), any()) }
+    }
+
+    @Test
+    fun `Process invalid faces after single fallback correctly`() = runTest {
+        val validFace: Face = getFace()
+        val badQuality: Face = getFace(quality = -2f)
+
+        coEvery { configManager.getProjectConfiguration().experimental().singleQualityFallbackRequired } returns true
+
+        every { faceDetector.analyze(frame) } returnsMany listOf(
+            badQuality, // not a fallback image due to bad quality
+            validFace, // fallback image
+            validFace, // 1st capture
+            badQuality, // 2nd capture
+        )
+
+        val detections = viewModel.currentDetection.testObserver()
+        viewModel.initCapture(1, 0)
+        // fallback image frames before the preparation delay elapses
+        viewModel.process(frame)
+        viewModel.process(frame)
+        advanceTimeBy(AUTO_CAPTURE_VIEWFINDER_RESUME_DELAY_MS + 1)
+        viewModel.process(frame)
+        viewModel.process(frame)
+
+        detections.observedValues.let {
+            // fallback image frame wasn't observed during preparation delay
+            assertThat(it[0]?.hasValidStatus()).isEqualTo(true)
+            assertThat(it[1]?.hasValidStatus()).isEqualTo(true)
+        }
+    }
+
+    @Test
+    fun `Save all valid captures without fallback image`() = runTest {
+        val validFace: Face = getFace()
+        every { faceDetector.analyze(frame) } returns validFace
+
+        val currentDetectionObserver = viewModel.currentDetection.testObserver()
+        val capturingStateObserver = viewModel.capturingState.testObserver()
+        viewModel.initCapture(2, 0)
+        viewModel.process(frame) // won't be observed during the preparation phase
+        advanceTimeBy(AUTO_CAPTURE_VIEWFINDER_RESUME_DELAY_MS + 1)
+        // imaging frame pacing
+        (1..AUTO_CAPTURE_SAMPLE_COUNT).forEach {
+            viewModel.process(frame)
+            advanceTimeBy(AUTO_CAPTURE_IMAGING_DURATION_MS / AUTO_CAPTURE_SAMPLE_COUNT)
+        }
+
+        currentDetectionObserver.observedValues.let {
+            // 1st frame wasn't observed during preparation delay
+            assertThat(it[0]?.hasValidStatus()).isEqualTo(true)
+            assertThat(it[1]?.hasValidStatus()).isEqualTo(true)
+        }
+
+        capturingStateObserver.observedValues.let {
+            assertThat(it[0]).isEqualTo(LiveFeedbackAutoCaptureFragmentViewModel.CapturingState.NOT_STARTED)
+            assertThat(it[1]).isEqualTo(LiveFeedbackAutoCaptureFragmentViewModel.CapturingState.CAPTURING)
+            assertThat(it[2]).isEqualTo(LiveFeedbackAutoCaptureFragmentViewModel.CapturingState.FINISHED)
+        }
+
+        assertThat(viewModel.userCaptures.size).isEqualTo(AUTO_CAPTURE_SAMPLE_COUNT)
+        viewModel.userCaptures.let {
+            with(it[0]) {
+                assertThat(hasValidStatus()).isEqualTo(true)
+                assertThat(face).isEqualTo(validFace)
+                assertThat(isFallback).isEqualTo(false)
+            }
+
+            assertThat(it[1].isFallback).isEqualTo(false)
+        }
+
+        with(viewModel.sortedQualifyingCaptures) {
+            assertThat(size).isEqualTo(2)
+            assertThat(get(0).face).isEqualTo(validFace)
+            assertThat(get(0).isFallback).isEqualTo(false)
+            assertThat(get(1).face).isEqualTo(validFace)
+            assertThat(get(1).isFallback).isEqualTo(false)
+        }
+
+        coVerify { eventReporter.addFallbackCaptureEvent(any(), any()) }
+        coVerify(exactly = 3) { eventReporter.addCaptureEvents(any(), any(), any(), any()) }
+    }
+
+    private fun getFace(
+        rect: Rect = Rect(0, 0, 60, 60),
+        quality: Float = 1f,
+        yaw: Float = 0f,
+        roll: Float = 0f,
+    ) = Face(100, 100, rect, yaw, roll, quality, Random.nextBytes(20), "format")
+
+    companion object {
+        private const val QUALITY_THRESHOLD = -1f
+        private const val AUTO_CAPTURE_VIEWFINDER_RESUME_DELAY_MS = 2000L
+        private const val AUTO_CAPTURE_IMAGING_DURATION_MS = 2000L
+        private const val AUTO_CAPTURE_SAMPLE_COUNT = 25
+    }
+}

--- a/face/capture/src/test/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporterTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporterTest.kt
@@ -167,6 +167,21 @@ class SimpleCaptureEventReporterTest {
         }
     }
 
+    @Test
+    fun `Adds capture event with correct auto-capture flag`() = runTest {
+        listOf(true, false).forEach { isAutoCapture ->
+            reporter.addCaptureEvents(getDetection(FaceDetection.Status.VALID), 1, 0.5f, isAutoCapture)
+            coVerify {
+                eventRepository.addOrUpdateEvent(
+                    withArg {
+                        assertThat(it).isInstanceOf(FaceCaptureEvent::class.java)
+                        assertThat((it.payload as FaceCaptureEvent.FaceCapturePayload).isAutoCapture).isEqualTo(isAutoCapture)
+                    },
+                )
+            }
+        }
+    }
+
     private fun getDetection(status: FaceDetection.Status) =
         FaceDetection(mockk(), getFace(), status, mockk(), Timestamp(1L), false, "id", Timestamp(1L))
 

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/FaceAutoCaptureEligibilityUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/FaceAutoCaptureEligibilityUseCase.kt
@@ -1,0 +1,44 @@
+package com.simprints.feature.orchestrator.usecases
+
+import com.simprints.core.DeviceID
+import javax.inject.Inject
+
+internal class FaceAutoCaptureEligibilityUseCase @Inject constructor(
+    @DeviceID private val deviceID: String,
+) {
+
+    /*
+        Face auto-capture configuration example - enabled for device1 and device2:
+        ```json
+        "faceAutoCapture": {
+            "enabled": true,
+            "deviceIdFilter": ["device1", "device2"]
+        }
+        ```
+        If no deviceIdFilter: entire device pool eligible.
+        If no config at all: no auto-capture.
+     */
+    operator fun invoke(
+        faceAutoCaptureConfig: Map<String, *>?,
+    ): Boolean {
+        if (faceAutoCaptureConfig == null) {
+            return false
+        }
+        if (faceAutoCaptureConfig[FACE_AUTO_CAPTURE_ENABLED] != true) {
+            return false
+        }
+        if (faceAutoCaptureConfig[FACE_AUTO_CAPTURE_DEVICE_ID_FILTER] == null) {
+            return true
+        }
+        val faceAutoCaptureDeviceIdsFiltered: List<String> =
+            (faceAutoCaptureConfig[FACE_AUTO_CAPTURE_DEVICE_ID_FILTER] as? List<*>)
+                ?.mapNotNull { it as? String }
+                ?: emptyList()
+        return deviceID in faceAutoCaptureDeviceIdsFiltered
+    }
+
+    private companion object {
+        private const val FACE_AUTO_CAPTURE_ENABLED = "enabled"
+        private const val FACE_AUTO_CAPTURE_DEVICE_ID_FILTER = "deviceIdFilter"
+    }
+}

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCase.kt
@@ -13,6 +13,7 @@ import com.simprints.feature.orchestrator.exceptions.SubjectAgeNotSupportedExcep
 import com.simprints.feature.orchestrator.steps.MatchStepStubPayload
 import com.simprints.feature.orchestrator.steps.Step
 import com.simprints.feature.orchestrator.steps.StepId
+import com.simprints.feature.orchestrator.usecases.FaceAutoCaptureEligibilityUseCase
 import com.simprints.feature.orchestrator.usecases.MapStepsForLastBiometricEnrolUseCase
 import com.simprints.feature.selectagegroup.SelectSubjectAgeGroupContract
 import com.simprints.feature.selectsubject.SelectSubjectContract
@@ -39,6 +40,7 @@ internal class BuildStepsUseCase @Inject constructor(
     private val buildMatcherSubjectQuery: BuildMatcherSubjectQueryUseCase,
     private val cache: OrchestratorCache,
     private val mapStepsForLastBiometrics: MapStepsForLastBiometricEnrolUseCase,
+    private val faceAutoCaptureEligibility: FaceAutoCaptureEligibilityUseCase,
 ) {
     fun build(
         action: ActionRequest,
@@ -368,11 +370,12 @@ internal class BuildStepsUseCase @Inject constructor(
                 // Face bio SDK is currently ignored until we add a second one
                 // TODO: samplesToCapture can be read directly from FaceCapture
                 val samplesToCapture = projectConfiguration.face?.nbOfImagesToCapture ?: 0
+                val isAutoCapture = faceAutoCaptureEligibility(projectConfiguration.experimental().faceAutoCaptureConfig)
                 Step(
                     id = StepId.FACE_CAPTURE,
                     navigationActionId = R.id.action_orchestratorFragment_to_faceCapture,
                     destinationId = FaceCaptureContract.DESTINATION,
-                    payload = FaceCaptureContract.getArgs(samplesToCapture),
+                    payload = FaceCaptureContract.getArgs(samplesToCapture, isAutoCapture),
                 )
             }
         }

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/FaceAutoCaptureEligibilityUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/FaceAutoCaptureEligibilityUseCaseTest.kt
@@ -1,0 +1,81 @@
+package com.simprints.feature.orchestrator.usecases
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class FaceAutoCaptureEligibilityUseCaseTest {
+
+    private val deviceId = "test_device"
+    private val useCase = FaceAutoCaptureEligibilityUseCase(deviceId)
+
+    @Test
+    fun `should return false when config is null`() {
+        assertThat(useCase(null)).isFalse()
+    }
+
+    @Test
+    fun `should return false when config is empty`() {
+        assertThat(useCase(emptyMap<String, Any>())).isFalse()
+    }
+
+    @Test
+    fun `should return false when enabled flag is false`() {
+        val config = mapOf(
+            "enabled" to false,
+        )
+        assertThat(useCase(config)).isFalse()
+    }
+
+    @Test
+    fun `should return false when enabled flag is invalid type`() {
+        val config = mapOf(
+            "enabled" to "not_a_boolean",
+        )
+        assertThat(useCase(config)).isFalse()
+    }
+
+    @Test
+    fun `should return true when enabled is true and no device filter`() {
+        val config = mapOf(
+            "enabled" to true,
+        )
+        assertThat(useCase(config)).isTrue()
+    }
+
+    @Test
+    fun `should return true when enabled is true and device is in filter`() {
+        val config = mapOf(
+            "enabled" to true,
+            "deviceIdFilter" to listOf(deviceId, "other_device"),
+        )
+        assertThat(useCase(config)).isTrue()
+    }
+
+    @Test
+    fun `should return false when enabled is true but device not in filter`() {
+        val config = mapOf(
+            "enabled" to true,
+            "deviceIdFilter" to listOf("other_device"),
+        )
+        assertThat(useCase(config)).isFalse()
+    }
+
+    @Test
+    fun `should return false when enabled is true but filter is empty`() {
+        val config = mapOf(
+            "enabled" to true,
+            "deviceIdFilter" to emptyList<String>(),
+        )
+        assertThat(useCase(config)).isFalse()
+    }
+
+    @Test
+    fun `should return false when enabled is true but filter is incorrect type`() {
+        val config = mapOf(
+            "enabled" to true,
+            "deviceIdFilter" to "not_a_list",
+        )
+        assertThat(useCase(config)).isFalse()
+    }
+
+}

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.simprints.feature.orchestrator.cache.OrchestratorCache
 import com.simprints.feature.orchestrator.exceptions.SubjectAgeNotSupportedException
 import com.simprints.feature.orchestrator.steps.Step
 import com.simprints.feature.orchestrator.steps.StepId
+import com.simprints.feature.orchestrator.usecases.FaceAutoCaptureEligibilityUseCase
 import com.simprints.feature.orchestrator.usecases.MapStepsForLastBiometricEnrolUseCase
 import com.simprints.infra.config.store.models.AgeGroup
 import com.simprints.infra.config.store.models.FaceConfiguration
@@ -15,12 +16,9 @@ import com.simprints.infra.config.store.models.GeneralConfiguration.Modality
 import com.simprints.infra.config.store.models.ProjectConfiguration
 import com.simprints.infra.config.store.models.experimental
 import com.simprints.infra.orchestration.data.ActionRequest
-import io.mockk.MockKAnnotations
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.RelaxedMockK
-import io.mockk.mockk
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 
@@ -35,6 +33,9 @@ class BuildStepsUseCaseTest {
     private lateinit var mapStepsForLastBiometrics: MapStepsForLastBiometricEnrolUseCase
 
     @RelaxedMockK
+    private lateinit var faceAutoCaptureEligibility: FaceAutoCaptureEligibilityUseCase
+
+    @RelaxedMockK
     private lateinit var secugenSimMatcher: FingerprintConfiguration.FingerprintSdkConfiguration
 
     @RelaxedMockK
@@ -45,7 +46,7 @@ class BuildStepsUseCaseTest {
     @Before
     fun setup() {
         MockKAnnotations.init(this)
-        useCase = BuildStepsUseCase(buildMatcherSubjectQuery, cache, mapStepsForLastBiometrics)
+        useCase = BuildStepsUseCase(buildMatcherSubjectQuery, cache, mapStepsForLastBiometrics, faceAutoCaptureEligibility)
     }
 
     private fun mockCommonProjectConfiguration(): ProjectConfiguration {

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
@@ -19,8 +19,16 @@ data class ExperimentalProjectConfiguration(
             ?.let { it as? Boolean }
             .let { it == true }
 
+    val faceAutoCaptureConfig: Map<String, *>
+        get() = customConfig
+            ?.get(FACE_AUTO_CAPTURE)
+            ?.let { it as? Map<*, *> }
+            ?.let { map -> map.mapKeys { it.key.toString() } }
+            ?: emptyMap<String, String>()
+
     companion object {
         internal const val ENABLE_ID_POOL_VALIDATION = "validateIdentificationPool"
         internal const val SINGLE_GOOD_QUALITY_FALLBACK_REQUIRED = "singleQualityFallbackRequired"
+        internal const val FACE_AUTO_CAPTURE = "faceAutoCapture"
     }
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
@@ -3,6 +3,7 @@ package com.simprints.infra.config.store.models
 import com.google.common.truth.Truth.assertThat
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.ENABLE_ID_POOL_VALIDATION
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.SINGLE_GOOD_QUALITY_FALLBACK_REQUIRED
+import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.FACE_AUTO_CAPTURE
 import org.junit.Test
 
 internal class ExperimentalProjectConfigurationTest {
@@ -35,6 +36,21 @@ internal class ExperimentalProjectConfigurationTest {
             mapOf(SINGLE_GOOD_QUALITY_FALLBACK_REQUIRED to true) to true,
         ).forEach { (config, result) ->
             assertThat(ExperimentalProjectConfiguration(config).singleQualityFallbackRequired).isEqualTo(result)
+        }
+    }
+
+    @Test
+    fun `check face auto capture config correctly`() {
+        val autoCaptureConfigMap = mapOf("key" to "value")
+        mapOf<Map<String, Any>, Map<String, *>>(
+            // Value not present
+            emptyMap<String, Any>() to emptyMap<String, String>(),
+            // Value present and not a map
+            mapOf(FACE_AUTO_CAPTURE to "not a map") to emptyMap<String, String>(),
+            // Value present and a map
+            mapOf(FACE_AUTO_CAPTURE to autoCaptureConfigMap) to autoCaptureConfigMap,
+        ).forEach { (config, result) ->
+            assertThat(ExperimentalProjectConfiguration(config).faceAutoCaptureConfig).isEqualTo(result)
         }
     }
 }

--- a/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
+++ b/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
@@ -244,6 +244,7 @@ fun createFaceCaptureEvent() = FaceCaptureEvent(
     attemptNb = 0,
     qualityThreshold = 1F,
     result = FaceCaptureEvent.FaceCapturePayload.Result.VALID,
+    isAutoCapture = false,
     isFallback = true,
     face = FaceCaptureEvent.FaceCapturePayload.Face(0F, 1F, 2F, FACE_TEMPLATE_FORMAT),
 )

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureEvent.kt
@@ -25,6 +25,7 @@ data class FaceCaptureEvent(
         attemptNb: Int,
         qualityThreshold: Float,
         result: FaceCapturePayload.Result,
+        isAutoCapture: Boolean,
         isFallback: Boolean,
         face: Face?,
         id: String = randomUUID(),
@@ -38,6 +39,7 @@ data class FaceCaptureEvent(
             attemptNb = attemptNb,
             qualityThreshold = qualityThreshold,
             result = result,
+            isAutoCapture = isAutoCapture,
             isFallback = isFallback,
             face = face,
             id = payloadId,
@@ -58,11 +60,12 @@ data class FaceCaptureEvent(
         val attemptNb: Int,
         val qualityThreshold: Float,
         val result: Result,
+        val isAutoCapture: Boolean,
         val isFallback: Boolean,
         val face: Face?,
         override val type: EventType = FACE_CAPTURE,
     ) : EventPayload() {
-        override fun toSafeString(): String = "result: $result, attempt nr: $attemptNb, fallback: $isFallback, " +
+        override fun toSafeString(): String = "result: $result, attempt nr: $attemptNb, auto-capture: $isAutoCapture, fallback: $isFallback, " +
             "quality: ${face?.quality},  format: ${face?.format}"
 
         @Keep

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/EventPayloadTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/EventPayloadTest.kt
@@ -140,6 +140,7 @@ class EventPayloadTest {
             attemptNb = 0,
             qualityThreshold = 1F,
             result = FaceCaptureEvent.FaceCapturePayload.Result.VALID,
+            isAutoCapture = false,
             isFallback = true,
             face = FaceCaptureEvent.FaceCapturePayload.Face(0F, 1F, 2F, FACE_TEMPLATE_FORMAT),
         ),

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureEventTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureEventTest.kt
@@ -18,6 +18,7 @@ class FaceCaptureEventTest {
             0,
             1F,
             FaceCaptureEvent.FaceCapturePayload.Result.VALID,
+            false,
             true,
             faceArg,
         )


### PR DESCRIPTION
# Face auto-capture

Jira: MS-716

## UX

Same as the regular manual capture, except:

#### 1. When face image of good quality appears in viewfinder:

| for manual capture: | for auto-capture: |
|---|---|
| Green button appears - press to capture | Capture starts automatically and completes in 2 seconds |

#### 2. Initial hold-off, to let user aim the viewfinder:

* First 2 seconds when viewfinder starts
* Also if user clicks away from Simprints ID and returns


## Configuration

> `<Project>` -> `Configurations` -> `Custom`

Face auto-capture configuration example - enabled for device1 and device2:

```json
"faceAutoCapture": {
    "enabled": true,
    "deviceIdFilter": ["device1", "device2"]
}
```

If no `deviceIdFilter`: entire device pool eligible.

If no `faceAutoCapture` config at all: no auto-capture.


## Event data

Same as for regular manual capture, except:
* `isAutoCapture: true` included with the capture events
* Events registered only for qualifying images


## Technical details

#### Live feedback view & viewmodel

The `livefeedbackautocapture` package is similar to the conventional capture `livefeedback` one, except:
* Auto-capture has a preparation period from the moment `LiveFeedbackAutoCaptureFragment` becomes visible and for `LiveFeedbackAutoCaptureFragmentViewModel.AUTO_CAPTURE_VIEWFINDER_RESUME_DELAY_MS` amount of time. This helps prevent startling the user with a too early start of auto-capture - before the user would aim the viewfinder at a face.
* The auto-capture imaging progress starts when a qualifying face image appears in the viewfinder, and lasts for `LiveFeedbackAutoCaptureFragmentViewModel.AUTO_CAPTURE_IMAGING_DURATION_MS` amount of time.
* The number of images auto-captured is limited to `LiveFeedbackAutoCaptureFragmentViewModel.AUTO_CAPTURE_SAMPLE_COUNT`. Imaging is done by sampling the frames over even periods of time within the auto-capture imaging time period.
* The number of images to accept is `LiveFeedbackAutoCaptureFragmentViewModel.samplesToKeep` - similarly to `LiveFeedbackFragmentViewModel.samplesToCapture`. The best quality sampled images are selected to keep.
* The kept sampled images and the fallback image are included in the capture events - unlike in `LiveFeedbackFragmentViewModel` where all conventionally captured and the fallback images are included.
* The capture events have an `isAutoCapture` flag value of `true`.

The reason for having this package as a near-copy of `livefeedback` is to keep both implementations independent but similar. The layout for `LiveFeedbackAutoCaptureFragment` is `fragment_live_feedback_auto_capture.xml`.

#### Decision-making between manual and auto-capture

If the project is configured to have auto-capture enabled on the current device ID (or on all devices):
* An `isAutoCapture` flag, included into `face/capture/src/main/java/com/simprints/face/capture/FaceCaptureContract` at the face capture step at the orchestrator in `feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCase`, in enabled.
* The `face/capture/src/main/java/com/simprints/face/capture/screens/controller/FaceCaptureControllerFragment` reads the auto-capture flag from the `FaceCaptureContract` and selects the appropriate navigation graph.
* The auto-capture `graph_face_capture_auto_internal` navigation graph is similar to the manual `graph_face_capture_internal` one, except the regular live feedback fragment is replaced with the similar auto-capture one (see description above).