### PR TITLE
[MS-929] Fix 1:N pool count for CoSync

### DIFF
--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/commcare/CommCareIdentityDataSource.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/commcare/CommCareIdentityDataSource.kt
@@ -52,10 +52,11 @@ internal class CommCareIdentityDataSource @Inject constructor(
         project: Project,
         onCandidateLoaded: () -> Unit,
     ): List<FingerprintIdentity> = withContext(dispatcher) {
-        loadEnrolmentRecordCreationEvents(range, dataSource.callerPackageName(), query, project, onCandidateLoaded)
+        loadEnrolmentRecordCreationEvents(range, dataSource.callerPackageName(), query, project)
             .filter { erce ->
                 erce.payload.biometricReferences.any { it is FingerprintReference && it.format == query.fingerprintSampleFormat }
             }.map {
+                onCandidateLoaded()
                 FingerprintIdentity(
                     it.payload.subjectId,
                     it.payload.biometricReferences
@@ -80,7 +81,6 @@ internal class CommCareIdentityDataSource @Inject constructor(
         callerPackageName: String,
         query: SubjectQuery,
         project: Project,
-        onCandidateLoaded: () -> Unit,
     ): List<EnrolmentRecordCreationEvent> {
         val enrolmentRecordCreationEvents: MutableList<EnrolmentRecordCreationEvent> = mutableListOf()
         try {
@@ -103,7 +103,6 @@ internal class CommCareIdentityDataSource @Inject constructor(
                                 enrolmentRecordCreationEvents.addAll(
                                     loadEnrolmentRecordCreationEvents(caseId, callerPackageName, query, project),
                                 )
-                                onCandidateLoaded()
                             }
                         } while (caseMetadataCursor.moveToNext() && caseMetadataCursor.position < range.last)
                     }
@@ -132,10 +131,11 @@ internal class CommCareIdentityDataSource @Inject constructor(
         project: Project,
         onCandidateLoaded: () -> Unit,
     ): List<FaceIdentity> = withContext(dispatcher) {
-        loadEnrolmentRecordCreationEvents(range, dataSource.callerPackageName(), query, project, onCandidateLoaded)
+        loadEnrolmentRecordCreationEvents(range, dataSource.callerPackageName(), query, project)
             .filter { erce ->
                 erce.payload.biometricReferences.any { it is FaceReference && it.format == query.faceSampleFormat }
             }.map {
+                onCandidateLoaded()
                 FaceIdentity(
                     it.payload.subjectId,
                     it.payload.biometricReferences


### PR DESCRIPTION
[MS-929](https://simprints.atlassian.net/browse/MS-929)

**Problem**
Both the fingerprint and face matcher get the pool size (recorded in OneToManyMatch.MatchPool.count) by calling:
`val totalCandidates = enrolmentRecordRepository.count(queryWithSupportedFormat, dataSource = matchParams.biometricDataSource)`
This is fine when using the local DB. However, when using CommCare as the biometric data source, we cannot use any of the query’s filtering criteria so instead we just count the whole ContentProvider URI. This means we get the count of all cases in CommCare, regardless of their module or even whether they have biometric data attached or not. This might often lead to incorrect pool size reported in the `OneToManyMatch` event.

**Fix**
The fix contains two parts:
1. In the matchers count the number of actually loaded candidates and report that upstream so it ends in the `OneToManyMatch` event
2. In CommCareIdentityProvider move the onCandidateLoaded callback after filtering so that it only count actually loaded candidates (similar to how the local DB works)

[MS-929]: https://simprints.atlassian.net/browse/MS-929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ