### PR TITLE
[MS-721] Investigate what cause first enrolment to be unidentifiable on this specific project

### DIFF
--- a/feature/enrol-last-biometric/src/main/java/com/simprints/feature/enrollast/screen/EnrolLastBiometricViewModel.kt
+++ b/feature/enrol-last-biometric/src/main/java/com/simprints/feature/enrollast/screen/EnrolLastBiometricViewModel.kt
@@ -51,6 +51,7 @@ internal class EnrolLastBiometricViewModel @Inject constructor(
         enrolWasAttempted = true
 
         val projectConfig = configManager.getProjectConfiguration()
+        val project = configManager.getProject(projectConfig.projectId)
         val modalities = projectConfig.general.modalities
 
         val previousLastEnrolmentResult = getPreviousEnrolmentResult(params.steps)
@@ -70,7 +71,7 @@ internal class EnrolLastBiometricViewModel @Inject constructor(
         try {
             val subject = buildSubject(params)
             registerEvent(subject)
-            enrolmentRecordRepository.performActions(listOf(SubjectAction.Creation(subject)))
+            enrolmentRecordRepository.performActions(listOf(SubjectAction.Creation(subject)), project)
             _finish.send(EnrolLastState.Success(subject.subjectId))
         } catch (t: Throwable) {
             Simber.e("Enrolment failed", t, tag = ENROLMENT)

--- a/feature/enrol-last-biometric/src/test/java/com/simprints/feature/enrollast/screen/EnrolLastBiometricViewModelTest.kt
+++ b/feature/enrol-last-biometric/src/test/java/com/simprints/feature/enrollast/screen/EnrolLastBiometricViewModelTest.kt
@@ -135,7 +135,7 @@ internal class EnrolLastBiometricViewModelTest {
         )
 
         coVerify(exactly = 0) { eventRepository.addOrUpdateEvent(any()) }
-        coVerify(exactly = 0) { enrolmentRecordRepository.performActions(any()) }
+        coVerify(exactly = 0) { enrolmentRecordRepository.performActions(any(), any()) }
     }
 
     @Test
@@ -193,14 +193,14 @@ internal class EnrolLastBiometricViewModelTest {
         viewModel.enrolBiometric(createParams(listOf()))
 
         coVerify { eventRepository.addOrUpdateEvent(any()) }
-        coVerify { enrolmentRecordRepository.performActions(any()) }
+        coVerify { enrolmentRecordRepository.performActions(any(), any()) }
     }
 
     @Test
     fun `returns failure record saving fails`() = runTest {
         every { hasDuplicateEnrolments.invoke(any(), any()) } returns false
         coEvery { buildSubject.invoke(any()) } returns subject
-        coEvery { enrolmentRecordRepository.performActions(any()) } throws Exception()
+        coEvery { enrolmentRecordRepository.performActions(any(), any()) } throws Exception()
 
         viewModel.enrolBiometric(createParams(listOf()))
 

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorViewModel.kt
@@ -200,10 +200,12 @@ internal class OrchestratorViewModel @Inject constructor(
 
     private fun buildAppResponse() = viewModelScope.launch {
         val projectConfiguration = configManager.getProjectConfiguration()
+        val project = configManager.getProject(projectConfiguration.projectId)
         val appResponse = appResponseBuilder(
             projectConfiguration,
             actionRequest,
             steps.mapNotNull { it.result },
+            project
         )
 
         updateDailyActivity(appResponse)

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/AppResponseBuilderUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/AppResponseBuilderUseCase.kt
@@ -1,6 +1,7 @@
 package com.simprints.feature.orchestrator.usecases.response
 
 import com.simprints.core.domain.response.AppErrorReason
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.config.store.models.ProjectConfiguration
 import com.simprints.infra.orchestration.data.ActionRequest
 import com.simprints.infra.orchestration.data.responses.AppErrorResponse
@@ -20,9 +21,10 @@ internal class AppResponseBuilderUseCase @Inject constructor(
         projectConfiguration: ProjectConfiguration,
         request: ActionRequest?,
         results: List<Serializable>,
+        project: Project
     ): AppResponse = when (request) {
         is ActionRequest.EnrolActionRequest -> if (isNewEnrolment(projectConfiguration, results)) {
-            handleEnrolment(request, results)
+            handleEnrolment(request, results, project)
         } else {
             handleIdentify(projectConfiguration, results)
         }

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/CreateEnrolResponseUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/CreateEnrolResponseUseCase.kt
@@ -3,6 +3,7 @@ package com.simprints.feature.orchestrator.usecases.response
 import com.simprints.core.domain.response.AppErrorReason
 import com.simprints.face.capture.FaceCaptureResult
 import com.simprints.fingerprint.capture.FingerprintCaptureResult
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.eventsync.sync.down.tasks.SubjectFactory
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
@@ -20,6 +21,7 @@ internal class CreateEnrolResponseUseCase @Inject constructor(
     suspend operator fun invoke(
         request: ActionRequest.EnrolActionRequest,
         results: List<Serializable>,
+        project: Project
     ): AppResponse {
         val fingerprintCapture = results.filterIsInstance(FingerprintCaptureResult::class.java).lastOrNull()
         val faceCapture = results.filterIsInstance(FaceCaptureResult::class.java).lastOrNull()
@@ -32,7 +34,7 @@ internal class CreateEnrolResponseUseCase @Inject constructor(
                 fingerprintResponse = fingerprintCapture,
                 faceResponse = faceCapture,
             )
-            enrolSubject(subject)
+            enrolSubject(subject, project)
 
             AppEnrolResponse(subject.subjectId)
         } catch (e: Exception) {

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/EnrolSubjectUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/EnrolSubjectUseCase.kt
@@ -1,6 +1,7 @@
 package com.simprints.feature.orchestrator.usecases.response
 
 import com.simprints.core.tools.time.TimeHelper
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.enrolment.records.store.EnrolmentRecordRepository
 import com.simprints.infra.enrolment.records.store.domain.models.Subject
 import com.simprints.infra.enrolment.records.store.domain.models.SubjectAction
@@ -14,7 +15,7 @@ internal class EnrolSubjectUseCase @Inject constructor(
     private val timeHelper: TimeHelper,
     private val enrolmentRecordRepository: EnrolmentRecordRepository,
 ) {
-    suspend operator fun invoke(subject: Subject) {
+    suspend operator fun invoke(subject: Subject, project: Project) {
         val personCreationEvent = eventRepository
             .getEventsInCurrentSession()
             .filterIsInstance<PersonCreationEvent>()
@@ -31,6 +32,6 @@ internal class EnrolSubjectUseCase @Inject constructor(
                 personCreationEvent.id,
             ),
         )
-        enrolmentRecordRepository.performActions(listOf(SubjectAction.Creation(subject)))
+        enrolmentRecordRepository.performActions(listOf(SubjectAction.Creation(subject)), project)
     }
 }

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/OrchestratorViewModelTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/OrchestratorViewModelTest.kt
@@ -172,7 +172,7 @@ internal class OrchestratorViewModelTest {
         )
         coEvery { mapRefusalOrErrorResult(any(), any()) } returns null
         coEvery { shouldCreatePerson(any(), any(), any()) } returns false
-        coEvery { appResponseBuilder(any(), any(), any()) } returns mockk()
+        coEvery { appResponseBuilder(any(), any(), any(), any()) } returns mockk()
         coJustRun { dailyActivityUseCase(any()) }
         justRun { addCallbackEvent(any()) }
 
@@ -400,9 +400,12 @@ internal class OrchestratorViewModelTest {
             mockk(),
             mockk(),
         )
+        val id = "projectId"
         coEvery { configManager.getProjectConfiguration() } returns mockk {
+            every { projectId } returns id
             every { general.modalities } returns emptyList() andThen projectModalities
         }
+        coEvery { configManager.getProject(id) } returns mockk()
 
         viewModel.handleAction(mockk())
         viewModel.restoreModalitiesIfNeeded()
@@ -416,9 +419,12 @@ internal class OrchestratorViewModelTest {
             mockk(),
             mockk(),
         )
+        val id = "projectId"
         coEvery { configManager.getProjectConfiguration() } returns mockk {
+            every { projectId } returns id
             every { general.modalities } returns projectModalities
         }
+        coEvery { configManager.getProject(id) } returns mockk()
 
         viewModel.handleAction(mockk())
         viewModel.restoreModalitiesIfNeeded()

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/response/AppResponseBuilderUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/response/AppResponseBuilderUseCaseTest.kt
@@ -38,7 +38,7 @@ internal class AppResponseBuilderUseCaseTest {
     fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
 
-        coEvery { handleEnrolment.invoke(any(), any()) } returns mockk()
+        coEvery { handleEnrolment.invoke(any(), any(), any()) } returns mockk()
         coEvery { handleIdentify.invoke(any(), any()) } returns mockk()
         every { handleVerify.invoke(any(), any()) } returns mockk()
         every { handleConfirmIdentity.invoke(any()) } returns mockk()
@@ -57,43 +57,43 @@ internal class AppResponseBuilderUseCaseTest {
     @Test
     fun `Handles as enrolment for new enrolment action`() = runTest {
         every { isNewEnrolment(any(), any()) } returns true
-        useCase(mockk(), mockk<ActionRequest.EnrolActionRequest>(), mockk())
-        coVerify { handleEnrolment.invoke(any(), any()) }
+        useCase(mockk(), mockk<ActionRequest.EnrolActionRequest>(), mockk(), mockk())
+        coVerify { handleEnrolment.invoke(any(), any(), any()) }
     }
 
     @Test
     fun `Handles as identification for enrolment action with existing item`() = runTest {
         every { isNewEnrolment(any(), any()) } returns false
-        useCase(mockk(), mockk<ActionRequest.EnrolActionRequest>(), mockk())
+        useCase(mockk(), mockk<ActionRequest.EnrolActionRequest>(), mockk(), mockk())
         coVerify { handleIdentify.invoke(any(), any()) }
     }
 
     @Test
     fun `Handles as identification for identification action`() = runTest {
-        useCase(mockk(), mockk<ActionRequest.IdentifyActionRequest>(), mockk())
+        useCase(mockk(), mockk<ActionRequest.IdentifyActionRequest>(), mockk(), mockk())
         coVerify { handleIdentify.invoke(any(), any()) }
     }
 
     @Test
     fun `Handles as verification for verification action`() = runTest {
-        useCase(mockk(), mockk<ActionRequest.VerifyActionRequest>(), mockk())
+        useCase(mockk(), mockk<ActionRequest.VerifyActionRequest>(), mockk(), mockk())
         coVerify { handleVerify.invoke(any(), any()) }
     }
 
     @Test
     fun `Handles as confirmIdentity for confirm action`() = runTest {
-        useCase(mockk(), mockk<ActionRequest.ConfirmIdentityActionRequest>(), mockk())
+        useCase(mockk(), mockk<ActionRequest.ConfirmIdentityActionRequest>(), mockk(), mockk())
         coVerify { handleConfirmIdentity.invoke(any()) }
     }
 
     @Test
     fun `Handles as enrol last biometric for enrol last action`() = runTest {
-        useCase(mockk(), mockk<ActionRequest.EnrolLastBiometricActionRequest>(), mockk())
+        useCase(mockk(), mockk<ActionRequest.EnrolLastBiometricActionRequest>(), mockk(), mockk())
         coVerify { handleEnrolLastBiometric.invoke(any()) }
     }
 
     @Test
     fun `Handles null request`() = runTest {
-        assertThat(useCase(mockk(), null, mockk())).isInstanceOf(AppErrorResponse::class.java)
+        assertThat(useCase(mockk(), null, mockk(), mockk())).isInstanceOf(AppErrorResponse::class.java)
     }
 }

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/response/CreateEnrolResponseUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/response/CreateEnrolResponseUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.simprints.core.domain.tokenization.asTokenizableRaw
 import com.simprints.face.capture.FaceCaptureResult
 import com.simprints.feature.orchestrator.exceptions.MissingCaptureException
 import com.simprints.fingerprint.capture.FingerprintCaptureResult
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.eventsync.sync.down.tasks.SubjectFactory
 import com.simprints.infra.orchestration.data.ActionRequest
 import com.simprints.infra.orchestration.data.responses.AppEnrolResponse
@@ -25,6 +26,9 @@ internal class CreateEnrolResponseUseCaseTest {
     @MockK
     lateinit var enrolSubject: EnrolSubjectUseCase
 
+    @MockK
+    lateinit var project: Project
+
     private val action = mockk<ActionRequest.EnrolActionRequest> {
         every { projectId } returns "projectId"
         every { userId } returns "userId".asTokenizableRaw()
@@ -37,7 +41,7 @@ internal class CreateEnrolResponseUseCaseTest {
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
 
-        coJustRun { enrolSubject.invoke(any()) }
+        coJustRun { enrolSubject.invoke(any(), any()) }
 
         useCase = CreateEnrolResponseUseCase(subjectFactory, enrolSubject)
     }
@@ -56,6 +60,7 @@ internal class CreateEnrolResponseUseCaseTest {
                     FaceCaptureResult(emptyList()),
                     mockk(),
                 ),
+                project
             ),
         ).isInstanceOf(AppEnrolResponse::class.java)
     }
@@ -66,6 +71,6 @@ internal class CreateEnrolResponseUseCaseTest {
             subjectFactory.buildSubjectFromCaptureResults(any(), any(), any(), null, null)
         } throws MissingCaptureException()
 
-        assertThat(useCase(action, emptyList())).isInstanceOf(AppErrorResponse::class.java)
+        assertThat(useCase(action, emptyList(), project)).isInstanceOf(AppErrorResponse::class.java)
     }
 }

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/response/EnrolSubjectUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/response/EnrolSubjectUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.tokenization.asTokenizableRaw
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.enrolment.records.store.EnrolmentRecordRepository
 import com.simprints.infra.enrolment.records.store.domain.models.Subject
 import com.simprints.infra.enrolment.records.store.domain.models.SubjectAction
@@ -30,6 +31,9 @@ class EnrolSubjectUseCaseTest {
 
     @MockK
     private lateinit var enrolmentRecordRepository: EnrolmentRecordRepository
+
+    @MockK
+    private lateinit var project: Project
 
     private lateinit var useCase: EnrolSubjectUseCase
 
@@ -61,6 +65,7 @@ class EnrolSubjectUseCaseTest {
                 attendantId = "moduleId".asTokenizableRaw(),
                 moduleId = "attendantId".asTokenizableRaw(),
             ),
+            project
         )
 
         coVerify {
@@ -85,6 +90,7 @@ class EnrolSubjectUseCaseTest {
                 attendantId = "moduleId".asTokenizableRaw(),
                 moduleId = "attendantId".asTokenizableRaw(),
             ),
+            project
         )
 
         coVerify {
@@ -92,6 +98,7 @@ class EnrolSubjectUseCaseTest {
                 withArg {
                     assertThat(it.first()).isInstanceOf(SubjectAction.Creation::class.java)
                 },
+                project
             )
         }
     }
@@ -123,6 +130,7 @@ class EnrolSubjectUseCaseTest {
                 attendantId = "moduleId".asTokenizableRaw(),
                 moduleId = "attendantId".asTokenizableRaw(),
             ),
+            project
         )
 
         coVerify {

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/ConfigRepositoryImplTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/ConfigRepositoryImplTest.kt
@@ -16,6 +16,7 @@ import com.simprints.infra.config.store.testtools.deviceConfiguration
 import com.simprints.infra.config.store.testtools.deviceState
 import com.simprints.infra.config.store.testtools.project
 import com.simprints.infra.config.store.testtools.projectConfiguration
+import com.simprints.infra.config.store.tokenization.TokenizationProcessor
 import com.simprints.infra.network.SimNetwork
 import com.simprints.infra.network.exceptions.BackendMaintenanceException
 import com.simprints.testtools.common.syntax.assertThrows
@@ -40,6 +41,7 @@ class ConfigRepositoryImplTest {
     private val localDataSource = mockk<ConfigLocalDataSource>(relaxed = true)
     private val remoteDataSource = mockk<ConfigRemoteDataSource>()
     private val simNetwork = mockk<SimNetwork>(relaxed = true)
+    private val tokenizationProcessor = mockk<TokenizationProcessor>(relaxed = true)
 
     private lateinit var configServiceImpl: ConfigRepositoryImpl
 
@@ -49,6 +51,7 @@ class ConfigRepositoryImplTest {
             localDataSource,
             remoteDataSource,
             simNetwork,
+            tokenizationProcessor,
             DEVICE_ID,
         )
     }
@@ -245,5 +248,16 @@ class ConfigRepositoryImplTest {
         assertThat(emittedConfigs[0]).isEqualTo(config1)
         assertThat(emittedConfigs[1]).isEqualTo(config2)
         coVerify(exactly = 0) { remoteDataSource.getProject(any()) }
+    }
+
+    @Test
+    fun `should return project config from local data source`() = runTest {
+        val config = projectConfiguration.copy(projectId = "project1")
+        coEvery { localDataSource.getProjectConfiguration() } returns config
+
+        val result = configServiceImpl.getProjectConfiguration()
+
+        assertThat(result).isEqualTo(config)
+        coVerify { localDataSource.getProjectConfiguration() }
     }
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/local/ConfigLocalDataSourceImplTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/local/ConfigLocalDataSourceImplTest.kt
@@ -20,6 +20,7 @@ import com.simprints.infra.config.store.testtools.identificationConfiguration
 import com.simprints.infra.config.store.testtools.project
 import com.simprints.infra.config.store.testtools.projectConfiguration
 import com.simprints.infra.config.store.testtools.synchronizationConfiguration
+import com.simprints.infra.config.store.tokenization.TokenizationProcessor
 import com.simprints.testtools.common.syntax.assertThrows
 import io.mockk.mockk
 import kotlinx.coroutines.launch
@@ -57,6 +58,9 @@ class ConfigLocalDataSourceImplTest {
         produceFile = { testContext.dataStoreFile(TEST_DEVICE_CONFIG_DATASTORE_NAME) },
     )
 
+    private val tokenizationProcessor = mockk<TokenizationProcessor>(relaxed = true)
+
+
     private lateinit var configLocalDataSourceImpl: ConfigLocalDataSourceImpl
 
     @Before
@@ -68,6 +72,7 @@ class ConfigLocalDataSourceImplTest {
             testProjectDataStore,
             testProjectConfigDataStore,
             testDeviceConfigDataStore,
+            tokenizationProcessor
         )
     }
 

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImpl.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImpl.kt
@@ -96,7 +96,7 @@ internal class EnrolmentRecordRepositoryImpl(
                         )
                         return@mapNotNull subject.copy(moduleId = moduleId, attendantId = attendantId)
                     }.map(SubjectAction::Creation)
-            localDataSource.performActions(tokenizedSubjectsCreateAction)
+            localDataSource.performActions(tokenizedSubjectsCreateAction, project)
         } catch (e: Exception) {
             when (e) {
                 is RealmUninitialisedException -> Unit // AuthStore hasn't yet saved the project, no need to do anything

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSource.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSource.kt
@@ -1,5 +1,6 @@
 package com.simprints.infra.enrolment.records.store.local
 
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.enrolment.records.store.IdentityDataSource
 import com.simprints.infra.enrolment.records.store.domain.models.Subject
 import com.simprints.infra.enrolment.records.store.domain.models.SubjectAction
@@ -12,5 +13,5 @@ interface EnrolmentRecordLocalDataSource : IdentityDataSource {
 
     suspend fun deleteAll()
 
-    suspend fun performActions(actions: List<SubjectAction>)
+    suspend fun performActions(actions: List<SubjectAction>, project: Project)
 }

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImplTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/EnrolmentRecordRepositoryImplTest.kt
@@ -215,7 +215,7 @@ class EnrolmentRecordRepositoryImplTest {
                 moduleId = moduleIdTokenized,
             )
             val expectedSubjectActions = listOf(SubjectAction.Creation(expectedSubject))
-            coVerify { localDataSource.performActions(expectedSubjectActions) }
+            coVerify { localDataSource.performActions(expectedSubjectActions, project) }
         }
 
     @Test
@@ -238,7 +238,7 @@ class EnrolmentRecordRepositoryImplTest {
         coEvery { localDataSource.load(any()) } returns listOf(subject)
 
         repository.tokenizeExistingRecords(project)
-        coVerify { localDataSource.performActions(emptyList()) }
+        coVerify { localDataSource.performActions(emptyList(), project) }
     }
 
     @Test

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImplTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/local/EnrolmentRecordLocalDataSourceImplTest.kt
@@ -5,6 +5,7 @@ import com.simprints.core.domain.face.FaceSample
 import com.simprints.core.domain.tokenization.asTokenizableEncrypted
 import com.simprints.core.domain.tokenization.asTokenizableRaw
 import com.simprints.infra.config.store.models.Project
+import com.simprints.infra.config.store.tokenization.TokenizationProcessor
 import com.simprints.infra.enrolment.records.store.domain.models.BiometricDataSource
 import com.simprints.infra.enrolment.records.store.domain.models.Subject
 import com.simprints.infra.enrolment.records.store.domain.models.SubjectAction
@@ -47,6 +48,9 @@ class EnrolmentRecordLocalDataSourceImplTest {
     private lateinit var realmQuery: RealmQuery<DbSubject>
 
     @MockK
+    private lateinit var tokenizationProcessor: TokenizationProcessor
+
+    @MockK
     private lateinit var project: Project
 
     private lateinit var blockCapture: CapturingSlot<(Realm) -> Any>
@@ -84,7 +88,7 @@ class EnrolmentRecordLocalDataSourceImplTest {
         every { realm.query(DbSubject::class) } returns realmQuery
         every { mutableRealm.query(DbSubject::class) } returns realmQuery
 
-        enrolmentRecordLocalDataSource = EnrolmentRecordLocalDataSourceImpl(realmWrapperMock)
+        enrolmentRecordLocalDataSource = EnrolmentRecordLocalDataSourceImpl(realmWrapperMock, tokenizationProcessor)
     }
 
     @Test
@@ -236,6 +240,7 @@ class EnrolmentRecordLocalDataSourceImplTest {
         val subject = getFakePerson()
         enrolmentRecordLocalDataSource.performActions(
             listOf(SubjectAction.Creation(subject.fromDbToDomain())),
+            project,
         )
         val peopleCount = enrolmentRecordLocalDataSource.count()
         assertThat(peopleCount).isEqualTo(1)
@@ -247,6 +252,7 @@ class EnrolmentRecordLocalDataSourceImplTest {
         saveFakePerson(subject)
         enrolmentRecordLocalDataSource.performActions(
             listOf(SubjectAction.Deletion(subject.subjectId.toString())),
+            project,
         )
         val peopleCount = enrolmentRecordLocalDataSource.count()
         assertThat(peopleCount).isEqualTo(0)
@@ -258,6 +264,7 @@ class EnrolmentRecordLocalDataSourceImplTest {
         saveFakePerson(subject)
         enrolmentRecordLocalDataSource.performActions(
             listOf(),
+            project,
         )
         val peopleCount = enrolmentRecordLocalDataSource.count()
         assertThat(peopleCount).isEqualTo(1)

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManagerImpl.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManagerImpl.kt
@@ -95,7 +95,7 @@ internal class EventSyncManagerImpl @Inject constructor(
                 modes = getProjectModes(configRepository.getProjectConfiguration()),
             ),
         )
-        downSyncTask.downSync(this, op, eventScope).toList()
+        downSyncTask.downSync(this, op, eventScope, configRepository.getProject()).toList()
     }
 
     private fun getProjectModes(projectConfiguration: ProjectConfiguration) = projectConfiguration.general.modalities.map { it.toMode() }

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/EventSyncManagerTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/EventSyncManagerTest.kt
@@ -6,6 +6,7 @@ import com.simprints.core.domain.common.Partitioning
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.infra.config.store.ConfigRepository
+import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.events.EventRepository
 import com.simprints.infra.events.event.domain.EventCount
 import com.simprints.infra.events.event.domain.models.scope.EventScope
@@ -69,6 +70,9 @@ internal class EventSyncManagerTest {
 
     @MockK
     lateinit var eventScope: EventScope
+
+    @MockK
+    lateinit var project: Project
 
     private lateinit var eventSyncManagerImpl: EventSyncManagerImpl
 
@@ -137,11 +141,11 @@ internal class EventSyncManagerTest {
     @Test
     fun `downSync should call down sync helper`() = runTest {
         coEvery { eventRepository.createEventScope(any()) } returns eventScope
-        coEvery { downSyncTask.downSync(any(), any(), eventScope) } returns emptyFlow()
+        coEvery { downSyncTask.downSync(any(), any(), eventScope, any()) } returns emptyFlow()
 
         eventSyncManagerImpl.downSyncSubject(DEFAULT_PROJECT_ID, "subjectId")
 
-        coVerify { downSyncTask.downSync(any(), any(), eventScope) }
+        coVerify { downSyncTask.downSync(any(), any(), eventScope, any()) }
     }
 
     @Test

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/down/workers/EventDownSyncDownloaderWorkerTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/down/workers/EventDownSyncDownloaderWorkerTest.kt
@@ -9,6 +9,7 @@ import androidx.work.workDataOf
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.tools.json.JsonHelper
 import com.simprints.infra.authstore.exceptions.RemoteDbNotSignedInException
+import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.events.EventRepository
 import com.simprints.infra.events.event.domain.models.scope.EventScope
 import com.simprints.infra.eventsync.SampleSyncScopes.projectDownSyncScope
@@ -60,6 +61,10 @@ internal class EventDownSyncDownloaderWorkerTest {
     @MockK
     lateinit var eventScope: EventScope
 
+
+    @MockK
+    lateinit var configRepository: ConfigRepository
+
     private lateinit var eventDownSyncDownloaderWorker: EventDownSyncDownloaderWorker
 
     @Before
@@ -79,6 +84,7 @@ internal class EventDownSyncDownloaderWorkerTest {
             syncCache,
             JsonHelper,
             eventRepository,
+            configRepository,
             testCoroutineRule.testCoroutineDispatcher,
         )
     }
@@ -96,7 +102,7 @@ internal class EventDownSyncDownloaderWorkerTest {
     fun worker_failForCloudIntegration_shouldFail() = runTest {
         coEvery { eventRepository.getEventScope(any()) } returns eventScope
         coEvery {
-            downSyncTask.downSync(any(), any(), any())
+            downSyncTask.downSync(any(), any(), any(), any())
         } throws SyncCloudIntegrationException("Cloud integration", Throwable())
 
         val result = eventDownSyncDownloaderWorker.doWork()
@@ -114,7 +120,7 @@ internal class EventDownSyncDownloaderWorkerTest {
     fun worker_failForBackendMaintenanceError_shouldFail() = runTest {
         coEvery { eventRepository.getEventScope(any()) } returns eventScope
         coEvery {
-            downSyncTask.downSync(any(), any(), any())
+            downSyncTask.downSync(any(), any(), any(), any())
         } throws BackendMaintenanceException(estimatedOutage = null)
 
         val result = eventDownSyncDownloaderWorker.doWork()
@@ -133,7 +139,7 @@ internal class EventDownSyncDownloaderWorkerTest {
     fun worker_failForTimedBackendMaintenanceError_shouldFail() = runTest {
         coEvery { eventRepository.getEventScope(any()) } returns eventScope
         coEvery {
-            downSyncTask.downSync(any(), any(), any())
+            downSyncTask.downSync(any(), any(), any(), any())
         } throws BackendMaintenanceException(estimatedOutage = 600)
 
         val result = eventDownSyncDownloaderWorker.doWork()
@@ -152,7 +158,7 @@ internal class EventDownSyncDownloaderWorkerTest {
     fun worker_failForTooManyRequestsError_shouldFail() = runTest {
         coEvery { eventRepository.getEventScope(any()) } returns eventScope
         coEvery {
-            downSyncTask.downSync(any(), any(), any())
+            downSyncTask.downSync(any(), any(), any(), any())
         } throws TooManyRequestsException()
 
         val result = eventDownSyncDownloaderWorker.doWork()
@@ -170,7 +176,7 @@ internal class EventDownSyncDownloaderWorkerTest {
     fun worker_failForRemoteDbNotSignedInException_shouldFail() = runTest {
         coEvery { eventRepository.getEventScope(any()) } returns eventScope
         coEvery {
-            downSyncTask.downSync(any(), any(), any())
+            downSyncTask.downSync(any(), any(), any(), any())
         } throws RemoteDbNotSignedInException()
 
         val result = eventDownSyncDownloaderWorker.doWork()
@@ -188,7 +194,7 @@ internal class EventDownSyncDownloaderWorkerTest {
     fun worker_failForNetworkIssue_shouldRetry() = runTest {
         coEvery { eventRepository.getEventScope(any()) } returns eventScope
         coEvery {
-            downSyncTask.downSync(any(), any(), any())
+            downSyncTask.downSync(any(), any(), any(), any())
         } throws Throwable("Network Exception")
 
         val result = eventDownSyncDownloaderWorker.doWork()


### PR DESCRIPTION
## Overview
If the enrolment callout is made when there is no authentication in SID, then the `moduleId` and `attendantId` remain untokenized in the local database. Any further verification and identification request will have their `moduleId` tokenized, meaning that the initial enrolment will never be fetched from the local database, since its `moduleId` is untokenized.

## Example
- No SID auth
- Enrolment request is sent to SID with `moduleId` = `123`
- No tokenization keys are available at the moment of the event and subject creation, thus all the data from the request is saved with `moduleId` = `123`
- SID authenticates, tokenization keys become available, enrolment flow ends, data is saved in the local database
- Identification request is sent to SID with `moduleId` = `123`
- Since the tokenization keys are now available, `moduleId` becomes `encrypted_123`
- SID fetches all the subjects from module `encrypted_123`, receives 0 candidates, and returns 0 matches to the callout app

## Reactively tokenizing Subject fileds
### `EnrolmentRecordLocalDataSource`
When saving subject using the `performActions` method, the tokenization keys should already be available. Trying to reactively tokenize all tokenizable fields before saving
```
is SubjectAction.Creation -> {
    val tokenizedModuleId = moduleId.tokenizeIfNecessary()
    val tokenizedAttendantId = attendantId.tokenizeIfNecessary()
    realm.copyToRealm(
        action.subject.copy(moduleId = tokenizedModuleId, attendantId = tokenizedAttendantId)
    )
}
```
## Reactively tokenizing modules
The goal is to provide the tokenized `moduleId` values to all callers that work with modules.

### `ConfigRepository`
When fetching the project configuration, reactively tokenizing modules before returning the config to caller.
```
fun getProjectConfiguration() {
    val config = localDataSource.getProjectConfiguration()
    return tokenizeModules(config)
}

fun watchProjectConfiguration() = localDataSource.watchProjectConfiguration().map { config ->
    tokenizeModules(config)
}
```
### `ConfigLocalDataSource`
When fetching the device configuration, reactively tokenizing modules before returning the config to caller.
```
fun getDeviceConfiguration() {
    val config = deviceConfigDataStore.data.first().toDomain()
    val tokenizedModules = config.selectedModules.map { moduleId ->
        when(moduleId) {
            is TokenizableString.Raw -> tokenizationProcessor.encrypt(
                decrypted = moduleId,
                tokenKeyType = TokenKeyType.ModuleId,
                project = getProject()
            )
            is TokenizableString.Tokenized -> moduleId
        }
    }
    config.selectedModules = tokenizedModules
    return config
}
```
