### PR TITLE
[MS-852] Add explicit class type to the tokenizable fields returned to CoSync

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/usecases/GetEnrolmentCreationEventForSubjectUseCase.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/usecases/GetEnrolmentCreationEventForSubjectUseCase.kt
@@ -1,5 +1,9 @@
 package com.simprints.feature.clientapi.usecases
 
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.simprints.core.domain.tokenization.TokenizableString
+import com.simprints.core.domain.tokenization.serialization.TokenizationClassNameDeserializer
+import com.simprints.core.domain.tokenization.serialization.TokenizationClassNameSerializer
 import com.simprints.core.tools.json.JsonHelper
 import com.simprints.core.tools.utils.EncodingUtils
 import com.simprints.infra.config.store.models.canCoSyncAllData
@@ -34,7 +38,7 @@ internal class GetEnrolmentCreationEventForSubjectUseCase @Inject constructor(
             ?.fromSubjectToEnrolmentCreationEvent()
             ?: return null
 
-        return jsonHelper.toJson(CoSyncEnrolmentRecordEvents(listOf(recordCreationEvent)))
+        return jsonHelper.toJson(CoSyncEnrolmentRecordEvents(listOf(recordCreationEvent)), coSyncSerializationModule)
     }
 
     private fun Subject.fromSubjectToEnrolmentCreationEvent() = EnrolmentRecordCreationEvent(
@@ -44,4 +48,11 @@ internal class GetEnrolmentCreationEventForSubjectUseCase @Inject constructor(
         attendantId,
         EnrolmentRecordCreationEvent.buildBiometricReferences(fingerprintSamples, faceSamples, encoder),
     )
+
+    companion object {
+        val coSyncSerializationModule = SimpleModule().apply {
+            addSerializer(TokenizableString::class.java, TokenizationClassNameSerializer())
+            addDeserializer(TokenizableString::class.java, TokenizationClassNameDeserializer())
+        }
+    }
 }

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/usecases/GetEnrolmentCreationEventForSubjectUseCaseTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/usecases/GetEnrolmentCreationEventForSubjectUseCaseTest.kt
@@ -98,7 +98,7 @@ class GetEnrolmentCreationEventForSubjectUseCaseTest {
         val result = useCase("projectId", "subjectId")
 
         coVerify { enrolmentRecordRepository.load(any()) }
-        coVerify { jsonHelper.toJson(any()) }
+        coVerify { jsonHelper.toJson(any(), any()) }
         assertThat(result).isNotNull()
     }
 }

--- a/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/commcare/CommCareIdentityDataSource.kt
+++ b/infra/enrolment-records-store/src/main/java/com/simprints/infra/enrolment/records/store/commcare/CommCareIdentityDataSource.kt
@@ -40,14 +40,6 @@ internal class CommCareIdentityDataSource @Inject constructor(
     @ApplicationContext private val context: Context,
     @DispatcherIO private val dispatcher: CoroutineDispatcher,
 ) : IdentityDataSource {
-    companion object {
-        const val COLUMN_CASE_ID = "case_id"
-        const val COLUMN_DATUM_ID = "datum_id"
-        const val COLUMN_VALUE = "value"
-
-        const val ARG_CASE_ID = "caseId"
-    }
-
     private fun getCaseMetadataUri(packageName: String): Uri = Uri.parse("content://$packageName.case/casedb/case")
 
     private fun getCaseDataUri(packageName: String): Uri = Uri.parse("content://$packageName.case/casedb/data")
@@ -106,7 +98,9 @@ internal class CommCareIdentityDataSource @Inject constructor(
                     if (caseMetadataCursor.moveToPosition(range.first)) {
                         do {
                             caseMetadataCursor.getString(caseMetadataCursor.getColumnIndexOrThrow(COLUMN_CASE_ID))?.let { caseId ->
-                                enrolmentRecordCreationEvents.addAll(loadEnrolmentRecordCreationEvents(caseId, callerPackageName, query, project))
+                                enrolmentRecordCreationEvents.addAll(
+                                    loadEnrolmentRecordCreationEvents(caseId, callerPackageName, query, project),
+                                )
                                 onCandidateLoaded()
                             }
                         } while (caseMetadataCursor.moveToNext() && caseMetadataCursor.position < range.last)
@@ -160,7 +154,7 @@ internal class CommCareIdentityDataSource @Inject constructor(
         caseId: String,
         callerPackageName: String,
         query: SubjectQuery,
-        project: Project
+        project: Project,
     ): List<EnrolmentRecordCreationEvent> {
         // Access Case Data Listing for the caseId
         val caseDataUri = getCaseDataUri(callerPackageName).buildUpon().appendPath(caseId).build()
@@ -181,15 +175,15 @@ internal class CommCareIdentityDataSource @Inject constructor(
                         (query.subjectId != null && query.subjectId != event.payload.subjectId) ||
                             !compareImplicitTokenizedStringsUseCase(
                                 query.attendantId,
-                                event.payload.attendantId.value,
+                                event.payload.attendantId,
                                 TokenKeyType.AttendantId,
-                                project
+                                project,
                             ) ||
                             !compareImplicitTokenizedStringsUseCase(
                                 query.moduleId,
-                                event.payload.moduleId.value,
+                                event.payload.moduleId,
                                 TokenKeyType.ModuleId,
-                                project
+                                project,
                             )
                     }
             }.orEmpty()
@@ -243,5 +237,13 @@ internal class CommCareIdentityDataSource @Inject constructor(
                 null,
             )?.use { caseMetadataCursor -> count = caseMetadataCursor.count }
         count
+    }
+
+    companion object {
+        const val COLUMN_CASE_ID = "case_id"
+        const val COLUMN_DATUM_ID = "datum_id"
+        const val COLUMN_VALUE = "value"
+
+        const val ARG_CASE_ID = "caseId"
     }
 }

--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/usecases/CompareImplicitTokenizedStringsUseCaseTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/usecases/CompareImplicitTokenizedStringsUseCaseTest.kt
@@ -34,7 +34,7 @@ class CompareImplicitTokenizedStringsUseCaseTest {
     @Test
     fun `should return false when s1 is null`() {
         val s1 = null
-        val s2 = "s2"
+        val s2 = TokenizableString.Raw("s2")
 
         val result = useCase(s1, s2, tokenKeyType, project)
 
@@ -44,7 +44,7 @@ class CompareImplicitTokenizedStringsUseCaseTest {
     @Test
     fun `should return true if strings are equal (both untokenized)`() {
         val s1 = "s1".asTokenizableRaw()
-        val s2 = s1.value
+        val s2 = s1
         every { tokenizationProcessor.decrypt(any(), any(), any(), any()) } returns TokenizableString.Tokenized("some value")
 
         val result = useCase(s1, s2, tokenKeyType, project)
@@ -56,7 +56,7 @@ class CompareImplicitTokenizedStringsUseCaseTest {
     @Test
     fun `should return false if strings are not equal (both untokenized)`() {
         val s1 = "s1".asTokenizableRaw()
-        val s2 = "s2"
+        val s2 = "s2".asTokenizableRaw()
         every { tokenizationProcessor.decrypt(any(), any(), any(), any()) } returns TokenizableString.Tokenized("some value")
 
         val result = useCase(s1, s2, tokenKeyType, project)
@@ -68,7 +68,7 @@ class CompareImplicitTokenizedStringsUseCaseTest {
     @Test
     fun `should call encrypt if only first is tokenized)`() {
         val s1 = "s1".asTokenizableEncrypted()
-        val s2 = "s2"
+        val s2 = "s2".asTokenizableRaw()
         every { tokenizationProcessor.decrypt(any(), any(), any(), any()) } returns TokenizableString.Tokenized("some value")
 
         useCase(s1, s2, tokenKeyType, project)
@@ -79,8 +79,8 @@ class CompareImplicitTokenizedStringsUseCaseTest {
     @Test
     fun `should call encrypt if only second is tokenized)`() {
         val s1 = "s1".asTokenizableRaw()
-        val s2 = "encrypted s1"
-        every { tokenizationProcessor.decrypt(any(), any(), any(), any()) } returns TokenizableString.Raw(s2)
+        val s2 = "encrypted s1".asTokenizableEncrypted()
+        every { tokenizationProcessor.decrypt(any(), any(), any(), any()) } returns TokenizableString.Tokenized("some value")
 
         useCase(s1, s2, tokenKeyType, project)
 
@@ -90,7 +90,7 @@ class CompareImplicitTokenizedStringsUseCaseTest {
     @Test
     fun `should not call encrypt and return true if both strings are tokenized and equal`() {
         val s1 = "s1".asTokenizableEncrypted()
-        val s2 = s1.value
+        val s2 = "s1".asTokenizableEncrypted()
         every { tokenizationProcessor.decrypt(any(), any(), any(), any()) } returns TokenizableString.Raw("some value")
 
         val result = useCase(s1, s2, tokenKeyType, project)
@@ -102,7 +102,7 @@ class CompareImplicitTokenizedStringsUseCaseTest {
     @Test
     fun `should not call encrypt and return false if both strings are tokenized but not equal`() {
         val s1 = "s1".asTokenizableEncrypted()
-        val s2 = "s2"
+        val s2 = "s2".asTokenizableEncrypted()
         every { tokenizationProcessor.decrypt(any(), any(), any(), any()) } returns TokenizableString.Raw("some value")
 
         val result = useCase(s1, s2, tokenKeyType, project)
@@ -114,7 +114,7 @@ class CompareImplicitTokenizedStringsUseCaseTest {
     @Test
     fun `should return false if not equal`() {
         val s1 = "s1".asTokenizableRaw()
-        val s2 = "s2"
+        val s2 = "s2".asTokenizableRaw()
 
         val result = useCase(s1, s2, tokenKeyType, project)
 


### PR DESCRIPTION
1. Added the concrete class type (Raw or Tokenized) to tokenizable fields returned to CoSync
2. Given this - optimized CompareImplicitTokenizedStringsUseCase to only probe the tokenization state of TokenizableString.Raw values since if a value is TokenizableString.Tokenized we know its class was explicitly specified and can be sure of its tokenization state