### PR TITLE
[MS-925] Run modality migrations only if modality is present in configuration

### DIFF
--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceBioSdkMigration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceBioSdkMigration.kt
@@ -15,8 +15,8 @@ class ProjectConfigFaceBioSdkMigration @Inject constructor() : DataMigration<Pro
         Simber.i("Migration of project configuration face bio sdk is done", tag = MIGRATION)
     }
 
-    override suspend fun shouldMigrate(currentData: ProtoProjectConfiguration) = with(currentData.face) {
-        !hasRankOne() || allowedSdksCount == 0
+    override suspend fun shouldMigrate(currentData: ProtoProjectConfiguration) = with(currentData) {
+        hasFace() && (!face.hasRankOne() || face.allowedSdksCount == 0)
     }
 
     override suspend fun migrate(currentData: ProtoProjectConfiguration): ProtoProjectConfiguration {

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceEmptyVersionMigration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceEmptyVersionMigration.kt
@@ -11,8 +11,8 @@ class ProjectConfigFaceEmptyVersionMigration @Inject constructor() : DataMigrati
         Simber.i("Migration of project configuration face bio sdk empty version is done", tag = MIGRATION)
     }
 
-    override suspend fun shouldMigrate(currentData: ProtoProjectConfiguration) = with(currentData.face) {
-        rankOne.version.isEmpty()
+    override suspend fun shouldMigrate(currentData: ProtoProjectConfiguration) = with(currentData) {
+        hasFace() && face.rankOne.version.isEmpty()
     }
 
     override suspend fun migrate(currentData: ProtoProjectConfiguration): ProtoProjectConfiguration {

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFingerprintBioSdkMigration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFingerprintBioSdkMigration.kt
@@ -15,8 +15,8 @@ class ProjectConfigFingerprintBioSdkMigration @Inject constructor() : DataMigrat
         Simber.i("Migration of project configuration fingerprint bio sdk is done", tag = MIGRATION)
     }
 
-    override suspend fun shouldMigrate(currentData: ProtoProjectConfiguration) = with(currentData.fingerprint) {
-        !(hasNec() || hasSecugenSimMatcher())
+    override suspend fun shouldMigrate(currentData: ProtoProjectConfiguration) = with(currentData) {
+        hasFingerprint() && !(fingerprint.hasNec() || fingerprint.hasSecugenSimMatcher())
     }
 
     override suspend fun migrate(currentData: ProtoProjectConfiguration): ProtoProjectConfiguration {

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigLedsModeMigration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigLedsModeMigration.kt
@@ -15,8 +15,9 @@ class ProjectConfigLedsModeMigration @Inject constructor() : DataMigration<Proto
         Simber.i("Migration of project configuration displayLiveFeedback to leds mode is done", tag = MIGRATION)
     }
 
-    override suspend fun shouldMigrate(currentData: ProtoProjectConfiguration) =
-        currentData.fingerprint.secugenSimMatcher.vero2.displayLiveFeedback
+    override suspend fun shouldMigrate(currentData: ProtoProjectConfiguration) = with(currentData) {
+        hasFingerprint() && fingerprint.secugenSimMatcher.vero2.displayLiveFeedback
+    }
 
     override suspend fun migrate(currentData: ProtoProjectConfiguration): ProtoProjectConfiguration {
         Simber.i("Start migration of project configuration displayLiveFeedback to leds mode ", tag = MIGRATION)

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceBioSdkMigrationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceBioSdkMigrationTest.kt
@@ -10,6 +10,16 @@ import org.junit.Test
 
 class ProjectConfigFaceBioSdkMigrationTest {
     @Test
+    fun `should not migrate if doesn't have face`() = runTest {
+        val currentData = ProtoProjectConfiguration
+            .newBuilder()
+            .build()
+        val shouldMigrate = ProjectConfigFaceBioSdkMigration().shouldMigrate(currentData)
+
+        assertThat(shouldMigrate).isFalse()
+    }
+
+    @Test
     fun `should migrate if face has no rankone config`() = runTest {
         val currentData = ProtoProjectConfiguration
             .newBuilder()

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceEmptyVersionMigrationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceEmptyVersionMigrationTest.kt
@@ -9,6 +9,17 @@ import org.junit.Test
 
 class ProjectConfigFaceEmptyVersionMigrationTest {
     @Test
+    fun `should not migrate if doesn't have face`() = runTest {
+        val currentData = ProtoProjectConfiguration
+            .newBuilder()
+            .build()
+
+        val shouldMigrate = ProjectConfigFaceEmptyVersionMigration().shouldMigrate(currentData)
+
+        assertThat(shouldMigrate).isFalse()
+    }
+
+    @Test
     fun `should migrate if face has empty version`() = runTest {
         val currentData = ProtoProjectConfiguration
             .newBuilder()

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFingerprintBioSdkMigrationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFingerprintBioSdkMigrationTest.kt
@@ -28,6 +28,17 @@ class ProjectConfigFingerprintBioSdkMigrationTest {
     }
 
     @Test
+    fun `should not migrate if doesn't have fingerprint`() = runTest {
+        val currentData = ProtoProjectConfiguration
+            .newBuilder()
+            .build()
+
+        val shouldMigrate = ProjectConfigFingerprintBioSdkMigration().shouldMigrate(currentData)
+
+        Truth.assertThat(shouldMigrate).isFalse()
+    }
+
+    @Test
     fun `should not migrate if fingerprint has nec`() = runTest {
         val currentData = ProtoProjectConfiguration
             .newBuilder()

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigLedsModeMigrationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigLedsModeMigrationTest.kt
@@ -35,8 +35,22 @@ class ProjectConfigLedsModeMigrationTest {
     }
 
     @Test
+    fun `test doesn't have fingerprint, then shouldMigrate should return false`() = runBlocking {
+        // Given
+        every { mockProtoConfig.fingerprint } returns null
+
+        // When
+        val result = migration.shouldMigrate(mockProtoConfig)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
     fun `test displayLiveFeedback is enabled, then shouldMigrate should return true`() = runBlocking {
         // Given
+        every { mockProtoConfig.hasFingerprint() } returns true
+        every { mockProtoConfig.fingerprint } returns mockFingerprint
         val mockVero2 = mockk<ProtoVero2Configuration>(relaxed = true)
         every { mockProtoConfig.fingerprint.secugenSimMatcher.vero2 } returns mockVero2
         every { mockVero2.displayLiveFeedback } returns true
@@ -51,6 +65,8 @@ class ProjectConfigLedsModeMigrationTest {
     @Test
     fun `test displayLiveFeedback is disabled, then shouldMigrate should return false`() = runBlocking {
         // Given
+        every { mockProtoConfig.hasFingerprint() } returns true
+        every { mockProtoConfig.fingerprint } returns mockFingerprint
         val mockVero2 = mockk<ProtoVero2Configuration>(relaxed = true)
         every { mockProtoConfig.fingerprint.secugenSimMatcher.vero2 } returns mockVero2
         every { mockVero2.displayLiveFeedback } returns false


### PR DESCRIPTION
Found out by chance that a lot of the migrations for a modality run when this modality is not enabled, creating bogus config. E.g. if you have a fingerprint project, face config migrations would run and would create a face configuration with some defaults.