### PR TITLE
[MS-865] Configure good scans and adding new finger rules via BioSdkWrapper

### DIFF
--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
@@ -502,7 +502,8 @@ internal class FingerprintCaptureViewModel @Inject constructor(
         updateState { it.copy(isShowingSplashScreen = true) }
         viewModelScope.launch {
             delay(TRY_DIFFERENT_FINGER_SPLASH_DELAY)
-            if (addNewFinger) handleAutoAddFinger()
+            val isEligibleForFingerAddition = bioSdkWrapper.addNewFingerOnBadScan && addNewFinger
+            if (isEligibleForFingerAddition) handleAutoAddFinger()
             nudgeToNextFinger()
         }
     }
@@ -597,7 +598,7 @@ internal class FingerprintCaptureViewModel @Inject constructor(
         .filter {
             val currentCapture = it.currentCapture()
             currentCapture is CaptureState.ScanProcess.Collected && currentCapture.scanResult.isGoodScan()
-        }.size >= min(TARGET_NUMBER_OF_GOOD_SCANS, numberOfOriginalFingers())
+        }.size >= min(bioSdkWrapper.minGoodScans, numberOfOriginalFingers())
 
     private fun CollectFingerprintsState.weHaveTheMinimumNumberOfAnyQualityScans() = fingerStates
         .filter {
@@ -748,7 +749,6 @@ internal class FingerprintCaptureViewModel @Inject constructor(
     }
 
     companion object {
-        const val TARGET_NUMBER_OF_GOOD_SCANS = 2
         const val MAXIMUM_TOTAL_NUMBER_OF_FINGERS_FOR_AUTO_ADDING = 4
         const val NUMBER_OF_BAD_SCANS_REQUIRED_TO_AUTO_ADD_NEW_FINGER = 3
         const val AUTO_SWIPE_DELAY: Long = 500

--- a/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModelTest.kt
+++ b/fingerprint/capture/src/test/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModelTest.kt
@@ -136,10 +136,13 @@ class FingerprintCaptureViewModelTest {
         every { scanner.versionInformation().generation } returns ScannerGeneration.VERO_1
         every { scannerManager.scanner } returns scanner
         every { scannerManager.isScannerConnected } returns true
-
-        coJustRun { bioSdkWrapper.initialize() }
-        every { bioSdkWrapper.scanningTimeoutMs } returns 1000
-        every { bioSdkWrapper.imageTransferTimeoutMs } returns 1000
+        with(bioSdkWrapper) {
+            coJustRun { initialize() }
+            every { scanningTimeoutMs } returns 1000
+            every { imageTransferTimeoutMs } returns 1000
+            every { minGoodScans } returns 2
+            every { addNewFingerOnBadScan } returns true
+        }
 
         vm = FingerprintCaptureViewModel(
             scannerManager = scannerManager,

--- a/fingerprint/infra/bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdk/BioSdkWrapper.kt
+++ b/fingerprint/infra/bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdk/BioSdkWrapper.kt
@@ -12,6 +12,12 @@ interface BioSdkWrapper {
     // Maximum time to wait for the bio sdk to transfer the fingerprint image
     val imageTransferTimeoutMs: Long
 
+    // Minimum Number of required good scans
+    val minGoodScans: Int
+
+    // Determines whether to suggest adding a new finger after multiple bad scans
+    val addNewFingerOnBadScan: Boolean
+
     val matcherName: String
 
     val supportedTemplateFormat: String

--- a/fingerprint/infra/bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdk/NECBioSdkWrapper.kt
+++ b/fingerprint/infra/bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdk/NECBioSdkWrapper.kt
@@ -21,6 +21,12 @@ class NECBioSdkWrapper @Inject constructor(
     override val imageTransferTimeoutMs: Long
         get() = 0 // 0 seconds as the image is already captured and stored in the memory from the scanning step
 
+    override val minGoodScans: Int
+        get() = 0 // NEC SDK has a high rate of bad scans, so we don't need to enforce a minimum number of good scans
+
+    override val addNewFingerOnBadScan: Boolean
+        get() = false // NEC SDK has a high rate of bad scans, so we don't need to add a new finger on bad scan
+
     override val matcherName: String = bioSdk.matcherName
 
     override val supportedTemplateFormat: String = bioSdk.supportedTemplateFormat

--- a/fingerprint/infra/bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdk/SimprintsBioSdkWrapper.kt
+++ b/fingerprint/infra/bio-sdk/src/main/java/com/simprints/fingerprint/infra/biosdk/SimprintsBioSdkWrapper.kt
@@ -20,6 +20,11 @@ class SimprintsBioSdkWrapper @Inject constructor(
     override val imageTransferTimeoutMs
         get() = 3000L
 
+    override val minGoodScans: Int
+        get() = 2
+    override val addNewFingerOnBadScan: Boolean
+        get() = true
+
     override val matcherName: String
         get() = bioSdk.matcherName
     override val supportedTemplateFormat: String

--- a/fingerprint/infra/bio-sdk/src/test/java/com/simprints/fingerprint/infra/biosdk/NECBioSdkWrapperTest.kt
+++ b/fingerprint/infra/bio-sdk/src/test/java/com/simprints/fingerprint/infra/biosdk/NECBioSdkWrapperTest.kt
@@ -1,6 +1,6 @@
 package com.simprints.fingerprint.infra.biosdk
 
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import com.simprints.fingerprint.infra.basebiosdk.FingerprintBioSdk
 import com.simprints.fingerprint.infra.basebiosdk.acquisition.domain.ImageResponse
 import com.simprints.fingerprint.infra.basebiosdk.acquisition.domain.TemplateResponse
@@ -39,18 +39,24 @@ class NECBioSdkWrapperTest {
     }
 
     @Test
-    fun `test scanningTimeoutMs and imageTransferTimeoutMs`() {
+    fun `test Fixed Properties`() {
         // Given
         val expectedScanningTimeoutMs = 8000L
         val expectedImageTransferTimeoutMs = 0L
+        val expectedMinGoodScans = 0
+        val expectedAddNewFingerOnBadScan = false
 
         // When
         val actualScanningTimeoutMs = necBioSdkWrapper.scanningTimeoutMs
         val actualImageTransferTimeoutMs = necBioSdkWrapper.imageTransferTimeoutMs
+        val actualMinGoodScans = necBioSdkWrapper.minGoodScans
+        val actualAddNewFingerOnBadScan = necBioSdkWrapper.addNewFingerOnBadScan
 
         // Then
-        Truth.assertThat(actualScanningTimeoutMs).isEqualTo(expectedScanningTimeoutMs)
-        Truth.assertThat(actualImageTransferTimeoutMs).isEqualTo(expectedImageTransferTimeoutMs)
+        assertThat(actualScanningTimeoutMs).isEqualTo(expectedScanningTimeoutMs)
+        assertThat(actualImageTransferTimeoutMs).isEqualTo(expectedImageTransferTimeoutMs)
+        assertThat(actualMinGoodScans).isEqualTo(expectedMinGoodScans)
+        assertThat(actualAddNewFingerOnBadScan).isEqualTo(expectedAddNewFingerOnBadScan)
     }
 
     @Test
@@ -106,19 +112,18 @@ class NECBioSdkWrapperTest {
         // Then
         coVerify { bioSdk.acquireFingerprintTemplate(any()) }
         with(settingsSlot.captured) {
-            Truth
-                .assertThat(processingResolution?.value)
+            assertThat(processingResolution?.value)
                 .isEqualTo(captureFingerprintStrategy.toShort())
-            Truth.assertThat(timeOutMs).isEqualTo(captureTimeOutMs)
-            Truth.assertThat(qualityThreshold).isEqualTo(captureQualityThreshold)
-            Truth.assertThat(allowLowQualityExtraction).isEqualTo(captureAllowLowQualityExtraction)
+            assertThat(timeOutMs).isEqualTo(captureTimeOutMs)
+            assertThat(qualityThreshold).isEqualTo(captureQualityThreshold)
+            assertThat(allowLowQualityExtraction).isEqualTo(captureAllowLowQualityExtraction)
         }
-        Truth.assertThat(bioSdkResponse.template).isEqualTo(response.template)
-        Truth
-            .assertThat(bioSdkResponse.templateMetadata?.templateFormat)
+        assertThat(bioSdkResponse.template).isEqualTo(response.template)
+
+        assertThat(bioSdkResponse.templateMetadata?.templateFormat)
             .isEqualTo(response.templateFormat)
-        Truth
-            .assertThat(bioSdkResponse.templateMetadata?.imageQualityScore)
+
+        assertThat(bioSdkResponse.templateMetadata?.imageQualityScore)
             .isEqualTo(response.imageQualityScore)
     }
 
@@ -149,6 +154,6 @@ class NECBioSdkWrapperTest {
         val response = necBioSdkWrapper.acquireFingerprintImage()
         // Then
         coVerify { bioSdk.acquireFingerprintImage() }
-        Truth.assertThat(bioSdkResponse.imageBytes).isEqualTo(response.imageBytes)
+        assertThat(bioSdkResponse.imageBytes).isEqualTo(response.imageBytes)
     }
 }

--- a/fingerprint/infra/bio-sdk/src/test/java/com/simprints/fingerprint/infra/biosdk/SimprintsBioSdkWrapperTest.kt
+++ b/fingerprint/infra/bio-sdk/src/test/java/com/simprints/fingerprint/infra/biosdk/SimprintsBioSdkWrapperTest.kt
@@ -33,18 +33,24 @@ class SimprintsBioSdkWrapperTest {
     }
 
     @Test
-    fun `test scanningTimeoutMs and imageTransferTimeoutMs`() {
+    fun `test Fixed Properties`() {
         // Given
         val expectedScanningTimeoutMs = 3000L
         val expectedImageTransferTimeoutMs = 3000L
+        val expectedMinGoodScans = 2
+        val expectedAddNewFingerOnBadScan = true
 
         // When
         val actualScanningTimeoutMs = simprintsBioSdkWrapper.scanningTimeoutMs
         val actualImageTransferTimeoutMs = simprintsBioSdkWrapper.imageTransferTimeoutMs
+        val actualMinGoodScans = simprintsBioSdkWrapper.minGoodScans
+        val actualAddNewFingerOnBadScan = simprintsBioSdkWrapper.addNewFingerOnBadScan
 
         // Then
         assertThat(actualScanningTimeoutMs).isEqualTo(expectedScanningTimeoutMs)
         assertThat(actualImageTransferTimeoutMs).isEqualTo(expectedImageTransferTimeoutMs)
+        assertThat(actualMinGoodScans).isEqualTo(expectedMinGoodScans)
+        assertThat(actualAddNewFingerOnBadScan).isEqualTo(expectedAddNewFingerOnBadScan)
     }
 
     @Test


### PR DESCRIPTION
This PR configures the minimum number of good scans and new finger addition rules based on the active SDK via BioSdkWrapper.
- Set TARGET_NUMBER_OF_GOOD_SCANS:
        SimMatcher: 2 good scans.
        NEC: 0 good scans.
- Control new finger on bad scans:
        SimMatcher: Allowed.
        NEC: Disabled.
- Removed hardcoded values from FingerprintCaptureViewModel.

Why?

- NEC is used for toddlers, who typically have higher bad scan rates. The current setup in the GT project prevents adding new fingers when there are too many bad scans.
- No change in behavior for SimMatcher; only NEC is adjusted.
