### PR TITLE
update debug version name

### DIFF
--- a/.github/workflows/pipeline-deploy-to-dev.yml
+++ b/.github/workflows/pipeline-deploy-to-dev.yml
@@ -7,6 +7,10 @@ jobs:
 
     extract-version-name:
         runs-on: ubuntu-latest
+
+        outputs:
+            version-name: ${{ steps.extract-version-name.outputs.version-name }}
+
         steps:
             -   name: Checkout repository
                 uses: actions/checkout@v4
@@ -15,7 +19,7 @@ jobs:
                 id: extract-version-name
                 run: |
                     VERSION_NAME=$(grep 'VERSION_NAME' build-logic/build_properties.gradle.kts | awk -F'"' '{print $2}')
-                    echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV
+                    echo "version-name=$VERSION_NAME" >> $GITHUB_OUTPUT
 
     build-dev-apk:
         uses: ./.github/workflows/reusable-build-apk.yml
@@ -23,7 +27,7 @@ jobs:
         needs: extract-version-name
         with:
             build-environment: dev
-            version-name: ${{ env.VERSION_NAME }}
+            version-name: ${{ needs.extract-version-name.outputs.version-name }}
 
     deploy-to-firebase:
         uses: ./.github/workflows/reusable-deploy-to-firebase-distribution.yml

--- a/.github/workflows/pipeline-deploy-to-dev.yml
+++ b/.github/workflows/pipeline-deploy-to-dev.yml
@@ -5,30 +5,18 @@ on:
 
 jobs:
 
-    extract-version-name:
-        runs-on: ubuntu-latest
-
-        outputs:
-            version-name: ${{ steps.extract-version-name.outputs.version-name }}
-
-        steps:
-            -   name: Checkout repository
-                uses: actions/checkout@v4
-
-            -   name: Extract VERSION_NAME from build_properties.gradle.kts
-                id: extract-version-name
-                run: |
-                    VERSION_NAME=$(grep 'set("VERSION_NAME"' build-logic/build_properties.gradle.kts \
-                    | sed -E 's/.*set\("VERSION_NAME",[[:space:]]*"([^"]+)".*/\1/')                   
-                    echo "version-name=$VERSION_NAME" >> $GITHUB_OUTPUT
+    get-version:
+        uses: ./.github/workflows/reusable-get-version-name.yml
+        with:
+            version-source: "internal"
 
     build-dev-apk:
         uses: ./.github/workflows/reusable-build-apk.yml
         secrets: inherit
-        needs: extract-version-name
+        needs: get-version
         with:
             build-environment: dev
-            version-name: ${{ needs.extract-version-name.outputs.version-name }}
+            version-name: ${{ needs.get-version.outputs.version-name }}
 
     deploy-to-firebase:
         uses: ./.github/workflows/reusable-deploy-to-firebase-distribution.yml

--- a/.github/workflows/pipeline-deploy-to-dev.yml
+++ b/.github/workflows/pipeline-deploy-to-dev.yml
@@ -18,7 +18,8 @@ jobs:
             -   name: Extract VERSION_NAME from build_properties.gradle.kts
                 id: extract-version-name
                 run: |
-                    VERSION_NAME=$(grep 'VERSION_NAME =' build-logic/build_properties.gradle.kts | awk -F' = ' '{print $2}' | tr -d '"')
+                    VERSION_NAME=$(grep 'set("VERSION_NAME"' build-logic/build_properties.gradle.kts \
+                    | sed -E 's/.*set\("VERSION_NAME",[[:space:]]*"([^"]+)".*/\1/')                   
                     echo "version-name=$VERSION_NAME" >> $GITHUB_OUTPUT
 
     build-dev-apk:

--- a/.github/workflows/pipeline-deploy-to-dev.yml
+++ b/.github/workflows/pipeline-deploy-to-dev.yml
@@ -4,12 +4,26 @@ on:
     workflow_call:
 
 jobs:
+
+    extract-version-name:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v4
+
+            -   name: Extract VERSION_NAME from build_properties.gradle.kts
+                id: extract-version-name
+                run: |
+                    VERSION_NAME=$(grep 'VERSION_NAME' build-logic/build_properties.gradle.kts | awk -F'"' '{print $2}')
+                    echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV
+
     build-dev-apk:
         uses: ./.github/workflows/reusable-build-apk.yml
         secrets: inherit
+        needs: extract-version-name
         with:
             build-environment: dev
-
+            version-name: ${{ env.VERSION_NAME }}
 
     deploy-to-firebase:
         uses: ./.github/workflows/reusable-deploy-to-firebase-distribution.yml

--- a/.github/workflows/pipeline-deploy-to-dev.yml
+++ b/.github/workflows/pipeline-deploy-to-dev.yml
@@ -18,7 +18,7 @@ jobs:
             -   name: Extract VERSION_NAME from build_properties.gradle.kts
                 id: extract-version-name
                 run: |
-                    VERSION_NAME=$(grep 'VERSION_NAME' build-logic/build_properties.gradle.kts | awk -F'"' '{print $2}')
+                    VERSION_NAME=$(grep 'VERSION_NAME =' build-logic/build_properties.gradle.kts | awk -F' = ' '{print $2}' | tr -d '"')
                     echo "version-name=$VERSION_NAME" >> $GITHUB_OUTPUT
 
     build-dev-apk:

--- a/.github/workflows/pipeline-deploy-to-internal.yml
+++ b/.github/workflows/pipeline-deploy-to-internal.yml
@@ -10,6 +10,7 @@ jobs:
         secrets: inherit
         with:
             build-environment: internal
+            version-name: ${{ github.ref_name.split('/').last }}
 
     run-app-sweep:
         uses: ./.github/workflows/reusable-app-sweep.yml

--- a/.github/workflows/pipeline-deploy-to-internal.yml
+++ b/.github/workflows/pipeline-deploy-to-internal.yml
@@ -5,12 +5,17 @@ on:
 
 jobs:
 
+    get-version:
+        uses: ./.github/workflows/reusable-get-version-name.yml
+        with:
+            version-source: "branch"
+
     build-internal-aab:
         uses: ./.github/workflows/reusable-build-apk.yml
         secrets: inherit
         with:
             build-environment: internal
-            version-name: ${{ github.ref_name.split('/').last }}
+            version-name: ${{ needs.get-version.outputs.version-name }}
 
     run-app-sweep:
         uses: ./.github/workflows/reusable-app-sweep.yml

--- a/.github/workflows/pipeline-deploy-to-staging.yml
+++ b/.github/workflows/pipeline-deploy-to-staging.yml
@@ -9,6 +9,7 @@ jobs:
         secrets: inherit
         with:
             build-environment: staging
+            version-name: ${{ github.ref_name.split('/').last }}
 
     deploy-to-firebase:
         uses: ./.github/workflows/reusable-deploy-to-firebase-distribution.yml

--- a/.github/workflows/pipeline-deploy-to-staging.yml
+++ b/.github/workflows/pipeline-deploy-to-staging.yml
@@ -4,12 +4,18 @@ on:
     workflow_call:
 
 jobs:
+
+    get-version:
+        uses: ./.github/workflows/reusable-get-version-name.yml
+        with:
+            version-source: "branch"
+
     build-staging-apk:
         uses: ./.github/workflows/reusable-build-apk.yml
         secrets: inherit
         with:
             build-environment: staging
-            version-name: ${{ github.ref_name.split('/').last }}
+            version-name: ${{ needs.get-version.outputs.version-name }}
 
     deploy-to-firebase:
         uses: ./.github/workflows/reusable-deploy-to-firebase-distribution.yml

--- a/.github/workflows/reusable-build-apk.yml
+++ b/.github/workflows/reusable-build-apk.yml
@@ -72,7 +72,7 @@ jobs:
 
             -   name: Compute file name
                 run: |
-                    echo "FILE_NAME=${{ env.VERSION_NAME }}-${{ env.VERSION_SUFFIX }}+${{ env.VERSION_BUILD }}" >> $GITHUB_ENV
+                    echo "FILE_NAME=${{ env.VERSION_NAME }}+${{ env.VERSION_SUFFIX }}.${{ env.VERSION_BUILD }}" >> $GITHUB_ENV
 
             -   name: Set up build files
                 uses: ./.github/actions/setup-gradle-build-files

--- a/.github/workflows/reusable-build-apk.yml
+++ b/.github/workflows/reusable-build-apk.yml
@@ -6,6 +6,9 @@ on:
             build-environment:
                 type: string
                 required: true
+            version-name:
+                type: string
+                required: true
 
         outputs:
             build-artifact:
@@ -30,7 +33,7 @@ jobs:
             # VERSION_CODE: Unique version code using the sum of the current timestamp and run number.
             VERSION_CODE: "set in lower step"
             # VERSION_NAME: Version name derived from the GitHub ref name after the final /.
-            VERSION_NAME: "set in lower step"
+            VERSION_NAME: ${{ inputs.version-name }}
             # VERSION_SUFFIX: The build environment (e.g., dev, staging, internal).
             VERSION_SUFFIX: ${{ inputs.build-environment }}
             # VERSION_BUILD: A unique build identifier combining the run number and attempt.
@@ -66,7 +69,6 @@ jobs:
             -   name: Compute version variables
                 run: |
                     echo "VERSION_CODE=$(($BASE_VERSION_CODE + ${{ github.run_number }} * 100 + ${{ github.run_attempt }}))" >> $GITHUB_ENV
-                    echo "VERSION_NAME=$(echo '${{ github.ref_name }}' | awk -F'/' '{print $NF}')" >> $GITHUB_ENV
 
             -   name: Compute file name
                 run: |

--- a/.github/workflows/reusable-get-version-name.yml
+++ b/.github/workflows/reusable-get-version-name.yml
@@ -28,9 +28,9 @@ jobs:
                       last_part="${GITHUB_REF_NAME##*/}"
                       echo "version-name=$last_part" >> "$GITHUB_OUTPUT"                
                     elif [ "${{ inputs.version-source }}" = "internal" ]; then
-                      version_name=$(grep 'set("VERSION_NAME",' build-logic/build_properties.gradle.kts \
-                        | sed -E 's/.*set\("VERSION_NAME",[[:space:]]*"([^"]+)".*/\1/')
-                      echo "version-name=$version_name" >> "$GITHUB_OUTPUT"
+                        VERSION_NAME=$(grep 'set("VERSION_NAME"' build-logic/build_properties.gradle.kts \
+                        | sed -E 's/.*set\("VERSION_NAME",[[:space:]]*"([^"]+)".*/\1/')                   
+                        echo "version-name=$VERSION_NAME" >> $GITHUB_OUTPUT
                     else
                       echo "Error: Unknown version-source '${{ inputs.version-source }}'"
                       exit 1

--- a/.github/workflows/reusable-get-version-name.yml
+++ b/.github/workflows/reusable-get-version-name.yml
@@ -21,18 +21,17 @@ jobs:
                 if: ${{ inputs.version-source == 'internal' }}
                 uses: actions/checkout@v4
 
-            - name: Extract version
-              id: extract
-              run: |
-                  if [ "${{ inputs.version-source }}" = "branch" ]; then
-                    last_part="${GITHUB_REF_NAME##*/}"
-                    echo "version-name=$last_part" >> "$GITHUB_OUTPUT"
-                  
-                  elif [ "${{ inputs.version-source }}" = "internal" ]; then
-                    version_name=$(grep 'set("VERSION_NAME",' build-logic/build_properties.gradle.kts \
-                      | sed -E 's/.*set\("VERSION_NAME",[[:space:]]*"([^"]+)".*/\1/')
-                    echo "version-name=$version_name" >> "$GITHUB_OUTPUT"
-                  
-                  else
-                    echo "Error: Unknown version-source '${{ inputs.version-source }}'"
-                    exit 1
+            -   name: Extract version
+                id: extract
+                run: |
+                    if [ "${{ inputs.version-source }}" = "branch" ]; then
+                      last_part="${GITHUB_REF_NAME##*/}"
+                      echo "version-name=$last_part" >> "$GITHUB_OUTPUT"                
+                    elif [ "${{ inputs.version-source }}" = "internal" ]; then
+                      version_name=$(grep 'set("VERSION_NAME",' build-logic/build_properties.gradle.kts \
+                        | sed -E 's/.*set\("VERSION_NAME",[[:space:]]*"([^"]+)".*/\1/')
+                      echo "version-name=$version_name" >> "$GITHUB_OUTPUT"
+                    else
+                      echo "Error: Unknown version-source '${{ inputs.version-source }}'"
+                      exit 1
+                    fi

--- a/.github/workflows/reusable-get-version-name.yml
+++ b/.github/workflows/reusable-get-version-name.yml
@@ -9,6 +9,11 @@ on:
                 description: "Where to get the version from: 'branch' or 'internal'"
                 default: "internal"
 
+        outputs:
+            version-name:
+                description: "The version name extracted from the source"
+                value: ${{ jobs.extract-version.outputs.version-name }}
+
 jobs:
     extract-version:
         runs-on: ubuntu-latest

--- a/.github/workflows/reusable-get-version-name.yml
+++ b/.github/workflows/reusable-get-version-name.yml
@@ -1,0 +1,37 @@
+# Parse out the version name based on the release type
+name: "[Reusable] Get Version Name"
+
+on:
+    workflow_call:
+        inputs:
+            version-source:
+                type: string
+                description: "Where to get the version from: 'branch' or 'internal'"
+                default: "internal"
+
+jobs:
+    extract-version:
+        runs-on: ubuntu-latest
+
+        outputs:
+            version-name: ${{ steps.extract.outputs.version-name }}
+
+        steps:
+            -   name: Checkout if using internal version
+                if: ${{ inputs.version-source == 'internal' }}
+                uses: actions/checkout@v4
+
+            -   name: Extract version (branch)
+                id: extract
+                if: ${{ inputs.version-source == 'branch' }}
+                run: |
+                    last_part="${GITHUB_REF_NAME##*/}"
+                    echo "version-name=$last_part" >> "$GITHUB_OUTPUT"
+
+            -   name: Extract version (internal file)
+                id: extract
+                if: ${{ inputs.version-source == 'internal' }}
+                run: |
+                    version_name=$(grep 'set("VERSION_NAME",' build-logic/build_properties.gradle.kts \
+                      | sed -E 's/.*set\("VERSION_NAME",[[:space:]]*"([^"]+)".*/\1/')
+                    echo "version-name=$version_name" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable-get-version-name.yml
+++ b/.github/workflows/reusable-get-version-name.yml
@@ -21,17 +21,18 @@ jobs:
                 if: ${{ inputs.version-source == 'internal' }}
                 uses: actions/checkout@v4
 
-            -   name: Extract version (branch)
-                id: extract
-                if: ${{ inputs.version-source == 'branch' }}
-                run: |
+            - name: Extract version
+              id: extract
+              run: |
+                  if [ "${{ inputs.version-source }}" = "branch" ]; then
                     last_part="${GITHUB_REF_NAME##*/}"
                     echo "version-name=$last_part" >> "$GITHUB_OUTPUT"
-
-            -   name: Extract version (internal file)
-                id: extract
-                if: ${{ inputs.version-source == 'internal' }}
-                run: |
+                  
+                  elif [ "${{ inputs.version-source }}" = "internal" ]; then
                     version_name=$(grep 'set("VERSION_NAME",' build-logic/build_properties.gradle.kts \
                       | sed -E 's/.*set\("VERSION_NAME",[[:space:]]*"([^"]+)".*/\1/')
                     echo "version-name=$version_name" >> "$GITHUB_OUTPUT"
+                  
+                  else
+                    echo "Error: Unknown version-source '${{ inputs.version-source }}'"
+                    exit 1

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -88,7 +88,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                         isShrinkResources = true
                         isDebuggable = propDebuggable
                         lint.fatal += "StopShip"
-                        versionNameSuffix = "-$propVersionSuffix+$propVersionBuild"
+                        versionNameSuffix = "+$propVersionSuffix.$propVersionBuild"
                         buildConfigField("Boolean", "DEBUG_MODE", "true")
                     }
 
@@ -96,7 +96,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                         isMinifyEnabled = false
                         isShrinkResources = false
                         isDebuggable = propDebuggable
-                        versionNameSuffix = "-$propVersionSuffix+$propVersionBuild"
+                        versionNameSuffix = "+$propVersionSuffix.$propVersionBuild"
                         buildConfigField("Boolean", "DEBUG_MODE", "true")
 
                         withGroovyBuilder {


### PR DESCRIPTION
update the workflow to dynamically get the version name based on the type of build. This is needed because for debug version the version name is not available in the branch name. 

(I will squash on merge :-D)