### PR TITLE
[MS-887] Fix Filtering Logic in CommCareIdentityDataSource 

### DIFF
--- a/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/commcare/CommCareIdentityDataSourceTest.kt
+++ b/infra/enrolment-records-store/src/test/java/com/simprints/infra/enrolment/records/store/commcare/CommCareIdentityDataSourceTest.kt
@@ -8,6 +8,7 @@ import com.simprints.core.domain.face.FaceSample
 import com.simprints.core.domain.fingerprint.FingerprintSample
 import com.simprints.core.domain.fingerprint.IFingerIdentifier.LEFT_INDEX_FINGER
 import com.simprints.core.domain.fingerprint.IFingerIdentifier.LEFT_THUMB
+import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.core.tools.json.JsonHelper
 import com.simprints.core.tools.utils.EncodingUtils
 import com.simprints.infra.config.store.models.Project
@@ -259,7 +260,14 @@ class CommCareIdentityDataSourceTest {
             SUBJECT_ACTIONS_FACE_2,
         )
         val templateFormat = "ROC_1_23"
-        val query = SubjectQuery(faceSampleFormat = templateFormat)
+        val query = SubjectQuery(
+            faceSampleFormat = templateFormat,
+            attendantId = TokenizableString.Tokenized(
+                value = "AdySMrjuy7uq0Dcxov3rUFIw66uXTFrKd0BnzSr9MYXl5maWEpyKQT8AUdcPuVHUWpOkO88=",
+            ),
+            moduleId = TokenizableString.Tokenized(value = "AWuA3H0WGtHI2uod+ePZ3yiWTt9etQ=="),
+            subjectId = "b26c91bc-b307-4131-80c3-55090ba5dbf2",
+        )
         val range = 0..expectedFaceIdentities.size
         val actualIdentities = dataSource.loadFaceIdentities(query, range, project = project) {}
 


### PR DESCRIPTION
 There was a bug in the identification callouts from CommCare due to incorrect filtering logic in CommCareIdentityDataSource. The filtering logic was unintentionally excluding all records, causing identification failures.

The issue arose when building the subjectQuery in BuildMatcherSubjectQueryUseCase, where the filtering logic failed under different partitionType conditions:

    partitionType = PROJECT → Both module ID and attendant ID are null.
    partitionType = USER → The module ID in the query is null.
    partitionType = MODULE → The attendant ID is null in the query.

Due to this, the filtering logic always failed, as it did not account for null values correctly.


I updated the filtering logic to correctly handle null values to ensure that valid records are no longer filtered out incorrectly.