### PR TITLE
[MS-923] Adding internal counter for the amount of loaded candidates in the MatchViewModel

### DIFF
--- a/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchViewModel.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchViewModel.kt
@@ -34,6 +34,7 @@ internal class MatchViewModel @Inject constructor(
 ) : ViewModel() {
     var isInitialized = false
         private set
+    private var candidatesLoaded = 0
 
     var shouldCheckPermission: Boolean = true
 
@@ -55,11 +56,13 @@ internal class MatchViewModel @Inject constructor(
             else -> fingerprintMatcher
         }
         val project = configManager.getProject(authStore.signedInProjectId)
+        candidatesLoaded = 0
         matcherUseCase(params, project).collect { matcherState ->
             when (matcherState) {
                 MatcherUseCase.MatcherState.CandidateLoaded -> {
                     (_matchState.value as? MatchState.LoadingCandidates)?.let { currentState ->
-                        _matchState.postValue(currentState.copy(loaded = currentState.loaded + 1))
+                        candidatesLoaded++
+                        _matchState.postValue(currentState.copy(loaded = candidatesLoaded))
                     }
                 }
 


### PR DESCRIPTION
Closed due to targeting incorrect branch. Correct branch is set here: [PR 1126](https://github.com/Simprints/Android-Simprints-ID/pull/1126)
## Issue description
The `MatchViewModel` observes the `LoadingCandidates` event from the Matcher UseCase and emits it to the LiveData's Observer. The `LoadingCandidates` event that might be emitted multiple times a second. 

We've observed that the UI layer processed less than 5% of the events sent to the LiveData:
 - `43819` events emitted by the Use Case
 - `43819` events forwarded to the LiveData by the ViewModel (0% loss)
 - `2372` - received by the observer (`MatchFragment`, >90% loss)

Not only the events were being lost, the Observer stopped receiving them after some arbitrary threshold - after ~20 events on some devices, ~4000 events on others.

## Fix
It was identified that by removing the state reference to itself for update, the issue disappears.
```
MatcherUseCase.MatcherState.CandidateLoaded -> {
    (_matchState.value as? MatchState.LoadingCandidates)?.let { currentState ->
        _matchState.postValue(currentState.copy(loaded = currentState.loaded + 1)) // changing this line
    }
}
```
was changed to
```
MatcherUseCase.MatcherState.CandidateLoaded -> {
    (_matchState.value as? MatchState.LoadingCandidates)?.let { currentState ->
        candidatesLoaded++
        _matchState.postValue(currentState.copy(loaded = candidatesLoaded))
    }
}
```

This way the new state does need to access old state for update, and no longer exhausts resources to send updates to the LiveData observer. 

- CoSync works ✅
- SID local database works ✅

## Video before the update:

https://github.com/user-attachments/assets/70086e1d-7314-4088-b3e2-6a6f4e31c5c2

## Video after the update:
### Local database

https://github.com/user-attachments/assets/edcbf6b6-9c04-43ea-b7b1-5e3d97b3b298

### CoSync

https://github.com/user-attachments/assets/f3e30a31-4d0b-416c-987a-3bc2c70f23d1



