### PR TITLE
Move the built suffix into metadata part of version name

### DIFF
--- a/.github/workflows/reusable-build-apk.yml
+++ b/.github/workflows/reusable-build-apk.yml
@@ -70,7 +70,7 @@ jobs:
 
             -   name: Compute file name
                 run: |
-                    echo "FILE_NAME=${{ env.VERSION_NAME }}-${{ env.VERSION_SUFFIX }}+${{ env.VERSION_BUILD }}" >> $GITHUB_ENV
+                    echo "FILE_NAME=${{ env.VERSION_NAME }}+${{ env.VERSION_SUFFIX }}.${{ env.VERSION_BUILD }}" >> $GITHUB_ENV
 
             -   name: Set up build files
                 uses: ./.github/actions/setup-gradle-build-files

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -88,7 +88,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                         isShrinkResources = true
                         isDebuggable = propDebuggable
                         lint.fatal += "StopShip"
-                        versionNameSuffix = "-$propVersionSuffix+$propVersionBuild"
+                        versionNameSuffix = "+$propVersionSuffix.$propVersionBuild"
                         buildConfigField("Boolean", "DEBUG_MODE", "true")
                     }
 
@@ -96,7 +96,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                         isMinifyEnabled = false
                         isShrinkResources = false
                         isDebuggable = propDebuggable
-                        versionNameSuffix = "-$propVersionSuffix+$propVersionBuild"
+                        versionNameSuffix = "+$propVersionSuffix.$propVersionBuild"
                         buildConfigField("Boolean", "DEBUG_MODE", "true")
 
                         withGroovyBuilder {


### PR DESCRIPTION
Our current versioning scheme causes a minor off-by-one issue (and annoyance) where features that are planned to be released in a specific version require us to set the version of debug build to v+1 (e.g. current "VERSION_NAME" in code is `2024.3.0` just to be able to receive responses from BFSID that are expected by `2024.2.2`).

This is caused by an enforced "SemVer" spec on BFSID side in which the [part after the hyphen](https://semver.org/#spec-item-9) indicates the pre-release versions and therefore `2024.2.2-dev`<`2024.2.2`. 

This change proposes to move the build type into the [meta data part](https://semver.org/#spec-item-10) of the version that should be ignored by the version checker and would allow us to use the exact version where some features become available. (`2024.2.2+dev`==`2024.2.2`)