### PR TITLE
CoSync: adding explicit class types to the tokenizable fields. Removing extra filtering

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/usecases/GetEnrolmentCreationEventForSubjectUseCase.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/usecases/GetEnrolmentCreationEventForSubjectUseCase.kt
@@ -1,5 +1,9 @@
 package com.simprints.feature.clientapi.usecases
 
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.simprints.core.domain.tokenization.TokenizableString
+import com.simprints.core.domain.tokenization.serialization.TokenizationClassNameDeserializer
+import com.simprints.core.domain.tokenization.serialization.TokenizationClassNameSerializer
 import com.simprints.core.tools.json.JsonHelper
 import com.simprints.core.tools.utils.EncodingUtils
 import com.simprints.infra.config.store.models.canCoSyncAllData
@@ -34,7 +38,7 @@ internal class GetEnrolmentCreationEventForSubjectUseCase @Inject constructor(
             ?.fromSubjectToEnrolmentCreationEvent()
             ?: return null
 
-        return jsonHelper.toJson(CoSyncEnrolmentRecordEvents(listOf(recordCreationEvent)))
+        return jsonHelper.toJson(CoSyncEnrolmentRecordEvents(listOf(recordCreationEvent)), dbSerializationModule)
     }
 
     private fun Subject.fromSubjectToEnrolmentCreationEvent() = EnrolmentRecordCreationEvent(
@@ -44,4 +48,11 @@ internal class GetEnrolmentCreationEventForSubjectUseCase @Inject constructor(
         attendantId,
         EnrolmentRecordCreationEvent.buildBiometricReferences(fingerprintSamples, faceSamples, encoder),
     )
+
+    companion object {
+        val dbSerializationModule = SimpleModule().apply {
+            addSerializer(TokenizableString::class.java, TokenizationClassNameSerializer())
+            addDeserializer(TokenizableString::class.java, TokenizationClassNameDeserializer())
+        }
+    }
 }


### PR DESCRIPTION
- From now on, tokenizable strings in `subjectActions` JSON specify the explicit class type: `TokenizableString.Raw` or `TokenizableString.Tokenized`. This is done by passing a serializer to the `GetEnrolmentCreationEventForSubjectUseCase`.
- Removing extra filtering from the CommCare data source. Sometimes, the tokenizable fields in the `query.*` and `event.payload.*` classes are incorrectly treated as tokenized/not tokenized, and therefore the value comparison returns false negatives. By removing the filter we slightly increase the validation pool but that should not affect the performance because the most resource-intensive operation is the JSON parsing, and the filtration is happening after the JSON is parsed.