### PR TITLE
[MS-920] Set ROC V1 as default FaceBioSDK version for migrated configs

### DIFF
--- a/face/infra/bio-sdk-resolver/src/main/java/com/simprints/face/infra/biosdkresolver/ResolveFaceBioSdkUseCase.kt
+++ b/face/infra/bio-sdk-resolver/src/main/java/com/simprints/face/infra/biosdkresolver/ResolveFaceBioSdkUseCase.kt
@@ -1,7 +1,6 @@
 package com.simprints.face.infra.biosdkresolver
 
 import com.simprints.infra.config.store.ConfigRepository
-import com.simprints.infra.logging.Simber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -17,8 +16,8 @@ class ResolveFaceBioSdkUseCase @Inject constructor(
             .face
             ?.rankOne
             ?.version
-        Simber.d("FaceBioSDK version: $version")
-        // if the version is null, return rocV1BioSdk
+            ?.takeIf { it.isNotBlank() } // Ensures version is not null or empty
+        requireNotNull(version) { "FaceBioSDK version is null or empty" }
         return if (version == rocV3BioSdk.version) rocV3BioSdk else rocV1BioSdk
     }
 }

--- a/face/infra/bio-sdk-resolver/src/test/java/ResolveFaceBioSdkUseCaseTest.kt
+++ b/face/infra/bio-sdk-resolver/src/test/java/ResolveFaceBioSdkUseCaseTest.kt
@@ -1,0 +1,97 @@
+package com.simprints.face.infra.biosdkresolver
+
+import com.google.common.truth.Truth.assertThat
+import com.simprints.infra.config.store.ConfigRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.lang.IllegalArgumentException
+
+class ResolveFaceBioSdkUseCaseTest {
+    private lateinit var resolveFaceBioSdkUseCase: ResolveFaceBioSdkUseCase
+    private val configRepository: ConfigRepository = mockk()
+    private lateinit var rocV1BioSdk: RocV1BioSdk
+    private lateinit var rocV3BioSdk: RocV3BioSdk
+
+    @Before
+    fun setUp() {
+        rocV1BioSdk = RocV1BioSdk(mockk(), mockk(), mockk())
+        rocV3BioSdk = RocV3BioSdk(mockk(), mockk(), mockk())
+        resolveFaceBioSdkUseCase = ResolveFaceBioSdkUseCase(configRepository, rocV1BioSdk, rocV3BioSdk)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `throw exception when version is null`() = runTest {
+        // Given
+        coEvery {
+            configRepository
+                .getProjectConfiguration()
+                .face
+                ?.rankOne
+                ?.version
+        } returns null
+
+        // When
+        resolveFaceBioSdkUseCase.invoke()
+
+        // Then: Expect IllegalArgumentException to be thrown
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `throw exception when version is empty`() = runTest {
+        // Given
+        coEvery {
+            configRepository
+                .getProjectConfiguration()
+                .face
+                ?.rankOne
+                ?.version
+        } returns ""
+
+        // When
+        resolveFaceBioSdkUseCase.invoke()
+
+        // Then: Expect IllegalArgumentException to be thrown
+    }
+
+    // Given that version is valid and matches ROC V3
+    @Test
+    fun `return ROC V3 SDK when version is valid and matches ROC V3`() = runTest {
+        // Given
+
+        coEvery {
+            configRepository
+                .getProjectConfiguration()
+                .face
+                ?.rankOne
+                ?.version
+        } returns rocV3BioSdk.version
+
+        // When
+        val result = resolveFaceBioSdkUseCase.invoke()
+
+        // Then
+        assertThat(result).isEqualTo(rocV3BioSdk)
+    }
+
+    // Given that version is valid and does not match ROC V3 (should match ROC V1)
+    @Test
+    fun `return ROC V1 SDK when version is valid and does not match ROC V3`() = runTest {
+        // Given
+        coEvery {
+            configRepository
+                .getProjectConfiguration()
+                .face
+                ?.rankOne
+                ?.version
+        } returns rocV1BioSdk.version
+
+        // When
+        val result = resolveFaceBioSdkUseCase.invoke()
+
+        // Then
+        assertThat(result).isEqualTo(rocV1BioSdk)
+    }
+}

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/ConfigStoreModule.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/ConfigStoreModule.kt
@@ -8,6 +8,7 @@ import com.simprints.infra.config.store.local.ConfigLocalDataSource
 import com.simprints.infra.config.store.local.ConfigLocalDataSourceImpl
 import com.simprints.infra.config.store.local.migrations.DeviceConfigSharedPrefsMigration
 import com.simprints.infra.config.store.local.migrations.ProjectConfigFaceBioSdkMigration
+import com.simprints.infra.config.store.local.migrations.ProjectConfigFaceEmptyVersionMigration
 import com.simprints.infra.config.store.local.migrations.ProjectConfigFaceSdkQualityThresholdMigration
 import com.simprints.infra.config.store.local.migrations.ProjectConfigFingerprintBioSdkMigration
 import com.simprints.infra.config.store.local.migrations.ProjectConfigLedsModeMigration
@@ -74,6 +75,7 @@ object DataStoreModule {
         projectConfigFaceSdkQualityThresholdMigration: ProjectConfigFaceSdkQualityThresholdMigration,
         projectConfigLedsModeMigration: ProjectConfigLedsModeMigration,
         projectConfigMatchingModalitiesMigration: ProjectConfigMatchingModalitiesMigration,
+        projectConfigFaceEmptyVersionMigration: ProjectConfigFaceEmptyVersionMigration,
     ): DataStore<ProtoProjectConfiguration> = DataStoreFactory.create(
         serializer = ProjectConfigurationSerializer,
         produceFile = { appContext.dataStoreFile(PROJECT_CONFIG_DATA_STORE_FILE_NAME) },
@@ -85,6 +87,7 @@ object DataStoreModule {
             projectConfigFaceSdkQualityThresholdMigration,
             projectConfigLedsModeMigration,
             projectConfigMatchingModalitiesMigration,
+            projectConfigFaceEmptyVersionMigration,
         ),
     )
 

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceEmptyVersionMigration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceEmptyVersionMigration.kt
@@ -1,0 +1,35 @@
+package com.simprints.infra.config.store.local.migrations
+
+import androidx.datastore.core.DataMigration
+import com.simprints.infra.config.store.local.models.ProtoProjectConfiguration
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MIGRATION
+import com.simprints.infra.logging.Simber
+import javax.inject.Inject
+
+class ProjectConfigFaceEmptyVersionMigration @Inject constructor() : DataMigration<ProtoProjectConfiguration> {
+    override suspend fun cleanUp() {
+        Simber.i("Migration of project configuration face bio sdk empty version is done", tag = MIGRATION)
+    }
+
+    override suspend fun shouldMigrate(currentData: ProtoProjectConfiguration) = with(currentData.face) {
+        rankOne.version.isEmpty()
+    }
+
+    override suspend fun migrate(currentData: ProtoProjectConfiguration): ProtoProjectConfiguration {
+        Simber.i("Start migration of project configuration face bio sdk empty version ", tag = MIGRATION)
+
+        val faceProto = currentData.face.toBuilder()
+
+        // 1- set version to 1.23
+        faceProto.rankOne = faceProto.rankOne
+            .toBuilder()
+            .setVersion(ROC_V1_VERSION)
+            .build()
+
+        return currentData.toBuilder().setFace(faceProto).build()
+    }
+
+    companion object {
+        const val ROC_V1_VERSION = "1.23"
+    }
+}

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceEmptyVersionMigrationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceEmptyVersionMigrationTest.kt
@@ -1,0 +1,68 @@
+package com.simprints.infra.config.store.local.migrations
+
+import com.google.common.truth.Truth.assertThat
+import com.simprints.infra.config.store.local.models.ProtoFaceConfiguration
+import com.simprints.infra.config.store.local.models.ProtoFaceConfiguration.ProtoFaceSdkConfiguration
+import com.simprints.infra.config.store.local.models.ProtoProjectConfiguration
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class ProjectConfigFaceEmptyVersionMigrationTest {
+    @Test
+    fun `should migrate if face has empty version`() = runTest {
+        val currentData = ProtoProjectConfiguration
+            .newBuilder()
+            .setFace(
+                ProtoFaceConfiguration
+                    .newBuilder()
+                    .setRankOne(
+                        ProtoFaceSdkConfiguration
+                            .newBuilder()
+                            .build(),
+                    ).build(),
+            ).build()
+
+        val shouldMigrate = ProjectConfigFaceEmptyVersionMigration().shouldMigrate(currentData)
+
+        assertThat(shouldMigrate).isTrue()
+    }
+
+    @Test
+    fun `should not migrate if face has version`() = runTest {
+        val currentData = ProtoProjectConfiguration
+            .newBuilder()
+            .setFace(
+                ProtoFaceConfiguration
+                    .newBuilder()
+                    .setRankOne(
+                        ProtoFaceSdkConfiguration
+                            .newBuilder()
+                            .setVersion("1.23")
+                            .build(),
+                    ).build(),
+            ).build()
+
+        val shouldMigrate = ProjectConfigFaceEmptyVersionMigration().shouldMigrate(currentData)
+
+        assertThat(shouldMigrate).isFalse()
+    }
+
+    @Test
+    fun `migration converts empty version to ROC1`() = runTest {
+        val currentData = ProtoProjectConfiguration
+            .newBuilder()
+            .setFace(
+                ProtoFaceConfiguration
+                    .newBuilder()
+                    .setRankOne(
+                        ProtoFaceSdkConfiguration
+                            .newBuilder()
+                            .build(),
+                    ).build(),
+            ).build()
+
+        val migrated = ProjectConfigFaceEmptyVersionMigration().migrate(currentData)
+
+        assertThat(migrated.face.rankOne.version).isEqualTo(ProjectConfigFaceEmptyVersionMigration.ROC_V1_VERSION)
+    }
+}


### PR DESCRIPTION
Migrated face configurations now default to ROC V1 SDK version 1.23. Additionally, the FaceBioSDK resolver ensures a non-empty version is present.