### PR TITLE
[MS-972] Start Capture button to manually prepare for Face Auto-Capture

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragment.kt
@@ -220,6 +220,7 @@ internal class LiveFeedbackAutoCaptureFragment : Fragment(R.layout.fragment_live
             captureOverlay.drawSemiTransparentTarget()
             captureFeedbackBtn.setText(IDR.string.face_capture_start_capture)
             captureFeedbackBtn.isVisible = true
+            captureFeedbackBtn.isChecked = true
             captureFeedbackPermissionButton.isGone = true
         }
     }

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragment.kt
@@ -83,8 +83,11 @@ internal class LiveFeedbackAutoCaptureFragment : Fragment(R.layout.fragment_live
         bindViewModel()
         binding.captureProgress.max = 1 // normalized progress
 
-        binding.captureFeedbackBtn.setOnClickListener { vm.startCapture() }
-        
+        binding.captureFeedbackBtn.setOnClickListener {
+            vm.startCapture()
+            binding.captureFeedbackBtn.isClickable = false
+        }
+
         // Wait till the views gets its final size then init frame processor and setup the camera
         binding.faceCaptureCamera.post {
             if (view != null) {
@@ -99,6 +102,7 @@ internal class LiveFeedbackAutoCaptureFragment : Fragment(R.layout.fragment_live
             return@launch
         }
         vm.holdOffCapture()
+        binding.captureFeedbackBtn.isClickable = true
 
         // Initialize our background executor
         cameraExecutor = Executors.newSingleThreadExecutor()

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragment.kt
@@ -83,6 +83,8 @@ internal class LiveFeedbackAutoCaptureFragment : Fragment(R.layout.fragment_live
         bindViewModel()
         binding.captureProgress.max = 1 // normalized progress
 
+        binding.captureFeedbackBtn.setOnClickListener { vm.startCapture() }
+        
         // Wait till the views gets its final size then init frame processor and setup the camera
         binding.faceCaptureCamera.post {
             if (view != null) {
@@ -96,7 +98,7 @@ internal class LiveFeedbackAutoCaptureFragment : Fragment(R.layout.fragment_live
         if (::cameraExecutor.isInitialized && !cameraExecutor.isShutdown) {
             return@launch
         }
-        vm.startPreparationDelay()
+        vm.holdOffCapture()
 
         // Initialize our background executor
         cameraExecutor = Executors.newSingleThreadExecutor()
@@ -216,7 +218,7 @@ internal class LiveFeedbackAutoCaptureFragment : Fragment(R.layout.fragment_live
     private fun renderCapturingNotStarted() {
         binding.apply {
             captureOverlay.drawSemiTransparentTarget()
-            captureFeedbackBtn.setText(IDR.string.face_capture_title_previewing)
+            captureFeedbackBtn.setText(IDR.string.face_capture_start_capture)
             captureFeedbackBtn.isVisible = true
             captureFeedbackPermissionButton.isGone = true
         }

--- a/infra/resources/src/main/res/values/strings.xml
+++ b/infra/resources/src/main/res/values/strings.xml
@@ -175,6 +175,7 @@
     <string name="face_capture_onboarding_continue_button">Tap anywhere to continue</string>
     <string name="face_capture_capturing_title">Live Capture</string>
     <string name="face_capture_preparation_title">Preparation</string>
+    <string name="face_capture_start_capture">Start capture</string>
     <string name="face_capture_title_previewing">Preparing to scan</string>
     <string name="face_capture_title_no_face">No face detected</string>
     <string name="face_capture_error_no_face">Make sure the face fills the circle</string>


### PR DESCRIPTION
#### Before:

When using auto-capture and starting the viewfinder, the start of the "sensing" for the qualifying quality face presense in the frame was delayed for 2 seconds.

#### Now:

When using auto-capture and starting the viewfinder, the start of the "sensing" for the qualifying quality face presense in the frame is delayed until the user taps the "Start capture" button.
