### PR TITLE
[MS-859] Using explicit tokenizable strings in api calls

### DIFF
--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiEvent.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiEvent.kt
@@ -1,10 +1,6 @@
 package com.simprints.infra.eventsync.event.remote.models
 
 import androidx.annotation.Keep
-import com.simprints.core.domain.tokenization.TokenizableString
-import com.simprints.infra.config.store.models.Project
-import com.simprints.infra.events.event.domain.models.Event
-import com.simprints.infra.eventsync.event.usecases.TokenizeEventPayloadFieldsUseCase
 
 @Keep
 internal data class ApiEvent(
@@ -14,20 +10,3 @@ internal data class ApiEvent(
     val payload: ApiEventPayload,
     val tokenizedFields: List<String>,
 )
-
-internal fun Event.fromDomainToApi(tokenizeEventPayloadFieldsUseCase: TokenizeEventPayloadFieldsUseCase, project: Project): ApiEvent {
-    with(tokenizeEventPayloadFieldsUseCase(this, project)) {
-        val apiPayload = payload.fromDomainToApi()
-        val tokenizedKeyTypes = getTokenizedFields().filter { it.value is TokenizableString.Tokenized }.keys.toList()
-        val tokenizedFields = tokenizedKeyTypes.mapNotNull(apiPayload::getTokenizedFieldJsonPath)
-
-        return ApiEvent(
-            id = id,
-            type = type.fromDomainToApi(),
-            version = payload.eventVersion,
-            payload = apiPayload,
-            tokenizedFields = tokenizedFields,
-        )
-
-    }
-}

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiEvent.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiEvent.kt
@@ -2,7 +2,9 @@ package com.simprints.infra.eventsync.event.remote.models
 
 import androidx.annotation.Keep
 import com.simprints.core.domain.tokenization.TokenizableString
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.events.event.domain.models.Event
+import com.simprints.infra.eventsync.event.usecases.TokenizeEventPayloadFieldsUseCase
 
 @Keep
 internal data class ApiEvent(
@@ -13,17 +15,19 @@ internal data class ApiEvent(
     val tokenizedFields: List<String>,
 )
 
-internal fun Event.fromDomainToApi(): ApiEvent {
-    val tokenizedKeyTypes =
-        getTokenizedFields().filter { it.value is TokenizableString.Tokenized }.keys.toList()
-    val apiPayload = payload.fromDomainToApi()
-    val tokenizedFields = tokenizedKeyTypes.mapNotNull(apiPayload::getTokenizedFieldJsonPath)
+internal fun Event.fromDomainToApi(tokenizeEventPayloadFieldsUseCase: TokenizeEventPayloadFieldsUseCase, project: Project): ApiEvent {
+    with(tokenizeEventPayloadFieldsUseCase(this, project)) {
+        val apiPayload = payload.fromDomainToApi()
+        val tokenizedKeyTypes = getTokenizedFields().filter { it.value is TokenizableString.Tokenized }.keys.toList()
+        val tokenizedFields = tokenizedKeyTypes.mapNotNull(apiPayload::getTokenizedFieldJsonPath)
 
-    return ApiEvent(
-        id = id,
-        type = type.fromDomainToApi(),
-        version = payload.eventVersion,
-        payload = apiPayload,
-        tokenizedFields = tokenizedFields,
-    )
+        return ApiEvent(
+            id = id,
+            type = type.fromDomainToApi(),
+            version = payload.eventVersion,
+            payload = apiPayload,
+            tokenizedFields = tokenizedFields,
+        )
+
+    }
 }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/session/ApiEventScope.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/session/ApiEventScope.kt
@@ -3,15 +3,9 @@ package com.simprints.infra.eventsync.event.remote.models.session
 import androidx.annotation.Keep
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include
-import com.simprints.infra.config.store.models.Project
-import com.simprints.infra.config.store.tokenization.TokenizationProcessor
-import com.simprints.infra.events.event.domain.models.Event
-import com.simprints.infra.events.event.domain.models.scope.EventScope
 import com.simprints.infra.eventsync.event.remote.models.ApiEvent
 import com.simprints.infra.eventsync.event.remote.models.ApiModality
 import com.simprints.infra.eventsync.event.remote.models.ApiTimestamp
-import com.simprints.infra.eventsync.event.remote.models.fromDomainToApi
-import com.simprints.infra.eventsync.event.usecases.TokenizeEventPayloadFieldsUseCase
 
 @Keep
 internal data class ApiEventScope(
@@ -31,29 +25,4 @@ internal data class ApiEventScope(
     val projectConfigurationUpdatedAt: String,
     val projectConfigurationId: String,
     val events: List<ApiEvent>,
-) {
-    companion object {
-        fun fromDomain(
-            scope: EventScope,
-            events: List<Event>,
-            tokenizeEventPayloadFieldsUseCase: TokenizeEventPayloadFieldsUseCase,
-            project: Project
-        ) = ApiEventScope(
-            id = scope.id,
-            projectId = scope.projectId,
-            startTime = scope.createdAt.fromDomainToApi(),
-            endTime = scope.endedAt?.fromDomainToApi(),
-            endCause = scope.payload.endCause.fromDomainToApi(),
-            modalities = scope.payload.modalities.map { it.fromDomainToApi() },
-            sidVersion = scope.payload.sidVersion,
-            libSimprintsVersion = scope.payload.libSimprintsVersion,
-            language = scope.payload.language,
-            device = scope.payload.device.fromDomainToApi(),
-            databaseInfo = scope.payload.databaseInfo.fromDomainToApi(),
-            location = scope.payload.location?.fromDomainToApi(),
-            projectConfigurationUpdatedAt = scope.payload.projectConfigurationUpdatedAt,
-            projectConfigurationId = scope.payload.projectConfigurationId.orEmpty(),
-            events = events.map { it.fromDomainToApi(tokenizeEventPayloadFieldsUseCase, project) },
-        )
-    }
-}
+)

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/session/ApiEventScope.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/session/ApiEventScope.kt
@@ -3,12 +3,15 @@ package com.simprints.infra.eventsync.event.remote.models.session
 import androidx.annotation.Keep
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include
+import com.simprints.infra.config.store.models.Project
+import com.simprints.infra.config.store.tokenization.TokenizationProcessor
 import com.simprints.infra.events.event.domain.models.Event
 import com.simprints.infra.events.event.domain.models.scope.EventScope
 import com.simprints.infra.eventsync.event.remote.models.ApiEvent
 import com.simprints.infra.eventsync.event.remote.models.ApiModality
 import com.simprints.infra.eventsync.event.remote.models.ApiTimestamp
 import com.simprints.infra.eventsync.event.remote.models.fromDomainToApi
+import com.simprints.infra.eventsync.event.usecases.TokenizeEventPayloadFieldsUseCase
 
 @Keep
 internal data class ApiEventScope(
@@ -33,6 +36,8 @@ internal data class ApiEventScope(
         fun fromDomain(
             scope: EventScope,
             events: List<Event>,
+            tokenizeEventPayloadFieldsUseCase: TokenizeEventPayloadFieldsUseCase,
+            project: Project
         ) = ApiEventScope(
             id = scope.id,
             projectId = scope.projectId,
@@ -48,7 +53,7 @@ internal data class ApiEventScope(
             location = scope.payload.location?.fromDomainToApi(),
             projectConfigurationUpdatedAt = scope.payload.projectConfigurationUpdatedAt,
             projectConfigurationId = scope.payload.projectConfigurationId.orEmpty(),
-            events = events.map { it.fromDomainToApi() },
+            events = events.map { it.fromDomainToApi(tokenizeEventPayloadFieldsUseCase, project) },
         )
     }
 }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventScopeToApiUseCase.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventScopeToApiUseCase.kt
@@ -1,0 +1,39 @@
+package com.simprints.infra.eventsync.event.usecases
+
+import com.simprints.infra.config.store.models.Project
+import com.simprints.infra.events.event.domain.models.Event
+import com.simprints.infra.events.event.domain.models.scope.EventScope
+import com.simprints.infra.eventsync.event.remote.models.fromDomainToApi
+import com.simprints.infra.eventsync.event.remote.models.session.ApiEventScope
+import com.simprints.infra.eventsync.event.remote.models.session.fromDomainToApi
+import javax.inject.Inject
+
+internal class MapDomainEventScopeToApiUseCase @Inject constructor(
+    private val mapDomainEventToApiUseCase: MapDomainEventToApiUseCase,
+) {
+
+    operator fun invoke(
+        scope: EventScope,
+        events: List<Event>,
+        project: Project,
+    ): ApiEventScope {
+        val apiEvents = events.map { event -> mapDomainEventToApiUseCase(event, project) }
+        return ApiEventScope(
+            id = scope.id,
+            projectId = scope.projectId,
+            startTime = scope.createdAt.fromDomainToApi(),
+            endTime = scope.endedAt?.fromDomainToApi(),
+            endCause = scope.payload.endCause.fromDomainToApi(),
+            modalities = scope.payload.modalities.map { it.fromDomainToApi() },
+            sidVersion = scope.payload.sidVersion,
+            libSimprintsVersion = scope.payload.libSimprintsVersion,
+            language = scope.payload.language,
+            device = scope.payload.device.fromDomainToApi(),
+            databaseInfo = scope.payload.databaseInfo.fromDomainToApi(),
+            location = scope.payload.location?.fromDomainToApi(),
+            projectConfigurationUpdatedAt = scope.payload.projectConfigurationUpdatedAt,
+            projectConfigurationId = scope.payload.projectConfigurationId.orEmpty(),
+            events = apiEvents,
+        )
+    }
+}

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventToApiUseCase.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventToApiUseCase.kt
@@ -12,7 +12,7 @@ internal class MapDomainEventToApiUseCase @Inject constructor(
 ) {
     operator fun invoke(event: Event, project: Project): ApiEvent = with(tokenizeEventPayloadFieldsUseCase(event, project)) {
         val apiPayload = payload.fromDomainToApi()
-        val tokenizedKeyTypes = getTokenizedFields().filter { it.value is TokenizableString.Tokenized }.keys.toList()
+        val tokenizedKeyTypes = getTokenizableFields().filter { it.value is TokenizableString.Tokenized }.keys.toList()
         val tokenizedFields = tokenizedKeyTypes.mapNotNull(apiPayload::getTokenizedFieldJsonPath)
         ApiEvent(
             id = id,

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventToApiUseCase.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventToApiUseCase.kt
@@ -1,0 +1,26 @@
+package com.simprints.infra.eventsync.event.usecases
+
+import com.simprints.core.domain.tokenization.TokenizableString
+import com.simprints.infra.config.store.models.Project
+import com.simprints.infra.events.event.domain.models.Event
+import com.simprints.infra.eventsync.event.remote.models.ApiEvent
+import com.simprints.infra.eventsync.event.remote.models.fromDomainToApi
+import javax.inject.Inject
+
+internal class MapDomainEventToApiUseCase @Inject constructor(
+    private val tokenizeEventPayloadFieldsUseCase: TokenizeEventPayloadFieldsUseCase,
+) {
+    operator fun invoke(event: Event, project: Project): ApiEvent = with(tokenizeEventPayloadFieldsUseCase(event, project)) {
+        val apiPayload = payload.fromDomainToApi()
+        val tokenizedKeyTypes = getTokenizedFields().filter { it.value is TokenizableString.Tokenized }.keys.toList()
+        val tokenizedFields = tokenizedKeyTypes.mapNotNull(apiPayload::getTokenizedFieldJsonPath)
+        ApiEvent(
+            id = id,
+            type = type.fromDomainToApi(),
+            version = payload.eventVersion,
+            payload = apiPayload,
+            tokenizedFields = tokenizedFields,
+        )
+    }
+
+}

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCase.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCase.kt
@@ -10,7 +10,7 @@ internal class TokenizeEventPayloadFieldsUseCase @Inject constructor(
     private val tokenizationProcessor: TokenizationProcessor
 ) {
     operator fun invoke(event: Event, project: Project): Event {
-        val tokenizedFields = event.getTokenizedFields().mapValues { entry ->
+        val tokenizedFields = event.getTokenizableFields().mapValues { entry ->
             val tokenKeyType = entry.key
             return@mapValues when (val tokenizableField = entry.value) {
                 is TokenizableString.Raw -> {

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCase.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCase.kt
@@ -1,0 +1,29 @@
+package com.simprints.infra.eventsync.event.usecases
+
+import com.simprints.core.domain.tokenization.TokenizableString
+import com.simprints.infra.config.store.models.Project
+import com.simprints.infra.config.store.tokenization.TokenizationProcessor
+import javax.inject.Inject
+import com.simprints.infra.events.event.domain.models.Event
+
+class TokenizeEventPayloadFieldsUseCase @Inject constructor(
+    private val tokenizationProcessor: TokenizationProcessor
+) {
+    operator fun invoke(event: Event, project: Project): Event {
+        val tokenizedFields = event.getTokenizedFields().mapValues { entry ->
+            val tokenKeyType = entry.key
+            return@mapValues when (val tokenizableField = entry.value) {
+                is TokenizableString.Raw -> {
+                    tokenizationProcessor.encrypt(
+                        decrypted = tokenizableField,
+                        tokenKeyType = tokenKeyType,
+                        project = project
+                    )
+                }
+
+                is TokenizableString.Tokenized -> tokenizableField
+            }
+        }
+        return event.setTokenizedFields(tokenizedFields)
+    }
+}

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCase.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCase.kt
@@ -6,7 +6,7 @@ import com.simprints.infra.config.store.tokenization.TokenizationProcessor
 import javax.inject.Inject
 import com.simprints.infra.events.event.domain.models.Event
 
-class TokenizeEventPayloadFieldsUseCase @Inject constructor(
+internal class TokenizeEventPayloadFieldsUseCase @Inject constructor(
     private val tokenizationProcessor: TokenizationProcessor
 ) {
     operator fun invoke(event: Event, project: Project): Event {

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/EventRemoteDataSourceTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/EventRemoteDataSourceTest.kt
@@ -2,7 +2,10 @@ package com.simprints.infra.eventsync.event.remote
 
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.tools.json.JsonHelper
+import com.simprints.core.tools.utils.StringTokenizer
 import com.simprints.infra.authstore.AuthStore
+import com.simprints.infra.config.store.models.Project
+import com.simprints.infra.config.store.tokenization.TokenizationProcessor
 import com.simprints.infra.events.event.domain.EventCount
 import com.simprints.infra.events.event.domain.models.Event
 import com.simprints.infra.events.event.domain.models.subject.EnrolmentRecordEvent
@@ -16,11 +19,13 @@ import com.simprints.infra.events.sampledata.createAlertScreenEvent
 import com.simprints.infra.events.sampledata.createSessionScope
 import com.simprints.infra.eventsync.event.remote.exceptions.TooManyRequestsException
 import com.simprints.infra.eventsync.event.remote.models.session.ApiEventScope
+import com.simprints.infra.eventsync.event.usecases.TokenizeEventPayloadFieldsUseCase
 import com.simprints.infra.network.SimNetwork
 import com.simprints.infra.network.exceptions.BackendMaintenanceException
 import com.simprints.infra.network.exceptions.SyncCloudIntegrationException
 import com.simprints.testtools.common.alias.InterfaceInvocation
 import com.simprints.testtools.common.syntax.assertThrows
+import com.simprints.testtools.unit.EncodingUtilsImplForTests
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -53,6 +58,11 @@ class EventRemoteDataSourceTest {
     @MockK
     private lateinit var eventRemoteInterface: EventRemoteInterface
 
+    private lateinit var useCase: TokenizeEventPayloadFieldsUseCase
+
+    @MockK
+    private lateinit var project: Project
+
     private lateinit var eventRemoteDataSource: EventRemoteDataSource
     private val query = ApiRemoteEventQuery(
         projectId = DEFAULT_PROJECT_ID,
@@ -75,6 +85,8 @@ class EventRemoteDataSourceTest {
 
         coEvery { authStore.buildClient(EventRemoteInterface::class) } returns simApiClient
         eventRemoteDataSource = EventRemoteDataSource(authStore, JsonHelper)
+        val tokenizationProcessor = TokenizationProcessor(StringTokenizer(EncodingUtilsImplForTests))
+        useCase = TokenizeEventPayloadFieldsUseCase(tokenizationProcessor)
     }
 
     @After
@@ -299,13 +311,14 @@ class EventRemoteDataSourceTest {
             mapOf("x-request-id" to "requestId").toHeaders(),
         )
 
-        val events = listOf(createAlertScreenEvent())
+        val event = createAlertScreenEvent()
+        val events = listOf(event)
         val scope = createSessionScope()
         eventRemoteDataSource.post(
             GUID1,
             DEFAULT_PROJECT_ID,
             ApiUploadEventsBody(
-                sessions = listOf(ApiEventScope.fromDomain(scope, events)),
+                sessions = listOf(ApiEventScope.fromDomain(scope, events, useCase, project)),
             ),
         )
 
@@ -317,7 +330,7 @@ class EventRemoteDataSourceTest {
                 match { body ->
                     assertThat(body.sessions).hasSize(1)
                     assertThat(body.sessions.firstOrNull())
-                        .isEqualTo(ApiEventScope.fromDomain(scope, events))
+                        .isEqualTo(ApiEventScope.fromDomain(scope, events, useCase, project))
                     true
                 },
             )

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventScopeToApiUseCaseTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventScopeToApiUseCaseTest.kt
@@ -1,0 +1,86 @@
+package com.simprints.infra.eventsync.event.usecases
+
+import com.simprints.core.tools.time.Timestamp
+import com.simprints.infra.config.store.models.Project
+import com.simprints.infra.events.event.domain.models.Event
+import com.simprints.infra.events.event.domain.models.scope.DatabaseInfo
+import com.simprints.infra.events.event.domain.models.scope.Device
+import com.simprints.infra.events.event.domain.models.scope.EventScope
+import com.simprints.infra.events.event.domain.models.scope.EventScopePayload
+import com.simprints.infra.events.event.domain.models.scope.EventScopeType
+import com.simprints.infra.eventsync.event.remote.models.ApiEvent
+import com.simprints.infra.eventsync.event.remote.models.fromDomainToApi
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+
+internal class MapDomainEventScopeToApiUseCaseTest {
+    @MockK
+    lateinit var mapDomainEventToApiUseCase: MapDomainEventToApiUseCase
+
+    @MockK
+    lateinit var project: Project
+
+    private lateinit var useCase: MapDomainEventScopeToApiUseCase
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxed = true)
+        useCase = MapDomainEventScopeToApiUseCase(mapDomainEventToApiUseCase)
+    }
+
+    @Test
+    fun `should map events using use case`() {
+        val scope = createBlankSessionScope()
+        val events = listOf(
+            mockk<Event>()
+        )
+        val resultEvent = mockk<ApiEvent>()
+        every { mapDomainEventToApiUseCase(any(), any()) } returns resultEvent
+
+        val result = useCase(scope, events, project)
+        verify { mapDomainEventToApiUseCase(events.first(), project) }
+        assertEquals(result.events.first(), resultEvent)
+    }
+
+    @Test
+    fun `should map fields correctly`() {
+        val scope = createBlankSessionScope()
+        val events = listOf(
+            mockk<Event>()
+        )
+        val resultEvent = mockk<ApiEvent>()
+        every { mapDomainEventToApiUseCase(any(), any()) } returns resultEvent
+
+        with(useCase(scope, events, project)) {
+            assertEquals(id, scope.id)
+            assertEquals(projectId, scope.projectId)
+            assertEquals(startTime.unixMs, scope.createdAt.ms)
+            assertEquals(endTime, scope.endedAt)
+        }
+
+    }
+
+    private fun createBlankSessionScope() = EventScope(
+        id = "eventId",
+        projectId = "projectId",
+        type = EventScopeType.SESSION,
+        createdAt = Timestamp(0L),
+        endedAt = null,
+        payload = EventScopePayload(
+            endCause = null,
+            modalities = emptyList(),
+            sidVersion = "appVersionName",
+            libSimprintsVersion = "libVersionName",
+            language = "language",
+            device = Device("deviceId", "deviceModel", "deviceManufacturer"),
+            databaseInfo = DatabaseInfo(0, 0),
+            projectConfigurationUpdatedAt = "",
+            projectConfigurationId = "",
+            location = null,
+        ),
+    )
+}

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventToApiUseCaseTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventToApiUseCaseTest.kt
@@ -1,4 +1,4 @@
-package com.simprints.infra.eventsync.event.remote
+package com.simprints.infra.eventsync.event.usecases
 
 import androidx.test.ext.junit.runners.*
 import com.google.common.truth.Truth.*
@@ -86,8 +86,6 @@ import com.simprints.infra.eventsync.event.remote.models.ApiEventPayloadType.Sca
 import com.simprints.infra.eventsync.event.remote.models.ApiEventPayloadType.ScannerFirmwareUpdate
 import com.simprints.infra.eventsync.event.remote.models.ApiEventPayloadType.SuspiciousIntent
 import com.simprints.infra.eventsync.event.remote.models.ApiEventPayloadType.Vero2InfoSnapshot
-import com.simprints.infra.eventsync.event.remote.models.fromDomainToApi
-import com.simprints.infra.eventsync.event.usecases.TokenizeEventPayloadFieldsUseCase
 import com.simprints.infra.eventsync.event.validateAgeGroupSelectionEventApiModel
 import com.simprints.infra.eventsync.event.validateAlertScreenEventApiModel
 import com.simprints.infra.eventsync.event.validateAuthenticationEventApiModel
@@ -129,10 +127,8 @@ import org.junit.runner.RunWith
 
 @Suppress("IMPLICIT_CAST_TO_ANY", "KotlinConstantConditions")
 @RunWith(AndroidJUnit4::class)
-class ApiEventTest {
+internal class MapDomainEventToApiUseCaseTest {
     private val jackson = JsonHelper.jackson
-    private val tokenizationProcessor = TokenizationProcessor(StringTokenizer(EncodingUtilsImplForTests))
-    private val useCase = TokenizeEventPayloadFieldsUseCase(tokenizationProcessor)
     private val project = Project(
         id = "id",
         name = "name",
@@ -143,12 +139,14 @@ class ApiEventTest {
         baseUrl = "baseUrl",
         tokenizationKeys = emptyMap(),
     )
-
+    private val tokenizationProcessor = TokenizationProcessor(StringTokenizer(EncodingUtilsImplForTests))
+    private val tokenizeEventPayloadFieldsUseCase = TokenizeEventPayloadFieldsUseCase(tokenizationProcessor)
+    private val useCase = MapDomainEventToApiUseCase(tokenizeEventPayloadFieldsUseCase)
 
     @Test
     fun validate_alertScreenEventApiModel() {
         val event = createAlertScreenEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateAlertScreenEventApiModel(json)
@@ -157,7 +155,7 @@ class ApiEventTest {
     @Test
     fun validate_IntentParsingEventApiModel() {
         val event = createIntentParsingEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateIntentParsingEventApiModel(json)
@@ -166,7 +164,7 @@ class ApiEventTest {
     @Test
     fun validate_authenticationEventApiModel() {
         val event = createAuthenticationEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateAuthenticationEventApiModel(json)
@@ -175,7 +173,7 @@ class ApiEventTest {
     @Test
     fun validate_authorizationEventApiModel() {
         val event = createAuthorizationEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateAuthorizationEventApiModel(json)
@@ -184,7 +182,7 @@ class ApiEventTest {
     @Test
     fun validate_calloutEventForVerificationApiModel() {
         val event = createVerificationCalloutEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCalloutEventApiModel(json)
@@ -193,7 +191,7 @@ class ApiEventTest {
     @Test
     fun validate_calloutEventForIdentificationApiModel() {
         val event = createIdentificationCalloutEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCalloutEventApiModel(json)
@@ -202,7 +200,7 @@ class ApiEventTest {
     @Test
     fun validate_calloutEventForEnrolLastBiometricsModel() {
         val event = createLastBiometricsEnrolmentCalloutEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCalloutEventApiModel(json)
@@ -211,7 +209,7 @@ class ApiEventTest {
     @Test
     fun validate_calloutEventForConfirmationApiModel() {
         val event = createConfirmationCalloutEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCalloutEventApiModel(json)
@@ -220,7 +218,7 @@ class ApiEventTest {
     @Test
     fun validate_calloutEventForEnrolmentApiModel() {
         val event = createEnrolmentCalloutEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCalloutEventApiModel(json)
@@ -229,7 +227,7 @@ class ApiEventTest {
     @Test
     fun validate_callbackEventForEnrolmentApiModel() {
         val event = createEnrolmentCallbackEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCallbackV1EventApiModel(json)
@@ -238,7 +236,7 @@ class ApiEventTest {
     @Test
     fun validate_callbackEventForErrorApiModel() {
         val event = createEnrolmentCallbackEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCallbackV1EventApiModel(json)
@@ -247,7 +245,7 @@ class ApiEventTest {
     @Test
     fun validate_callbackEventForIdentificationApiV2Model() {
         val event = createIdentificationCallbackEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCallbackV2EventApiModel(json)
@@ -256,7 +254,7 @@ class ApiEventTest {
     @Test
     fun validate_callbackEventForVerificationV1ApiModel() {
         val event = createVerificationCallbackEventV1()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCallbackV1EventApiModel(json)
@@ -265,7 +263,7 @@ class ApiEventTest {
     @Test
     fun validate_callbackEventForVerificationV2ApiModel() {
         val event = createVerificationCallbackEventV2()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCallbackV2EventApiModel(json)
@@ -274,7 +272,7 @@ class ApiEventTest {
     @Test
     fun validate_callbackEventForRefusalApiModel() {
         val event = createRefusalCallbackEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCallbackV1EventApiModel(json)
@@ -283,7 +281,7 @@ class ApiEventTest {
     @Test
     fun validate_callbackEventForConfirmationApiModel() {
         val event = createConfirmationCallbackEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCallbackV1EventApiModel(json)
@@ -292,7 +290,7 @@ class ApiEventTest {
     @Test
     fun validate_candidateReadEventApiModel() {
         val event = createCandidateReadEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCandidateReadEventApiModel(json)
@@ -301,7 +299,7 @@ class ApiEventTest {
     @Test
     fun validate_connectivitySnapshotEventApiModel() {
         val event = createConnectivitySnapshotEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateConnectivitySnapshotEventApiModel(json)
@@ -310,7 +308,7 @@ class ApiEventTest {
     @Test
     fun validate_consentEventApiModel() {
         val event = createConsentEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateConsentEventApiModel(json)
@@ -319,7 +317,7 @@ class ApiEventTest {
     @Test
     fun validateEnrolmentV1_enrolmentEventApiModel() {
         val event = createEnrolmentEventV1()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateEnrolmentEventV1ApiModel(json)
@@ -328,7 +326,7 @@ class ApiEventTest {
     @Test
     fun validateEnrolmentV2_enrolmentEventApiModel() {
         val event = createEnrolmentEventV2()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateEnrolmentEventV2ApiModel(json)
@@ -337,7 +335,7 @@ class ApiEventTest {
     @Test
     fun validate_completionCheckEventApiModel() {
         val event = createCompletionCheckEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateCompletionCheckEventApiModel(json)
@@ -346,7 +344,7 @@ class ApiEventTest {
     @Test
     fun validate_fingerprintCaptureEventApiModel() {
         val event = createFingerprintCaptureEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateFingerprintCaptureEventApiModel(json)
@@ -355,7 +353,7 @@ class ApiEventTest {
     @Test
     fun validate_guidSelectionEventApiModel() {
         val event = createGuidSelectionEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateGuidSelectionEventApiModel(json)
@@ -364,7 +362,7 @@ class ApiEventTest {
     @Test
     fun validate_oneToManyMatchEventApiModel() {
         val event = createOneToManyMatchEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateOneToManyMatchEventApiModel(json)
@@ -373,7 +371,7 @@ class ApiEventTest {
     @Test
     fun validate_oneToOneMatchEventApiModel() {
         val event = createOneToOneMatchEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateOneToOneMatchEventApiModel(json)
@@ -382,7 +380,7 @@ class ApiEventTest {
     @Test
     fun validate_personCreationEventApiModel() {
         val event = createPersonCreationEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validatePersonCreationEvent(json)
@@ -391,7 +389,7 @@ class ApiEventTest {
     @Test
     fun validate_refusalEventApiModel() {
         val event = createRefusalEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateRefusalEventApiModel(json)
@@ -400,7 +398,7 @@ class ApiEventTest {
     @Test
     fun validate_suspiciousIntentEventApiModel() {
         val event = createSuspiciousIntentEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateSuspiciousIntentEventApiModel(json)
@@ -409,7 +407,7 @@ class ApiEventTest {
     @Test
     fun validate_scannerConnectionEventApiModel() {
         val event = createScannerConnectionEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateScannerConnectionEventApiModel(json)
@@ -418,7 +416,7 @@ class ApiEventTest {
     @Test
     fun validate_vero2InfoSnapshotEvent() {
         val event = createVero2InfoSnapshotEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateVero2InfoSnapshotEventApiModel(json)
@@ -427,7 +425,7 @@ class ApiEventTest {
     @Test
     fun validate_scannerFirmwareUpdateEvent() {
         val event = createScannerFirmwareUpdateEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateScannerFirmwareUpdateEventApiModel(json)
@@ -436,7 +434,7 @@ class ApiEventTest {
     @Test
     fun validate_invalidEventApiModel() {
         val event = createInvalidIntentEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateInvalidEventApiModel(json)
@@ -445,7 +443,7 @@ class ApiEventTest {
     @Test
     fun validate_FaceOnboardingCompleteEventApiModel() {
         val event = createFaceOnboardingCompleteEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateFaceOnboardingCompleteEventApiModel(json)
@@ -454,7 +452,7 @@ class ApiEventTest {
     @Test
     fun validate_FaceFallbackCaptureEventApiModel() {
         val event = createFaceFallbackCaptureEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateFaceFallbackCaptureEventApiModel(json)
@@ -463,7 +461,7 @@ class ApiEventTest {
     @Test
     fun validate_FaceCaptureEventApiModel() {
         val event = createFaceCaptureEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateFaceCaptureEventApiModel(json)
@@ -472,7 +470,7 @@ class ApiEventTest {
     @Test
     fun validate_FaceCaptureConfirmationEventApiModel() {
         val event = createFaceCaptureConfirmationEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateFaceCaptureConfirmationEventApiModel(json)
@@ -481,7 +479,7 @@ class ApiEventTest {
     @Test
     fun validate_FaceCaptureBiometricsEventApiModel() {
         val event = createFaceCaptureBiometricsEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateFaceCaptureBiometricsEventApiModel(json)
@@ -490,7 +488,7 @@ class ApiEventTest {
     @Test
     fun validate_FingerprintCaptureBiometricsEventApiModel() {
         val event = createFingerprintCaptureBiometricsEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateFingerprintCaptureBiometricsEventApiModel(json)
@@ -499,7 +497,7 @@ class ApiEventTest {
     @Test
     fun validate_DownSyncRequestEventApiModel() {
         val event = createEventDownSyncRequestEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateDownSyncRequestEventApiModel(json)
@@ -508,7 +506,7 @@ class ApiEventTest {
     @Test
     fun validate_UpSyncRequestEventApiModel() {
         val event = createEventUpSyncRequestEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateUpSyncRequestEventApiModel(json)
@@ -517,7 +515,7 @@ class ApiEventTest {
     @Test
     fun validate_ageGroupSelectionEventApiModel() {
         val event = createAgeGroupSelectionEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateAgeGroupSelectionEventApiModel(json)
@@ -546,7 +544,7 @@ class ApiEventTest {
     @Test
     fun validate_licenseCheckEventApiModel() {
         val event = createLicenseCheckEvent()
-        val apiEvent = event.fromDomainToApi(useCase, project)
+        val apiEvent = useCase(event, project)
         val json = JSONObject(jackson.writeValueAsString(apiEvent))
 
         validateLicenseCheckEventApiModel(json)
@@ -561,7 +559,7 @@ class ApiEventTest {
         val event = createEnrolmentEventV2().let {
             it.copy(payload = it.payload.copy(moduleId = moduleId))
         }
-        with(event.fromDomainToApi(useCase, project).tokenizedFields) {
+        with(useCase(event, project).tokenizedFields) {
             when (moduleId) {
                 is TokenizableString.Raw -> assertThat(size).isEqualTo(0)
                 is TokenizableString.Tokenized -> {
@@ -576,7 +574,7 @@ class ApiEventTest {
         val event = createEnrolmentEventV2().let {
             it.copy(payload = it.payload.copy(attendantId = attendantId))
         }
-        with(event.fromDomainToApi(useCase, project).tokenizedFields) {
+        with(useCase(event, project).tokenizedFields) {
             when (attendantId) {
                 is TokenizableString.Raw -> assertThat(size).isEqualTo(0)
                 is TokenizableString.Tokenized -> {

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCaseTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCaseTest.kt
@@ -37,7 +37,7 @@ internal class TokenizeEventPayloadFieldsUseCaseTest {
 
         val tokenizedMap = mapOf(tokenKeyType to rawString)
 
-        every { event.getTokenizedFields() } returns tokenizedMap
+        every { event.getTokenizableFields() } returns tokenizedMap
         every { tokenizationProcessor.encrypt(rawString, tokenKeyType, project) } returns tokenizedString
 
         useCase(event = event, project = project)
@@ -52,7 +52,7 @@ internal class TokenizeEventPayloadFieldsUseCaseTest {
         val tokenizedString = TokenizableString.Tokenized("encrypted")
         val tokenizedMap = mapOf(tokenKeyType to tokenizedString)
 
-        every { event.getTokenizedFields() } returns tokenizedMap
+        every { event.getTokenizableFields() } returns tokenizedMap
 
         useCase(event = event, project = project)
 

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCaseTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCaseTest.kt
@@ -1,0 +1,61 @@
+package com.simprints.infra.eventsync.event.usecases
+
+import com.simprints.core.domain.tokenization.TokenizableString
+import com.simprints.infra.config.store.models.Project
+import com.simprints.infra.config.store.models.TokenKeyType
+import com.simprints.infra.config.store.tokenization.TokenizationProcessor
+import com.simprints.infra.events.event.domain.models.Event
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import org.junit.Before
+import kotlin.test.Test
+
+
+internal class TokenizeEventPayloadFieldsUseCaseTest {
+    @MockK
+    lateinit var tokenizationProcessor: TokenizationProcessor
+
+    @MockK
+    lateinit var project: Project
+
+    @MockK
+    lateinit var event: Event
+
+    lateinit var useCase: TokenizeEventPayloadFieldsUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+        useCase = TokenizeEventPayloadFieldsUseCase(tokenizationProcessor)
+    }
+
+    @Test
+    fun `should invoke tokenizationProcessor encrypt for TokenizableString Raw`() {
+        val tokenKeyType = mockk<TokenKeyType>()
+        val rawString = TokenizableString.Raw("decrypted")
+        val tokenizedString = TokenizableString.Tokenized("encrypted")
+
+        val tokenizedMap = mapOf(tokenKeyType to rawString)
+
+        every { event.getTokenizedFields() } returns tokenizedMap
+        every { tokenizationProcessor.encrypt(rawString, tokenKeyType, project) } returns tokenizedString
+
+        useCase(event = event, project = project)
+
+        verify { tokenizationProcessor.encrypt(rawString, tokenKeyType, project) }
+        verify { event.setTokenizedFields(mapOf(tokenKeyType to tokenizedString)) }
+    }
+
+    @Test
+    fun `should set the same tokenized string if already tokenized`() {
+        val tokenKeyType = mockk<TokenKeyType>()
+        val tokenizedString = TokenizableString.Tokenized("encrypted")
+        val tokenizedMap = mapOf(tokenKeyType to tokenizedString)
+
+        every { event.getTokenizedFields() } returns tokenizedMap
+
+        useCase(event = event, project = project)
+
+        verify { event.setTokenizedFields(mapOf(tokenKeyType to tokenizedString)) }
+    }
+}

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AgeGroupSelectionEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AgeGroupSelectionEvent.kt
@@ -25,7 +25,7 @@ data class AgeGroupSelectionEvent(
         AGE_GROUP_SELECTION,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AlertScreenEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AlertScreenEvent.kt
@@ -24,7 +24,7 @@ data class AlertScreenEvent(
         ALERT_SCREEN,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AuthenticationEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AuthenticationEvent.kt
@@ -28,7 +28,7 @@ data class AuthenticationEvent(
         AUTHENTICATION,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = mapOf(TokenKeyType.AttendantId to payload.userInfo.userId)
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = mapOf(TokenKeyType.AttendantId to payload.userInfo.userId)
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this.copy(
         payload = payload.copy(

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AuthorizationEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/AuthorizationEvent.kt
@@ -27,7 +27,7 @@ data class AuthorizationEvent(
         AUTHORIZATION,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = if (payload.userInfo == null) {
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = if (payload.userInfo == null) {
         emptyMap()
     } else {
         mapOf(TokenKeyType.AttendantId to payload.userInfo.userId)

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/CandidateReadEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/CandidateReadEvent.kt
@@ -34,7 +34,7 @@ data class CandidateReadEvent(
         CANDIDATE_READ,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/CompletionCheckEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/CompletionCheckEvent.kt
@@ -24,7 +24,7 @@ data class CompletionCheckEvent(
         COMPLETION_CHECK,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ConnectivitySnapshotEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ConnectivitySnapshotEvent.kt
@@ -25,7 +25,7 @@ data class ConnectivitySnapshotEvent(
         CONNECTIVITY_SNAPSHOT,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ConsentEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ConsentEvent.kt
@@ -26,7 +26,7 @@ data class ConsentEvent(
         CONSENT,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/EnrolmentEventV1.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/EnrolmentEventV1.kt
@@ -25,7 +25,7 @@ data class EnrolmentEventV1(
         ENROLMENT_V1,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/EnrolmentEventV2.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/EnrolmentEventV2.kt
@@ -36,7 +36,7 @@ data class EnrolmentEventV2(
         ENROLMENT_V2,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = mapOf(
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = mapOf(
         TokenKeyType.AttendantId to payload.attendantId,
         TokenKeyType.ModuleId to payload.moduleId,
     )

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/Event.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/Event.kt
@@ -148,7 +148,7 @@ abstract class Event {
     abstract var projectId: String?
 
     @JsonIgnore
-    abstract fun getTokenizedFields(): Map<TokenKeyType, TokenizableString>
+    abstract fun getTokenizableFields(): Map<TokenKeyType, TokenizableString>
 
     abstract fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>): Event
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/GuidSelectionEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/GuidSelectionEvent.kt
@@ -24,7 +24,7 @@ data class GuidSelectionEvent(
         GUID_SELECTION,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/IntentParsingEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/IntentParsingEvent.kt
@@ -24,7 +24,7 @@ data class IntentParsingEvent(
         INTENT_PARSING,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/InvalidIntentEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/InvalidIntentEvent.kt
@@ -25,7 +25,7 @@ data class InvalidIntentEvent(
         INVALID_INTENT,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/LicenseCheckEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/LicenseCheckEvent.kt
@@ -38,7 +38,7 @@ data class LicenseCheckEvent(
         ERROR,
     }
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/OneToManyMatchEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/OneToManyMatchEvent.kt
@@ -27,7 +27,7 @@ data class OneToManyMatchEvent(
         ONE_TO_MANY_MATCH,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/OneToOneMatchEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/OneToOneMatchEvent.kt
@@ -36,7 +36,7 @@ data class OneToOneMatchEvent(
         ONE_TO_ONE_MATCH,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/PersonCreationEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/PersonCreationEvent.kt
@@ -34,7 +34,7 @@ data class PersonCreationEvent(
         PERSON_CREATION,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/RefusalEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/RefusalEvent.kt
@@ -32,7 +32,7 @@ data class RefusalEvent(
         REFUSAL,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ScannerConnectionEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ScannerConnectionEvent.kt
@@ -24,7 +24,7 @@ data class ScannerConnectionEvent(
         SCANNER_CONNECTION,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ScannerFirmwareUpdateEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ScannerFirmwareUpdateEvent.kt
@@ -34,7 +34,7 @@ data class ScannerFirmwareUpdateEvent(
         SCANNER_FIRMWARE_UPDATE,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/SuspiciousIntentEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/SuspiciousIntentEvent.kt
@@ -24,7 +24,7 @@ data class SuspiciousIntentEvent(
         SUSPICIOUS_INTENT,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/Vero2InfoSnapshotEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/Vero2InfoSnapshotEvent.kt
@@ -32,7 +32,7 @@ data class Vero2InfoSnapshotEvent(
         VERO_2_INFO_SNAPSHOT,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/ConfirmationCallbackEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/ConfirmationCallbackEvent.kt
@@ -27,7 +27,7 @@ data class ConfirmationCallbackEvent(
         CALLBACK_CONFIRMATION,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/EnrolmentCallbackEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/EnrolmentCallbackEvent.kt
@@ -27,7 +27,7 @@ data class EnrolmentCallbackEvent(
         CALLBACK_ENROLMENT,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/ErrorCallbackEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/ErrorCallbackEvent.kt
@@ -28,7 +28,7 @@ data class ErrorCallbackEvent(
         CALLBACK_ERROR,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/IdentificationCallbackEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/IdentificationCallbackEvent.kt
@@ -27,7 +27,7 @@ data class IdentificationCallbackEvent(
         EventType.CALLBACK_IDENTIFICATION,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/RefusalCallbackEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/RefusalCallbackEvent.kt
@@ -28,7 +28,7 @@ data class RefusalCallbackEvent(
         CALLBACK_REFUSAL,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/VerificationCallbackEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callback/VerificationCallbackEvent.kt
@@ -27,7 +27,7 @@ data class VerificationCallbackEvent(
         CALLBACK_VERIFICATION,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEvent.kt
@@ -29,7 +29,7 @@ data class ConfirmationCalloutEvent(
         CALLOUT_CONFIRMATION,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/EnrolmentCalloutEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/EnrolmentCalloutEvent.kt
@@ -38,7 +38,7 @@ data class EnrolmentCalloutEvent(
         CALLOUT_ENROLMENT,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = mapOf(
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = mapOf(
         TokenKeyType.AttendantId to payload.userId,
         TokenKeyType.ModuleId to payload.moduleId,
     )

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/EnrolmentLastBiometricsCalloutEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/EnrolmentLastBiometricsCalloutEvent.kt
@@ -39,7 +39,7 @@ data class EnrolmentLastBiometricsCalloutEvent(
         CALLOUT_LAST_BIOMETRICS,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = mapOf(
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = mapOf(
         TokenKeyType.AttendantId to payload.userId,
         TokenKeyType.ModuleId to payload.moduleId,
     )

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/IdentificationCalloutEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/IdentificationCalloutEvent.kt
@@ -37,7 +37,7 @@ data class IdentificationCalloutEvent(
         CALLOUT_IDENTIFICATION,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = mapOf(
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = mapOf(
         TokenKeyType.AttendantId to payload.userId,
         TokenKeyType.ModuleId to payload.moduleId,
     )

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/VerificationCalloutEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/VerificationCalloutEvent.kt
@@ -39,7 +39,7 @@ data class VerificationCalloutEvent(
         CALLOUT_VERIFICATION,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = mapOf(
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = mapOf(
         TokenKeyType.AttendantId to payload.userId,
         TokenKeyType.ModuleId to payload.moduleId,
     )

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/downsync/EventDownSyncRequestEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/downsync/EventDownSyncRequestEvent.kt
@@ -42,7 +42,7 @@ data class EventDownSyncRequestEvent(
         EventType.EVENT_DOWN_SYNC_REQUEST,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = listOf(
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = listOf(
         payload.queryParameters.attendantId?.let { TokenKeyType.AttendantId to TokenizableString.Tokenized(it) },
         payload.queryParameters.moduleId?.let { TokenKeyType.ModuleId to TokenizableString.Tokenized(it) },
     ).mapNotNull { it }.toMap()

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureBiometricsEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureBiometricsEvent.kt
@@ -33,7 +33,7 @@ data class FaceCaptureBiometricsEvent(
         EventType.FACE_CAPTURE_BIOMETRICS,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureConfirmationEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureConfirmationEvent.kt
@@ -29,7 +29,7 @@ data class FaceCaptureConfirmationEvent(
         FACE_CAPTURE_CONFIRMATION,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureEvent.kt
@@ -47,7 +47,7 @@ data class FaceCaptureEvent(
         FACE_CAPTURE,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceFallbackCaptureEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceFallbackCaptureEvent.kt
@@ -27,7 +27,7 @@ data class FaceFallbackCaptureEvent(
         FACE_FALLBACK_CAPTURE,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceOnboardingCompleteEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/face/FaceOnboardingCompleteEvent.kt
@@ -27,7 +27,7 @@ data class FaceOnboardingCompleteEvent(
         FACE_ONBOARDING_COMPLETE,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/fingerprint/FingerprintCaptureBiometricsEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/fingerprint/FingerprintCaptureBiometricsEvent.kt
@@ -34,7 +34,7 @@ data class FingerprintCaptureBiometricsEvent(
         type = EventType.FINGERPRINT_CAPTURE_BIOMETRICS,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/fingerprint/FingerprintCaptureEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/fingerprint/FingerprintCaptureEvent.kt
@@ -43,7 +43,7 @@ data class FingerprintCaptureEvent(
         FINGERPRINT_CAPTURE,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>) = this // No tokenized fields
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/upsync/EventUpSyncRequestEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/upsync/EventUpSyncRequestEvent.kt
@@ -60,7 +60,7 @@ data class EventUpSyncRequestEvent(
         val eventDownSyncCount: Int = 0,
     )
 
-    override fun getTokenizedFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
+    override fun getTokenizableFields(): Map<TokenKeyType, TokenizableString> = emptyMap()
 
     override fun setTokenizedFields(map: Map<TokenKeyType, TokenizableString>): Event = this
 

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/downsync/EventDownSyncRequestEventTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/downsync/EventDownSyncRequestEventTest.kt
@@ -11,49 +11,49 @@ import org.junit.Test
 
 class EventDownSyncRequestEventTest {
     @Test
-    fun `getTokenizedFields returns empty map when attendantId and moduleId are null`() {
+    fun `getTokenizableFields returns empty map when attendantId and moduleId are null`() {
         val event = getEventDownSyncRequestEvent(
             attendantId = null,
             moduleId = null,
         )
 
-        val result = event.getTokenizedFields()
+        val result = event.getTokenizableFields()
 
         assertEquals(emptyMap<TokenKeyType, TokenizableString>(), result)
     }
 
     @Test
-    fun `getTokenizedFields returns map with AttendantId when only attendantId is not null`() {
+    fun `getTokenizableFields returns map with AttendantId when only attendantId is not null`() {
         val event = getEventDownSyncRequestEvent(
             attendantId = "attendantId",
             moduleId = null,
         )
 
-        val result = event.getTokenizedFields()
+        val result = event.getTokenizableFields()
 
         assertEquals(mapOf(TokenKeyType.AttendantId to TokenizableString.Tokenized("attendantId")), result)
     }
 
     @Test
-    fun `getTokenizedFields returns map with ModuleId when only moduleId is not null`() {
+    fun `getTokenizableFields returns map with ModuleId when only moduleId is not null`() {
         val event = getEventDownSyncRequestEvent(
             attendantId = null,
             moduleId = "moduleId",
         )
 
-        val result = event.getTokenizedFields()
+        val result = event.getTokenizableFields()
 
         assertEquals(mapOf(TokenKeyType.ModuleId to TokenizableString.Tokenized("moduleId")), result)
     }
 
     @Test
-    fun `getTokenizedFields returns map with AttendantId and ModuleId when both are not null`() {
+    fun `getTokenizableFields returns map with AttendantId and ModuleId when both are not null`() {
         val event = getEventDownSyncRequestEvent(
             attendantId = "attendantId",
             moduleId = "moduleId",
         )
 
-        val result = event.getTokenizedFields()
+        val result = event.getTokenizableFields()
 
         assertEquals(
             mapOf(


### PR DESCRIPTION
## Overview
When sending events to the BFSID, we need to make sure that all the values necessary values are tokenized.

## Implementation
- `TokenizeEventPayloadFieldsUseCase` is added. This use case gets the tokenizable fields of each `Event` object and checks whether they are tokenized. If not, attempts to tokenize said fields.
- `Event.fromDomainToApi` now takes the abovementioned use-case as an argument, and runs the tokenization before mapping the domain Event model to the API model.