### PR TITLE
[MS-860] Face capture confirmation double click prevention

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/confirmation/ConfirmationFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/confirmation/ConfirmationFragment.kt
@@ -51,6 +51,7 @@ internal class ConfirmationFragment : Fragment(R.layout.fragment_confirmation) {
         mainVm.getSampleDetection()?.bitmap?.let { binding.confirmationImg.setImageBitmap(it) }
 
         binding.confirmationBtn.setOnClickListener {
+            binding.confirmationBtn.setOnClickListener(null)
             mainVm.addCaptureConfirmationAction(startTime, true)
             mainVm.flowFinished()
         }


### PR DESCRIPTION
`FaceCaptureViewModel.saveFaceDetections` was observed to occasionally run twice in a row. That also means the entire `flowFinished` runs twice, causing unwanted duplication of event data. In turn this means `ConfirmationFragment`'s `confirmationBtn` listener was invoked twice.

Because `FaceCaptureViewModel.flowFinished` causes the app to navigate away from `ConfirmationFragment`, the `confirmationBtn` listener can be removed on (first) click. This should prevent the double click.