### PR TITLE
[MS-852] Tokenizable fields from CommCare response are now properly filtered

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
@@ -229,7 +229,7 @@ internal class SyncInfoViewModel @Inject constructor(
     private suspend fun getModuleCounts(projectId: String): List<ModuleCount> =
         configManager.getDeviceConfiguration().selectedModules.map { moduleName ->
             val count = enrolmentRecordRepository.count(
-                SubjectQuery(projectId = projectId, moduleId = moduleName.value),
+                SubjectQuery(projectId = projectId, moduleId = moduleName),
             )
             val decryptedName = when (moduleName) {
                 is TokenizableString.Raw -> moduleName

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/repository/ModuleRepositoryImpl.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/repository/ModuleRepositoryImpl.kt
@@ -47,7 +47,7 @@ internal class ModuleRepositoryImpl @Inject constructor(
 
     private suspend fun handleUnselectedModules(unselectedModules: List<Module>) {
         val queries = unselectedModules.map {
-            SubjectQuery(moduleId = it.name.value)
+            SubjectQuery(moduleId = it.name)
         }
         enrolmentRecordRepository.delete(queries)
 

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
@@ -169,7 +169,7 @@ class SyncInfoViewModelTest {
             enrolmentRecordRepository.count(
                 SubjectQuery(
                     projectId = PROJECT_ID,
-                    moduleId = module1.value,
+                    moduleId = module1,
                 ),
             )
         } returns numberForModule1
@@ -177,7 +177,7 @@ class SyncInfoViewModelTest {
             enrolmentRecordRepository.count(
                 SubjectQuery(
                     projectId = PROJECT_ID,
-                    moduleId = module2.value,
+                    moduleId = module2,
                 ),
             )
         } returns numberForModule2

--- a/feature/matcher/build.gradle.kts
+++ b/feature/matcher/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
     implementation(project(":face:infra:bio-sdk-resolver"))
 
     implementation(project(":fingerprint:infra:bio-sdk"))
+    implementation(project(":infra:auth-store"))
 }

--- a/feature/matcher/src/main/java/com/simprints/matcher/usecases/FaceMatcherUseCase.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/usecases/FaceMatcherUseCase.kt
@@ -5,6 +5,7 @@ import com.simprints.face.infra.basebiosdk.matching.FaceIdentity
 import com.simprints.face.infra.basebiosdk.matching.FaceMatcher
 import com.simprints.face.infra.basebiosdk.matching.FaceSample
 import com.simprints.face.infra.biosdkresolver.ResolveFaceBioSdkUseCase
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.enrolment.records.store.EnrolmentRecordRepository
 import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
 import com.simprints.infra.enrolment.records.store.domain.models.SubjectQuery
@@ -32,6 +33,7 @@ internal class FaceMatcherUseCase @Inject constructor(
 
     override suspend operator fun invoke(
         matchParams: MatchParams,
+        project: Project,
     ): Flow<MatcherState> = channelFlow {
         Simber.i("Initialising matcher", tag = crashReportTag)
         faceMatcher = resolveFaceBioSdk().matcher
@@ -61,6 +63,7 @@ internal class FaceMatcherUseCase @Inject constructor(
                         val batchCandidates = getCandidates(
                             queryWithSupportedFormat,
                             range,
+                            project = project,
                             dataSource = matchParams.biometricDataSource,
                         ) {
                             // When a candidate is loaded
@@ -84,9 +87,10 @@ internal class FaceMatcherUseCase @Inject constructor(
         query: SubjectQuery,
         range: IntRange,
         dataSource: BiometricDataSource = BiometricDataSource.Simprints,
+        project: Project,
         onCandidateLoaded: () -> Unit,
     ) = enrolmentRecordRepository
-        .loadFaceIdentities(query, range, dataSource, onCandidateLoaded)
+        .loadFaceIdentities(query, range, dataSource, project, onCandidateLoaded)
         .map {
             FaceIdentity(
                 it.subjectId,

--- a/feature/matcher/src/main/java/com/simprints/matcher/usecases/MatcherUseCase.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/usecases/MatcherUseCase.kt
@@ -1,5 +1,6 @@
 package com.simprints.matcher.usecases
 
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.logging.LoggingConstants
 import com.simprints.matcher.MatchParams
 import com.simprints.matcher.MatchResultItem
@@ -12,7 +13,7 @@ internal interface MatcherUseCase {
      * Returns a MatcherResult which contains a list of [MatchResultItem]s sorted by confidence score in descending order,
      * the total number of candidates that were considered and the name of the matcher that was used
      */
-    suspend operator fun invoke(matchParams: MatchParams): Flow<MatcherState>
+    suspend operator fun invoke(matchParams: MatchParams, project: Project): Flow<MatcherState>
 
     sealed class MatcherState {
         data class LoadingStarted(val totalCandidates: Int) : MatcherState()

--- a/feature/matcher/src/test/java/com/simprints/matcher/screen/MatchViewModelTest.kt
+++ b/feature/matcher/src/test/java/com/simprints/matcher/screen/MatchViewModelTest.kt
@@ -7,7 +7,9 @@ import com.simprints.core.domain.common.FlowType
 import com.simprints.core.domain.fingerprint.IFingerIdentifier
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
+import com.simprints.infra.authstore.AuthStore
 import com.simprints.infra.config.store.models.FingerprintConfiguration.BioSdk.SECUGEN_SIM_MATCHER
+import com.simprints.infra.config.sync.ConfigManager
 import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
 import com.simprints.matcher.FaceMatchResult
 import com.simprints.matcher.FingerprintMatchResult
@@ -55,6 +57,12 @@ internal class MatchViewModelTest {
     @MockK
     lateinit var timeHelper: TimeHelper
 
+    @MockK
+    lateinit var authStore: AuthStore
+
+    @MockK
+    lateinit var configManager: ConfigManager
+
     private lateinit var cb1: CapturingSlot<(Int) -> Unit>
     private val totalCandidates = 384
     private lateinit var viewModel: MatchViewModel
@@ -71,6 +79,8 @@ internal class MatchViewModelTest {
             faceMatcherUseCase,
             fingerprintMatcherUseCase,
             saveMatchEvent,
+            authStore,
+            configManager,
             timeHelper,
         )
     }
@@ -81,7 +91,7 @@ internal class MatchViewModelTest {
             FaceMatchResult.Item("1", 90f),
         )
 
-        coEvery { faceMatcherUseCase.invoke(any()) } returns flow {
+        coEvery { faceMatcherUseCase.invoke(any(), any()) } returns flow {
             emit(MatcherUseCase.MatcherState.LoadingStarted(responseItems.size))
             emit(MatcherUseCase.MatcherState.CandidateLoaded)
             emit(
@@ -127,7 +137,7 @@ internal class MatchViewModelTest {
             FaceMatchResult.Item("1", 20f),
             FaceMatchResult.Item("1", 10f),
         )
-        coEvery { faceMatcherUseCase.invoke(any()) } returns flow {
+        coEvery { faceMatcherUseCase.invoke(any(), any()) } returns flow {
             emit(MatcherUseCase.MatcherState.LoadingStarted(responseItems.size))
             emit(MatcherUseCase.MatcherState.CandidateLoaded)
             emit(
@@ -179,7 +189,7 @@ internal class MatchViewModelTest {
             FingerprintMatchResult.Item("1", 10f),
         )
 
-        coEvery { fingerprintMatcherUseCase.invoke(any()) } returns flow {
+        coEvery { fingerprintMatcherUseCase.invoke(any(), any()) } returns flow {
             emit(MatcherUseCase.MatcherState.LoadingStarted(responseItems.size))
             emit(MatcherUseCase.MatcherState.CandidateLoaded)
             emit(

--- a/feature/matcher/src/test/java/com/simprints/matcher/usecases/FaceMatcherUseCaseTest.kt
+++ b/feature/matcher/src/test/java/com/simprints/matcher/usecases/FaceMatcherUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.simprints.core.domain.common.FlowType
 import com.simprints.core.domain.face.FaceSample
 import com.simprints.face.infra.basebiosdk.matching.FaceMatcher
 import com.simprints.face.infra.biosdkresolver.ResolveFaceBioSdkUseCase
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.enrolment.records.store.EnrolmentRecordRepository
 import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
 import com.simprints.infra.enrolment.records.store.domain.models.FaceIdentity
@@ -44,6 +45,9 @@ internal class FaceMatcherUseCaseTest {
     lateinit var faceMatcher: FaceMatcher
 
     @MockK
+    lateinit var project: Project
+
+    @MockK
     lateinit var createRangesUseCase: CreateRangesUseCase
     private lateinit var useCase: FaceMatcherUseCase
 
@@ -69,6 +73,7 @@ internal class FaceMatcherUseCaseTest {
                 queryForCandidates = SubjectQuery(),
                 biometricDataSource = BiometricDataSource.Simprints,
             ),
+            project
         ).toList()
 
         coVerify(exactly = 0) { faceMatcher.getHighestComparisonScoreForCandidate(any(), any()) }
@@ -95,6 +100,7 @@ internal class FaceMatcherUseCaseTest {
                 queryForCandidates = SubjectQuery(),
                 biometricDataSource = BiometricDataSource.Simprints,
             ),
+            project
         ).toList()
 
         coVerify(exactly = 0) { faceMatcher.getHighestComparisonScoreForCandidate(any(), any()) }
@@ -119,7 +125,7 @@ internal class FaceMatcherUseCaseTest {
         )
         coEvery { enrolmentRecordRepository.count(any(), any()) } returns 100
         coEvery { createRangesUseCase(any()) } returns listOf(0..99)
-        coEvery { enrolmentRecordRepository.loadFaceIdentities(any(), any(), any(), any()) } returns faceIdentities
+        coEvery { enrolmentRecordRepository.loadFaceIdentities(any(), any(), any(), any(), any()) } returns faceIdentities
         coEvery { faceMatcher.getHighestComparisonScoreForCandidate(any(), any()) } returns 42f
 
 
@@ -132,6 +138,7 @@ internal class FaceMatcherUseCaseTest {
                 queryForCandidates = SubjectQuery(),
                 biometricDataSource = BiometricDataSource.Simprints,
             ),
+            project
         ).toList()
 
         coVerify { faceMatcher.getHighestComparisonScoreForCandidate(any(), any()) }

--- a/feature/matcher/src/test/java/com/simprints/matcher/usecases/FingerprintMatcherUseCaseTest.kt
+++ b/feature/matcher/src/test/java/com/simprints/matcher/usecases/FingerprintMatcherUseCaseTest.kt
@@ -8,6 +8,7 @@ import com.simprints.core.domain.fingerprint.IFingerIdentifier
 import com.simprints.fingerprint.infra.biosdk.BioSdkWrapper
 import com.simprints.fingerprint.infra.biosdk.ResolveBioSdkWrapperUseCase
 import com.simprints.infra.config.store.models.FingerprintConfiguration.BioSdk.SECUGEN_SIM_MATCHER
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.config.sync.ConfigManager
 import com.simprints.infra.enrolment.records.store.EnrolmentRecordRepository
 import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
@@ -45,6 +46,9 @@ internal class FingerprintMatcherUseCaseTest {
     lateinit var configManager: ConfigManager
 
     @MockK
+    lateinit var project: Project
+
+    @MockK
     lateinit var createRangesUseCase: CreateRangesUseCase
     private val onCandidateLoaded: () -> Unit = {}
     private lateinit var useCase: FingerprintMatcherUseCase
@@ -76,6 +80,7 @@ internal class FingerprintMatcherUseCaseTest {
                 queryForCandidates = SubjectQuery(),
                 biometricDataSource = BiometricDataSource.Simprints,
             ),
+           project
         ).toList()
 
         coVerify(exactly = 0) { bioSdkWrapper.match(any(), any(), any()) }
@@ -92,7 +97,7 @@ internal class FingerprintMatcherUseCaseTest {
     @Test
     fun `Skips matching if there are no candidates`() = runTest {
         coEvery { enrolmentRecordRepository.count(any()) } returns 0
-        coEvery { enrolmentRecordRepository.loadFaceIdentities(any(), any(), any(), onCandidateLoaded) } returns emptyList()
+        coEvery { enrolmentRecordRepository.loadFaceIdentities(any(), any(), any(), project, onCandidateLoaded) } returns emptyList()
         coEvery { bioSdkWrapper.match(any(), any(), any()) } returns listOf()
 
         val results = useCase.invoke(
@@ -109,6 +114,7 @@ internal class FingerprintMatcherUseCaseTest {
                 queryForCandidates = SubjectQuery(),
                 biometricDataSource = BiometricDataSource.Simprints,
             ),
+            project
         ).toList()
 
         coVerify(exactly = 0) { bioSdkWrapper.match(any(), any(), any()) }
@@ -131,6 +137,7 @@ internal class FingerprintMatcherUseCaseTest {
                 any(),
                 any(),
                 any(),
+                project,
                 onCandidateLoaded
             )
         } returns listOf(
@@ -166,6 +173,7 @@ internal class FingerprintMatcherUseCaseTest {
                 queryForCandidates = SubjectQuery(),
                 biometricDataSource = BiometricDataSource.Simprints,
             ),
+            project
         ).toList()
 
         coVerify { bioSdkWrapper.match(any(), any(), any()) }

--- a/feature/matcher/src/test/java/com/simprints/matcher/usecases/SaveMatchEventUseCaseTest.kt
+++ b/feature/matcher/src/test/java/com/simprints/matcher/usecases/SaveMatchEventUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.simprints.matcher.usecases
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.common.FlowType
 import com.simprints.core.domain.fingerprint.IFingerIdentifier
+import com.simprints.core.domain.tokenization.asTokenizableEncrypted
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.infra.config.store.models.FingerprintConfiguration.BioSdk.SECUGEN_SIM_MATCHER
 import com.simprints.infra.config.store.models.FingerprintConfiguration.FingerComparisonStrategy
@@ -188,7 +189,7 @@ class SaveMatchEventUseCaseTest {
             Timestamp(2L),
             MatchParams(
                 flowType = FlowType.IDENTIFY,
-                queryForCandidates = SubjectQuery(attendantId = "userId"),
+                queryForCandidates = SubjectQuery(attendantId = "userId".asTokenizableEncrypted()),
                 biometricDataSource = BiometricDataSource.Simprints,
             ),
             0,
@@ -213,7 +214,7 @@ class SaveMatchEventUseCaseTest {
             Timestamp(2L),
             MatchParams(
                 flowType = FlowType.IDENTIFY,
-                queryForCandidates = SubjectQuery(moduleId = "moduleId"),
+                queryForCandidates = SubjectQuery(moduleId = "moduleId".asTokenizableEncrypted()),
                 biometricDataSource = BiometricDataSource.Simprints,
             ),
             0,

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/BuildMatcherSubjectQueryUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/BuildMatcherSubjectQueryUseCase.kt
@@ -20,13 +20,13 @@ internal class BuildMatcherSubjectQueryUseCase @Inject constructor() {
 
         IdentificationConfiguration.PoolType.USER -> SubjectQuery(
             projectId = actionRequest.projectId,
-            attendantId = actionRequest.userId.value,
+            attendantId = actionRequest.userId,
             metadata = actionRequest.metadata,
         )
 
         IdentificationConfiguration.PoolType.MODULE -> SubjectQuery(
             projectId = actionRequest.projectId,
-            moduleId = (actionRequest as ActionRequest.FlowAction).moduleId.value,
+            moduleId = (actionRequest as ActionRequest.FlowAction).moduleId,
             metadata = actionRequest.metadata,
         )
     }

--- a/feature/validate-subject-pool/src/main/java/com/simprints/feature/validatepool/usecase/IsModuleIdNotSyncedUseCase.kt
+++ b/feature/validate-subject-pool/src/main/java/com/simprints/feature/validatepool/usecase/IsModuleIdNotSyncedUseCase.kt
@@ -1,13 +1,14 @@
 package com.simprints.feature.validatepool.usecase
 
+import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.infra.config.store.ConfigRepository
 import javax.inject.Inject
 
 internal class IsModuleIdNotSyncedUseCase @Inject constructor(
     private val configRepository: ConfigRepository,
 ) {
-    suspend operator fun invoke(moduleId: String): Boolean = configRepository
+    suspend operator fun invoke(moduleId: TokenizableString): Boolean = configRepository
         .getDeviceConfiguration()
         .selectedModules
-        .all { it.value != moduleId }
+        .all { it != moduleId }
 }

--- a/feature/validate-subject-pool/src/test/java/com/simprints/feature/validatepool/screen/ValidateSubjectPoolViewModelTest.kt
+++ b/feature/validate-subject-pool/src/test/java/com/simprints/feature/validatepool/screen/ValidateSubjectPoolViewModelTest.kt
@@ -3,6 +3,7 @@ package com.simprints.feature.validatepool.screen
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import com.jraska.livedata.test
+import com.simprints.core.domain.tokenization.asTokenizableEncrypted
 import com.simprints.feature.validatepool.usecase.HasRecordsUseCase
 import com.simprints.feature.validatepool.usecase.IsModuleIdNotSyncedUseCase
 import com.simprints.feature.validatepool.usecase.RunBlockingEventSyncUseCase
@@ -90,7 +91,7 @@ class ValidateSubjectPoolViewModelTest {
 
     @Test
     fun `if ID by user when subjects enrolled under other attendant ID returns UserMismatch`() = runTest {
-        val subjectQuery = SubjectQuery(attendantId = "attendantId")
+        val subjectQuery = SubjectQuery(attendantId = "attendantId".asTokenizableEncrypted())
         coEvery { hasRecordsUseCase(any()) } returns true
         coEvery { hasRecordsUseCase(subjectQuery) } returns false
 
@@ -103,7 +104,7 @@ class ValidateSubjectPoolViewModelTest {
 
     @Test
     fun `if ID by user when no subjects and should sync returns RequiredSync`() = runTest {
-        val subjectQuery = SubjectQuery(attendantId = "attendantId")
+        val subjectQuery = SubjectQuery(attendantId = "attendantId".asTokenizableEncrypted())
         coEvery { hasRecordsUseCase(any()) } returns false
         coEvery { shouldSuggestSyncUseCase() } returns true
 
@@ -115,7 +116,7 @@ class ValidateSubjectPoolViewModelTest {
 
     @Test
     fun `if ID by user when no subjects and synced returns PoolEmpty`() = runTest {
-        val subjectQuery = SubjectQuery(attendantId = "attendantId")
+        val subjectQuery = SubjectQuery(attendantId = "attendantId".asTokenizableEncrypted())
         coEvery { hasRecordsUseCase(any()) } returns false
         coEvery { shouldSuggestSyncUseCase() } returns false
 
@@ -127,7 +128,7 @@ class ValidateSubjectPoolViewModelTest {
 
     @Test
     fun `if ID by module when module is not synced returns ModuleMismatch`() = runTest {
-        val subjectQuery = SubjectQuery(moduleId = "module1")
+        val subjectQuery = SubjectQuery(moduleId = "module1".asTokenizableEncrypted())
         coEvery { hasRecordsUseCase(any()) } returns false
         coEvery { isModuleIdNotSyncedUseCase(any()) } returns true
 
@@ -140,7 +141,7 @@ class ValidateSubjectPoolViewModelTest {
 
     @Test
     fun `if ID by module when module is synced and not synced recently returns RequiresSync`() = runTest {
-        val subjectQuery = SubjectQuery(moduleId = "module1")
+        val subjectQuery = SubjectQuery(moduleId = "module1".asTokenizableEncrypted())
         coEvery { hasRecordsUseCase(any()) } returns false
         coEvery { isModuleIdNotSyncedUseCase(any()) } returns false
         coEvery { shouldSuggestSyncUseCase() } returns true
@@ -152,7 +153,7 @@ class ValidateSubjectPoolViewModelTest {
 
     @Test
     fun `if ID by module when module is synced and synced recently returns PoolEmpty`() = runTest {
-        val subjectQuery = SubjectQuery(moduleId = "module1")
+        val subjectQuery = SubjectQuery(moduleId = "module1".asTokenizableEncrypted())
         coEvery { hasRecordsUseCase(any()) } returns false
         coEvery { isModuleIdNotSyncedUseCase(any()) } returns false
         coEvery { shouldSuggestSyncUseCase() } returns false

--- a/feature/validate-subject-pool/src/test/java/com/simprints/feature/validatepool/usecase/IsModuleIdNotSyncedUseCaseTest.kt
+++ b/feature/validate-subject-pool/src/test/java/com/simprints/feature/validatepool/usecase/IsModuleIdNotSyncedUseCaseTest.kt
@@ -1,7 +1,7 @@
 package com.simprints.feature.validatepool.usecase
 
 import com.google.common.truth.Truth.assertThat
-import com.simprints.core.domain.tokenization.asTokenizableRaw
+import com.simprints.core.domain.tokenization.asTokenizableEncrypted
 import com.simprints.infra.config.store.ConfigRepository
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -23,9 +23,9 @@ class IsModuleIdNotSyncedUseCaseTest {
         coEvery {
             configRepository.getDeviceConfiguration().selectedModules
         } returns listOf(
-            "module1".asTokenizableRaw(),
-            "module2".asTokenizableRaw(),
-            "module3".asTokenizableRaw(),
+            "module1".asTokenizableEncrypted(),
+            "module2".asTokenizableEncrypted(),
+            "module3".asTokenizableEncrypted(),
         )
 
         usecase = IsModuleIdNotSyncedUseCase(configRepository)
@@ -33,11 +33,11 @@ class IsModuleIdNotSyncedUseCaseTest {
 
     @Test
     fun `returns true if module is not synced`() = runTest {
-        assertThat(usecase("module2")).isFalse()
+        assertThat(usecase("module2".asTokenizableEncrypted())).isFalse()
     }
 
     @Test
     fun `returns false if module is synced`() = runTest {
-        assertThat(usecase("moduleNone")).isTrue()
+        assertThat(usecase("moduleNone".asTokenizableEncrypted())).isTrue()
     }
 }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/tokenization/TokenizationProcessor.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/tokenization/TokenizationProcessor.kt
@@ -50,12 +50,15 @@ class TokenizationProcessor @Inject constructor(
         encrypted: TokenizableString.Tokenized,
         tokenKeyType: TokenKeyType,
         project: Project,
+        logError: Boolean = true
     ): TokenizableString {
         val moduleKeyset = project.tokenizationKeys[tokenKeyType] ?: return encrypted
         return try {
             stringTokenizer.decrypt(encrypted.value, moduleKeyset).asTokenizableRaw()
         } catch (e: Exception) {
-            Simber.e("Failed to decrypt tokenized value", e)
+            if (logError) {
+                Simber.e("Failed to decrypt tokenized value", e)
+            }
             encrypted
         }
     }

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepository.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepository.kt
@@ -23,6 +23,7 @@ interface EnrolmentRecordRepository : EnrolmentRecordLocalDataSource {
         query: SubjectQuery,
         range: IntRange,
         dataSource: BiometricDataSource,
+        project: Project,
         onCandidateLoaded: () -> Unit,
     ): List<FingerprintIdentity>
 
@@ -30,6 +31,7 @@ interface EnrolmentRecordRepository : EnrolmentRecordLocalDataSource {
         query: SubjectQuery,
         range: IntRange,
         dataSource: BiometricDataSource,
+        project: Project,
         onCandidateLoaded: () -> Unit,
     ): List<FaceIdentity>
 }

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImpl.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImpl.kt
@@ -127,15 +127,17 @@ internal class EnrolmentRecordRepositoryImpl(
         query: SubjectQuery,
         range: IntRange,
         dataSource: BiometricDataSource,
+        project: Project,
         onCandidateLoaded: () -> Unit,
-    ): List<FingerprintIdentity> = fromIdentityDataSource(dataSource).loadFingerprintIdentities(query, range, dataSource, onCandidateLoaded)
+    ): List<FingerprintIdentity> = fromIdentityDataSource(dataSource).loadFingerprintIdentities(query, range, dataSource, project, onCandidateLoaded)
 
     override suspend fun loadFaceIdentities(
         query: SubjectQuery,
         range: IntRange,
         dataSource: BiometricDataSource,
+        project: Project,
         onCandidateLoaded: () -> Unit,
-    ): List<FaceIdentity> = fromIdentityDataSource(dataSource).loadFaceIdentities(query, range, dataSource, onCandidateLoaded)
+    ): List<FaceIdentity> = fromIdentityDataSource(dataSource).loadFaceIdentities(query, range, dataSource, project, onCandidateLoaded)
 
     private fun fromIdentityDataSource(dataSource: BiometricDataSource) = when (dataSource) {
         is BiometricDataSource.Simprints -> localDataSource

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordsStoreModule.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordsStoreModule.kt
@@ -9,6 +9,7 @@ import com.simprints.infra.enrolment.records.store.local.EnrolmentRecordLocalDat
 import com.simprints.infra.enrolment.records.store.local.EnrolmentRecordLocalDataSourceImpl
 import com.simprints.infra.enrolment.records.store.remote.EnrolmentRecordRemoteDataSource
 import com.simprints.infra.enrolment.records.store.remote.EnrolmentRecordRemoteDataSourceImpl
+import com.simprints.infra.enrolment.records.store.usecases.CompareImplicitTokenizedStringsUseCase
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -43,11 +44,13 @@ class IdentityDataSourceModule {
     fun provideCommCareIdentityDataSource(
         encoder: EncodingUtils,
         jsonHelper: JsonHelper,
+        compareImplicitTokenizedStringsUseCase: CompareImplicitTokenizedStringsUseCase,
         @ApplicationContext context: Context,
         @DispatcherIO dispatcher: CoroutineDispatcher,
     ): IdentityDataSource = CommCareIdentityDataSource(
         encoder = encoder,
         jsonHelper = jsonHelper,
+        compareImplicitTokenizedStringsUseCase = compareImplicitTokenizedStringsUseCase,
         context = context,
         dispatcher = dispatcher,
     )

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/IdentityDataSource.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/IdentityDataSource.kt
@@ -1,5 +1,6 @@
 package com.simprints.infra.enrolment.records.store
 
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
 import com.simprints.infra.enrolment.records.store.domain.models.FaceIdentity
 import com.simprints.infra.enrolment.records.store.domain.models.FingerprintIdentity
@@ -15,6 +16,7 @@ interface IdentityDataSource {
         query: SubjectQuery,
         range: IntRange,
         dataSource: BiometricDataSource = BiometricDataSource.Simprints,
+        project: Project,
         onCandidateLoaded: () -> Unit,
     ): List<FingerprintIdentity>
 
@@ -22,6 +24,7 @@ interface IdentityDataSource {
         query: SubjectQuery,
         range: IntRange,
         dataSource: BiometricDataSource = BiometricDataSource.Simprints,
+        project: Project,
         onCandidateLoaded: () -> Unit,
     ): List<FaceIdentity>
 }

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/domain/models/SubjectQuery.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/domain/models/SubjectQuery.kt
@@ -1,6 +1,7 @@
 package com.simprints.infra.enrolment.records.store.domain.models
 
 import androidx.annotation.Keep
+import com.simprints.core.domain.tokenization.TokenizableString
 import java.io.Serializable
 
 @Keep
@@ -8,11 +9,11 @@ data class SubjectQuery(
     val projectId: String? = null,
     val subjectId: String? = null,
     val subjectIds: List<String>? = null,
-    val attendantId: String? = null,
+    val attendantId: TokenizableString? = null,
     val fingerprintSampleFormat: String? = null,
     val faceSampleFormat: String? = null,
     val hasUntokenizedFields: Boolean? = null,
-    val moduleId: String? = null,
+    val moduleId: TokenizableString? = null,
     val sort: Boolean = false,
     val afterSubjectId: String? = null,
     val metadata: String? = null,

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImpl.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.simprints.infra.enrolment.records.store.local
 
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
 import com.simprints.infra.enrolment.records.store.domain.models.FaceIdentity
 import com.simprints.infra.enrolment.records.store.domain.models.FingerprintIdentity
@@ -48,6 +49,7 @@ internal class EnrolmentRecordLocalDataSourceImpl @Inject constructor(
         query: SubjectQuery,
         range: IntRange,
         dataSource: BiometricDataSource,
+        project: Project,
         onCandidateLoaded: () -> Unit,
     ): List<FingerprintIdentity> = realmWrapper.readRealm { realm ->
         realm
@@ -67,6 +69,7 @@ internal class EnrolmentRecordLocalDataSourceImpl @Inject constructor(
         query: SubjectQuery,
         range: IntRange,
         dataSource: BiometricDataSource,
+        project: Project,
         onCandidateLoaded: () -> Unit,
     ): List<FaceIdentity> = realmWrapper.readRealm { realm ->
         realm

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/usecases/CompareImplicitTokenizedStringsUseCase.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/usecases/CompareImplicitTokenizedStringsUseCase.kt
@@ -54,7 +54,7 @@ class CompareImplicitTokenizedStringsUseCase @Inject constructor(
             tokenKeyType = tokenKeyType,
             project = project,
             logError = false,
-        ) is TokenizableString.Tokenized
+        ) is TokenizableString.Raw
 
         return if (isAlreadyTokenized) {
             s.asTokenizableEncrypted()

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/usecases/CompareTokenizedStringsUseCase.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/usecases/CompareTokenizedStringsUseCase.kt
@@ -31,7 +31,8 @@ class CompareImplicitTokenizedStringsUseCase @Inject constructor(
         val isAlreadyTokenized = tokenizationProcessor.decrypt(
             encrypted = s.asTokenizableEncrypted(),
             tokenKeyType = tokenKeyType,
-            project = project
+            project = project,
+            logError = false
         ) is TokenizableString.Tokenized
 
         return if (isAlreadyTokenized) {

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/usecases/CompareTokenizedStringsUseCase.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/usecases/CompareTokenizedStringsUseCase.kt
@@ -1,0 +1,47 @@
+package com.simprints.infra.enrolment.records.store.usecases
+
+import com.simprints.core.domain.tokenization.TokenizableString
+import com.simprints.core.domain.tokenization.asTokenizableEncrypted
+import com.simprints.core.domain.tokenization.asTokenizableRaw
+import com.simprints.infra.config.store.models.Project
+import com.simprints.infra.config.store.models.TokenKeyType
+import com.simprints.infra.config.store.tokenization.TokenizationProcessor
+import javax.inject.Inject
+
+/**
+ * Use case that checks two plain strings values but considers that the tokenization state of one of the values
+ * might differ from another. In this case this use tries to bring both strings to the same tokenization state
+ * and compare their values.
+ * Example:
+ *      s1 = 'abc'                  - untokenized value
+ *      s2 = 'AWcDe/==seF1LkcF4'    - tokenized value (result of tokenizing the 'abc' value)
+ *
+ *      Even though plain string values are different, they represent the same entity. s1 is going to be encrypted and compared to the s2.
+ */
+class CompareImplicitTokenizedStringsUseCase @Inject constructor(
+    private val tokenizationProcessor: TokenizationProcessor
+) {
+    operator fun invoke(s1: String?, s2: String, tokenKeyType: TokenKeyType, project: Project): Boolean = when {
+        s1 == null -> false
+        s1 == s2 -> true
+        else -> tokenize(s1, tokenKeyType, project) == tokenize(s2, tokenKeyType, project)
+    }
+
+    private fun tokenize(s: String, tokenKeyType: TokenKeyType, project: Project): TokenizableString {
+        val isAlreadyTokenized = tokenizationProcessor.decrypt(
+            encrypted = s.asTokenizableEncrypted(),
+            tokenKeyType = tokenKeyType,
+            project = project
+        ) is TokenizableString.Tokenized
+
+        return if (isAlreadyTokenized) {
+            s.asTokenizableEncrypted()
+        } else {
+            tokenizationProcessor.encrypt(
+                decrypted = s.asTokenizableRaw(),
+                tokenKeyType = tokenKeyType,
+                project = project
+            )
+        }
+    }
+}

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImplTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImplTest.kt
@@ -63,6 +63,7 @@ class EnrolmentRecordRepositoryImplTest {
         every { getSharedPreferences(any(), any()) } returns prefs
     }
     private lateinit var repository: EnrolmentRecordRepositoryImpl
+    private val project = mockk<Project>()
 
     @Before
     fun setup() {
@@ -277,17 +278,18 @@ class EnrolmentRecordRepositoryImplTest {
         val expectedSubjectQuery = SubjectQuery()
         val expectedRange = 0..10
         val expectedFingerprintIdentities = listOf<FingerprintIdentity>()
-        coEvery { localDataSource.loadFingerprintIdentities(expectedSubjectQuery, expectedRange, any(), onCandidateLoaded) } returns expectedFingerprintIdentities
+        coEvery { localDataSource.loadFingerprintIdentities(expectedSubjectQuery, expectedRange, any(), project, onCandidateLoaded) } returns expectedFingerprintIdentities
 
         val fingerprintIdentities = repository.loadFingerprintIdentities(
             query = expectedSubjectQuery,
             range = expectedRange,
             dataSource = BiometricDataSource.Simprints,
+            project = project,
             onCandidateLoaded = onCandidateLoaded
         )
 
         assert(fingerprintIdentities == expectedFingerprintIdentities)
-        coVerify(exactly = 1) { localDataSource.loadFingerprintIdentities(expectedSubjectQuery, expectedRange, any(), onCandidateLoaded) }
+        coVerify(exactly = 1) { localDataSource.loadFingerprintIdentities(expectedSubjectQuery, expectedRange, any(), project, onCandidateLoaded) }
     }
 
     @Test
@@ -295,17 +297,18 @@ class EnrolmentRecordRepositoryImplTest {
         val expectedSubjectQuery = SubjectQuery()
         val expectedRange = 0..10
         val expectedFingerprintIdentities = listOf<FingerprintIdentity>()
-        coEvery { commCareDataSource.loadFingerprintIdentities(expectedSubjectQuery, expectedRange, any(), onCandidateLoaded) } returns expectedFingerprintIdentities
+        coEvery { commCareDataSource.loadFingerprintIdentities(expectedSubjectQuery, expectedRange, any(), project, onCandidateLoaded) } returns expectedFingerprintIdentities
 
         val fingerprintIdentities = repository.loadFingerprintIdentities(
             query = expectedSubjectQuery,
             range = expectedRange,
             dataSource = BiometricDataSource.CommCare(""),
-            onCandidateLoaded
+            project = project,
+            onCandidateLoaded = onCandidateLoaded
         )
 
         assert(fingerprintIdentities == expectedFingerprintIdentities)
-        coVerify(exactly = 1) { commCareDataSource.loadFingerprintIdentities(expectedSubjectQuery, expectedRange, any(), onCandidateLoaded)  }
+        coVerify(exactly = 1) { commCareDataSource.loadFingerprintIdentities(expectedSubjectQuery, expectedRange, any(), project, onCandidateLoaded)  }
     }
 
     @Test
@@ -313,17 +316,18 @@ class EnrolmentRecordRepositoryImplTest {
         val expectedSubjectQuery = SubjectQuery()
         val expectedRange = 0..10
         val expectedFaceIdentities = listOf<FaceIdentity>()
-        coEvery { localDataSource.loadFaceIdentities(expectedSubjectQuery, expectedRange, any(), onCandidateLoaded) } returns expectedFaceIdentities
+        coEvery { localDataSource.loadFaceIdentities(expectedSubjectQuery, expectedRange, any(), project, onCandidateLoaded) } returns expectedFaceIdentities
 
         val faceIdentities = repository.loadFaceIdentities(
             query = expectedSubjectQuery,
             range = expectedRange,
             dataSource = BiometricDataSource.Simprints,
+            project = project,
             onCandidateLoaded = onCandidateLoaded
         )
 
         assert(faceIdentities == expectedFaceIdentities)
-        coVerify(exactly = 1) { localDataSource.loadFaceIdentities(expectedSubjectQuery, expectedRange, any(), onCandidateLoaded) }
+        coVerify(exactly = 1) { localDataSource.loadFaceIdentities(expectedSubjectQuery, expectedRange, any(), project, onCandidateLoaded) }
     }
 
     @Test
@@ -331,16 +335,17 @@ class EnrolmentRecordRepositoryImplTest {
         val expectedSubjectQuery = SubjectQuery()
         val expectedRange = 0..10
         val expectedFaceIdentities = listOf<FaceIdentity>()
-        coEvery { commCareDataSource.loadFaceIdentities(expectedSubjectQuery, expectedRange, any(), onCandidateLoaded) } returns expectedFaceIdentities
+        coEvery { commCareDataSource.loadFaceIdentities(expectedSubjectQuery, expectedRange, any(), project, onCandidateLoaded) } returns expectedFaceIdentities
 
         val faceIdentities = repository.loadFaceIdentities(
             query = expectedSubjectQuery,
             range = expectedRange,
             dataSource = BiometricDataSource.CommCare(""),
+            project = project,
             onCandidateLoaded = onCandidateLoaded
         )
 
         assert(faceIdentities == expectedFaceIdentities)
-        coVerify(exactly = 1) { commCareDataSource.loadFaceIdentities(expectedSubjectQuery, expectedRange, any(), onCandidateLoaded) }
+        coVerify(exactly = 1) { commCareDataSource.loadFaceIdentities(expectedSubjectQuery, expectedRange, any(), project, onCandidateLoaded) }
     }
 }

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/commcare/CommCareIdentityDataSourceTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/commcare/CommCareIdentityDataSourceTest.kt
@@ -10,11 +10,13 @@ import com.simprints.core.domain.fingerprint.IFingerIdentifier.LEFT_INDEX_FINGER
 import com.simprints.core.domain.fingerprint.IFingerIdentifier.LEFT_THUMB
 import com.simprints.core.tools.json.JsonHelper
 import com.simprints.core.tools.utils.EncodingUtils
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.enrolment.records.store.commcare.CommCareIdentityDataSource.Companion.COLUMN_DATUM_ID
 import com.simprints.infra.enrolment.records.store.commcare.CommCareIdentityDataSource.Companion.COLUMN_VALUE
 import com.simprints.infra.enrolment.records.store.domain.models.FaceIdentity
 import com.simprints.infra.enrolment.records.store.domain.models.FingerprintIdentity
 import com.simprints.infra.enrolment.records.store.domain.models.SubjectQuery
+import com.simprints.infra.enrolment.records.store.usecases.CompareImplicitTokenizedStringsUseCase
 import com.simprints.infra.logging.Simber
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import io.mockk.*
@@ -133,11 +135,17 @@ class CommCareIdentityDataSourceTest {
     @MockK
     private lateinit var mockContentResolver: ContentResolver
 
+    @MockK
+    private lateinit var useCase: CompareImplicitTokenizedStringsUseCase
+
     private lateinit var mockMetadataCursor: Cursor
 
     private lateinit var mockDataCursor: Cursor
 
     private lateinit var dataSource: CommCareIdentityDataSource
+
+    @MockK
+    lateinit var project: Project
 
     @Before
     fun setUp() {
@@ -176,10 +184,12 @@ class CommCareIdentityDataSourceTest {
         } returns mockDataCursor
 
         every { encoder.base64ToBytes(any()) } returns byteArrayOf()
+        every { useCase.invoke(any(), any(), any(), any()) } returns true
 
         dataSource = CommCareIdentityDataSource(
             encoder,
             JsonHelper,
+            useCase,
             context,
             testCoroutineRule.testCoroutineDispatcher,
         )
@@ -207,7 +217,7 @@ class CommCareIdentityDataSourceTest {
         val templateFormat = "ISO_19794_2"
         val query = SubjectQuery(fingerprintSampleFormat = templateFormat)
         val range = 0..expectedFingerprintIdentities.size
-        val actualIdentities = dataSource.loadFingerprintIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFingerprintIdentities(query, range, project = project) {}
 
         assertEquals(1, actualIdentities.size)
         val areContentsEqual =
@@ -251,7 +261,7 @@ class CommCareIdentityDataSourceTest {
         val templateFormat = "ROC_1_23"
         val query = SubjectQuery(faceSampleFormat = templateFormat)
         val range = 0..expectedFaceIdentities.size
-        val actualIdentities = dataSource.loadFaceIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFaceIdentities(query, range, project = project) {}
 
         assertEquals(1, actualIdentities.size)
         val areContentsEqual =
@@ -293,7 +303,7 @@ class CommCareIdentityDataSourceTest {
         val templateFormat = "NEC_1_5"
         val query = SubjectQuery(fingerprintSampleFormat = templateFormat)
         val range = 0..expectedFingerprintIdentities.size
-        val actualIdentities = dataSource.loadFingerprintIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFingerprintIdentities(query, range, project = project) {}
 
         assertEquals(1, actualIdentities.size)
         val areContentsEqual =
@@ -341,7 +351,7 @@ class CommCareIdentityDataSourceTest {
         val templateFormat = "ROC_1_23"
         val query = SubjectQuery(faceSampleFormat = templateFormat)
         val range = 0..expectedFaceIdentities.size
-        val actualIdentities = dataSource.loadFaceIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFaceIdentities(query, range, project = project) {}
 
         assertEquals(1, actualIdentities.size)
         val areContentsEqual =
@@ -380,7 +390,7 @@ class CommCareIdentityDataSourceTest {
         val templateFormat = "ISO_19794_2"
         val query = SubjectQuery(fingerprintSampleFormat = templateFormat)
         val range = 0..expectedFingerprintIdentities.size
-        val actualIdentities = dataSource.loadFingerprintIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFingerprintIdentities(query, range, project = project) {}
 
         assertEquals(1, actualIdentities.size)
         val areContentsEqual =
@@ -424,7 +434,7 @@ class CommCareIdentityDataSourceTest {
         val templateFormat = "ROC_1_23"
         val query = SubjectQuery(faceSampleFormat = templateFormat)
         val range = 0..expectedFaceIdentities.size
-        val actualIdentities = dataSource.loadFaceIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFaceIdentities(query, range, project = project) {}
 
         assertEquals(1, actualIdentities.size)
         val areContentsEqual =
@@ -469,7 +479,7 @@ class CommCareIdentityDataSourceTest {
 
         val query = SubjectQuery()
         val range = 0..0
-        val actualIdentities = dataSource.loadFingerprintIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFingerprintIdentities(query, range, project = project) {}
 
         assertTrue(actualIdentities.isEmpty())
         coVerify { mockContentResolver.query(mockMetadataUri, any(), any(), any(), any()) }
@@ -490,7 +500,7 @@ class CommCareIdentityDataSourceTest {
 
         val query = SubjectQuery()
         val range = 2..3
-        val actualIdentities = dataSource.loadFingerprintIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFingerprintIdentities(query, range, project = project) {}
 
         assertTrue(actualIdentities.isEmpty())
         coVerify { mockContentResolver.query(mockMetadataUri, any(), any(), any(), any()) }
@@ -528,7 +538,7 @@ class CommCareIdentityDataSourceTest {
         val templateFormat = "ISO_19794_2"
         val query = SubjectQuery(fingerprintSampleFormat = templateFormat)
         val range = 0..expectedFingerprintIdentities.size
-        val actualIdentities = dataSource.loadFingerprintIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFingerprintIdentities(query, range, project = project) {}
 
         assertEquals(1, actualIdentities.size)
         val areContentsEqual =
@@ -561,7 +571,7 @@ class CommCareIdentityDataSourceTest {
 
         val query = SubjectQuery()
         val range = 0..2
-        val actualIdentities = dataSource.loadFingerprintIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFingerprintIdentities(query, range, project = project) {}
 
         assertEquals(0, actualIdentities.size)
         coVerify { mockContentResolver.query(mockMetadataUri, any(), any(), any(), any()) }
@@ -590,7 +600,7 @@ class CommCareIdentityDataSourceTest {
 
         val query = SubjectQuery()
         val range = 0..2
-        val actualIdentities = dataSource.loadFingerprintIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFingerprintIdentities(query, range, project = project) {}
 
         assertEquals(0, actualIdentities.size)
         coVerify { mockContentResolver.query(mockMetadataUri, any(), any(), any(), any()) }
@@ -623,7 +633,7 @@ class CommCareIdentityDataSourceTest {
 
         val query = SubjectQuery()
         val range = 0..2
-        val actualIdentities = dataSource.loadFingerprintIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFingerprintIdentities(query, range, project = project) {}
 
         assertEquals(0, actualIdentities.size)
         coVerify { mockContentResolver.query(mockMetadataUri, any(), any(), any(), any()) }
@@ -643,7 +653,7 @@ class CommCareIdentityDataSourceTest {
 
         val query = SubjectQuery()
         val range = 0..2
-        val actualIdentities = dataSource.loadFingerprintIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFingerprintIdentities(query, range, project = project) {}
 
         assertEquals(0, actualIdentities.size)
         coVerify { mockContentResolver.query(mockMetadataUri, any(), any(), any(), any()) }
@@ -668,7 +678,7 @@ class CommCareIdentityDataSourceTest {
 
         val query = SubjectQuery()
         val range = 0..2
-        val actualIdentities = dataSource.loadFingerprintIdentities(query, range) {}
+        val actualIdentities = dataSource.loadFingerprintIdentities(query, range, project = project) {}
 
         assertEquals(0, actualIdentities.size)
         coVerify { mockContentResolver.query(mockMetadataUri, any(), any(), any(), any()) }

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImplTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImplTest.kt
@@ -3,6 +3,7 @@ package com.simprints.infra.enrolment.records.store.local
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.face.FaceSample
 import com.simprints.core.domain.tokenization.asTokenizableRaw
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
 import com.simprints.infra.enrolment.records.store.domain.models.Subject
 import com.simprints.infra.enrolment.records.store.domain.models.SubjectAction
@@ -43,6 +44,9 @@ class EnrolmentRecordLocalDataSourceImplTest {
 
     @MockK
     private lateinit var realmQuery: RealmQuery<DbSubject>
+
+    @MockK
+    private lateinit var project: Project
 
     private lateinit var blockCapture: CapturingSlot<(Realm) -> Any>
     private lateinit var mutableBlockCapture: CapturingSlot<(MutableRealm) -> Any>
@@ -115,6 +119,7 @@ class EnrolmentRecordLocalDataSourceImplTest {
             .loadFingerprintIdentities(
                 SubjectQuery(), IntRange(0, 20),
                 BiometricDataSource.Simprints,
+                project,
                 onCandidateLoaded
             )
             .toList()
@@ -133,6 +138,7 @@ class EnrolmentRecordLocalDataSourceImplTest {
                 SubjectQuery(fingerprintSampleFormat = format),
                 IntRange(0, 20),
                 BiometricDataSource.Simprints,
+                project,
                 onCandidateLoaded
             ).toList()
 
@@ -152,6 +158,7 @@ class EnrolmentRecordLocalDataSourceImplTest {
             .loadFingerprintIdentities(
                 SubjectQuery(faceSampleFormat = format), IntRange(0, 20),
                 BiometricDataSource.Simprints,
+                project,
                 onCandidateLoaded
             )
             .toList()
@@ -173,6 +180,7 @@ class EnrolmentRecordLocalDataSourceImplTest {
             .loadFaceIdentities(
                 SubjectQuery(), IntRange(0, 20),
                 BiometricDataSource.Simprints,
+                project,
                 onCandidateLoaded
             )
             .toList()

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImplTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImplTest.kt
@@ -2,6 +2,7 @@ package com.simprints.infra.enrolment.records.store.local
 
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.face.FaceSample
+import com.simprints.core.domain.tokenization.asTokenizableEncrypted
 import com.simprints.core.domain.tokenization.asTokenizableRaw
 import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
@@ -117,12 +118,12 @@ class EnrolmentRecordLocalDataSourceImplTest {
 
         val people = enrolmentRecordLocalDataSource
             .loadFingerprintIdentities(
-                SubjectQuery(), IntRange(0, 20),
+                SubjectQuery(),
+                IntRange(0, 20),
                 BiometricDataSource.Simprints,
                 project,
-                onCandidateLoaded
-            )
-            .toList()
+                onCandidateLoaded,
+            ).toList()
 
         listOf(fakePerson).zip(people).forEach { (subject, identity) ->
             assertThat(subject.subjectId).isEqualTo(identity.subjectId)
@@ -139,7 +140,7 @@ class EnrolmentRecordLocalDataSourceImplTest {
                 IntRange(0, 20),
                 BiometricDataSource.Simprints,
                 project,
-                onCandidateLoaded
+                onCandidateLoaded,
             ).toList()
 
         verify {
@@ -156,12 +157,12 @@ class EnrolmentRecordLocalDataSourceImplTest {
 
         enrolmentRecordLocalDataSource
             .loadFingerprintIdentities(
-                SubjectQuery(faceSampleFormat = format), IntRange(0, 20),
+                SubjectQuery(faceSampleFormat = format),
+                IntRange(0, 20),
                 BiometricDataSource.Simprints,
                 project,
-                onCandidateLoaded
-            )
-            .toList()
+                onCandidateLoaded,
+            ).toList()
 
         verify {
             realmQuery.query(
@@ -178,12 +179,12 @@ class EnrolmentRecordLocalDataSourceImplTest {
 
         val people = enrolmentRecordLocalDataSource
             .loadFaceIdentities(
-                SubjectQuery(), IntRange(0, 20),
+                SubjectQuery(),
+                IntRange(0, 20),
                 BiometricDataSource.Simprints,
                 project,
-                onCandidateLoaded
-            )
-            .toList()
+                onCandidateLoaded,
+            ).toList()
 
         listOf(fakePerson).zip(people).forEach { (subject, identity) ->
             assertThat(subject.subjectId).isEqualTo(identity.subjectId)
@@ -209,7 +210,7 @@ class EnrolmentRecordLocalDataSourceImplTest {
 
         val people =
             enrolmentRecordLocalDataSource
-                .load(SubjectQuery(attendantId = savedPersons[0].attendantId.value))
+                .load(SubjectQuery(attendantId = savedPersons[0].attendantId))
                 .toList()
         listOf(fakePerson).zip(people).forEach { (dbSubject, subject) ->
             assertThat(dbSubject.deepEquals(subject.fromDomainToDb())).isTrue()
@@ -223,7 +224,7 @@ class EnrolmentRecordLocalDataSourceImplTest {
 
         val people =
             enrolmentRecordLocalDataSource
-                .load(SubjectQuery(moduleId = fakePerson.moduleId))
+                .load(SubjectQuery(moduleId = fakePerson.moduleId.asTokenizableEncrypted()))
                 .toList()
         listOf(fakePerson).zip(people).forEach { (dbSubject, subject) ->
             assertThat(dbSubject.deepEquals(subject.fromDomainToDb())).isTrue()

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/usecases/CompareImplicitTokenizedStringsUseCaseTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/usecases/CompareImplicitTokenizedStringsUseCaseTest.kt
@@ -52,7 +52,7 @@ class CompareImplicitTokenizedStringsUseCaseTest {
         val s1 = "s1"
         val s2 = "s2"
         useCase(s1, s2, tokenKeyType, project)
-        verify(exactly = 2) { tokenizationProcessor.decrypt(any(), any(), any()) }
+        verify(exactly = 2) { tokenizationProcessor.decrypt(any(), any(), any(), any()) }
     }
 
     @Test
@@ -70,7 +70,7 @@ class CompareImplicitTokenizedStringsUseCaseTest {
         val s1 = "s1"
         val s2 = s1
 
-        every { tokenizationProcessor.decrypt(any(), any(), any()) } returns TokenizableString.Tokenized("some value")
+        every { tokenizationProcessor.decrypt(any(), any(), any(), any()) } returns TokenizableString.Tokenized("some value")
         val result = useCase(s1, s2, tokenKeyType, project)
         assertTrue(result)
     }

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/usecases/CompareImplicitTokenizedStringsUseCaseTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/usecases/CompareImplicitTokenizedStringsUseCaseTest.kt
@@ -1,0 +1,78 @@
+package com.simprints.infra.enrolment.records.store.usecases
+
+import com.simprints.core.domain.tokenization.TokenizableString
+import com.simprints.infra.config.store.models.Project
+import com.simprints.infra.config.store.models.TokenKeyType
+import com.simprints.infra.config.store.tokenization.TokenizationProcessor
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+
+class CompareImplicitTokenizedStringsUseCaseTest {
+
+    lateinit var useCase: CompareImplicitTokenizedStringsUseCase
+
+    @MockK
+    lateinit var tokenizationProcessor: TokenizationProcessor
+
+    @MockK
+    lateinit var project: Project
+
+    @MockK
+    lateinit var tokenKeyType: TokenKeyType
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+        useCase = CompareImplicitTokenizedStringsUseCase(tokenizationProcessor)
+    }
+
+    @Test
+    fun `should return false when s1 is null`() {
+        val s1 = null
+        val s2 = "s2"
+        val result = useCase(s1, s2, tokenKeyType, project)
+        assertFalse(result)
+    }
+
+    @Test
+    fun `should return true if strings are equal`() {
+        val s1 = "s1"
+        val s2 = s1
+        val result = useCase(s1, s2, tokenKeyType, project)
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should try to decrypt both strings if not equal`() {
+        val s1 = "s1"
+        val s2 = "s2"
+        useCase(s1, s2, tokenKeyType, project)
+        verify(exactly = 2) { tokenizationProcessor.decrypt(any(), any(), any()) }
+    }
+
+    @Test
+    fun `should encrypt both strings if not already tokenized`() {
+        val s1 = "s1"
+        val s2 = "s2"
+
+        every { tokenizationProcessor.decrypt(any(), any(), any()) } returns TokenizableString.Raw("some value")
+        useCase(s1, s2, tokenKeyType, project)
+        verify(exactly = 2) { tokenizationProcessor.encrypt(any(), any(), any()) }
+    }
+
+    @Test
+    fun `should return true for equal tokenized strings`() {
+        val s1 = "s1"
+        val s2 = s1
+
+        every { tokenizationProcessor.decrypt(any(), any(), any()) } returns TokenizableString.Tokenized("some value")
+        val result = useCase(s1, s2, tokenKeyType, project)
+        assertTrue(result)
+    }
+
+}


### PR DESCRIPTION
## Overview
Given that the plain string values might be both tokenized or untokenized, we need some mechanism that properly compares the values in the `CommCareIdentityDataSource`.

## Solutions
The `CompareImplicitTokenizedStringsUseCase` is added to check is the implicitly tokenized values are the same. Implicitly tokenized means that the plain string value can be both tokenized and untokenized, and we have no additional information that specifies the tokenization state. 

The use case operates using the following logic:
- Checks if the values are already similar
- If not, then tries to tokenize both values so that each of them is wrapped into `TokenizableString.Tokenized` class. It tries to decrypt each string using the project tokenization keys. If successful, then the string is already tokenized. If not, it tokenizes the value. Once both strings are tokenized, it compares their resulting value.
