### PR TITLE
improve OkHttpClient reuse & efficiency

### DIFF
--- a/infra/network/src/main/java/com/simprints/infra/network/SimNetworkImpl.kt
+++ b/infra/network/src/main/java/com/simprints/infra/network/SimNetworkImpl.kt
@@ -1,14 +1,16 @@
 package com.simprints.infra.network
 
 import com.simprints.infra.network.apiclient.SimApiClientImpl
-import com.simprints.infra.network.httpclient.DefaultOkHttpClientBuilder
+import com.simprints.infra.network.httpclient.BuildOkHttpClientUseCase
 import com.simprints.infra.network.url.BaseUrlProvider
 import javax.inject.Inject
+import javax.inject.Singleton
 import kotlin.reflect.KClass
 
+@Singleton
 internal class SimNetworkImpl @Inject constructor(
     private val baseUrlProvider: BaseUrlProvider,
-    private val okHttpClientBuilder: DefaultOkHttpClientBuilder,
+    private val buildOkHttpClient: BuildOkHttpClientUseCase,
 ) : SimNetwork {
     override fun <T : SimRemoteInterface> getSimApiClient(
         remoteInterface: KClass<T>,
@@ -17,7 +19,7 @@ internal class SimNetworkImpl @Inject constructor(
         authToken: String?,
     ): SimNetwork.SimApiClient<T> = SimApiClientImpl(
         remoteInterface,
-        okHttpClientBuilder,
+        buildOkHttpClient,
         getApiBaseUrl(),
         deviceId,
         versionName,

--- a/infra/network/src/test/java/com/simprints/infra/network/SimNetworkImplTest.kt
+++ b/infra/network/src/test/java/com/simprints/infra/network/SimNetworkImplTest.kt
@@ -1,7 +1,7 @@
 package com.simprints.infra.network
 
 import com.simprints.infra.network.apiclient.SimApiClientImpl
-import com.simprints.infra.network.httpclient.DefaultOkHttpClientBuilder
+import com.simprints.infra.network.httpclient.BuildOkHttpClientUseCase
 import com.simprints.infra.network.url.BaseUrlProvider
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.MockK
@@ -15,7 +15,7 @@ class SimNetworkImplTest {
     private lateinit var baseUrlProvider: BaseUrlProvider
 
     @MockK
-    private lateinit var okHttpClientBuilder: DefaultOkHttpClientBuilder
+    private lateinit var okHttpClientBuilder: BuildOkHttpClientUseCase
 
     @Before
     fun setUp() {

--- a/infra/network/src/test/java/com/simprints/infra/network/apiclient/SimApiClientImplTest.kt
+++ b/infra/network/src/test/java/com/simprints/infra/network/apiclient/SimApiClientImplTest.kt
@@ -7,7 +7,7 @@ import com.simprints.infra.network.exceptions.ApiError
 import com.simprints.infra.network.exceptions.BackendMaintenanceException
 import com.simprints.infra.network.exceptions.NetworkConnectionException
 import com.simprints.infra.network.exceptions.SyncCloudIntegrationException
-import com.simprints.infra.network.httpclient.DefaultOkHttpClientBuilder
+import com.simprints.infra.network.httpclient.BuildOkHttpClientUseCase
 import com.simprints.logging.persistent.PersistentLogger
 import com.simprints.testtools.common.syntax.assertThrows
 import io.mockk.MockKAnnotations
@@ -38,7 +38,7 @@ class SimApiClientImplTest {
     private lateinit var mockWebServer: MockWebServer
     private lateinit var simApiClientImpl: SimApiClientImpl<FakeRetrofitInterface>
 
-    private lateinit var httpClientBuilder: DefaultOkHttpClientBuilder
+    private lateinit var httpClientBuilder: BuildOkHttpClientUseCase
 
     @Before
     fun setup() {
@@ -46,7 +46,7 @@ class SimApiClientImplTest {
 
         mockWebServer = MockWebServer()
         mockWebServer.start()
-        httpClientBuilder = DefaultOkHttpClientBuilder(
+        httpClientBuilder = BuildOkHttpClientUseCase(
             mockk(),
             networkCache,
             persistentLogger,


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-934)
Will be released in:  2025.2.0

### Root cause analysis (for bugfixes only)

First known affected version:From the moment we started using OkHttp 

The issue was identified through [this](https://console.firebase.google.com/project/simprints-152315/crashlytics/app/android:com.simprints.id/issues/9f70fa04d60773d9576c0a1c4381e56a?utm_campaign=extensions&utm_medium=SLACK&utm_source=NEW_ISSUE)  Crashlytics OOM error, revealing that OkHttp had created 300 threads. After reviewing the OkHttp [documentation](https://square.github.io/okhttp/5.x/okhttp/okhttp3/-ok-http-client/index.html), I discovered that SID was incorrectly creating a new `OkHttpClient` instance for each API call instead of reusing a single instance.
### Notable changes

- Reuses `OkHttpClient` for identical auth tokens, reducing memory usage.
- Ensures thread-safe access with a lock.
- Creates new instances only when the auth token changes.
- Extracts timeouts as constants.

### Testing guidance
As the change is in the network layer then all general api calls should be checked
1. **Login & Logout** – Validate authentication/ non-authnticated API calls.  
2. **Sync (Scheduled & Manual)** – Ensure correct up/down sync behavior.  
3. **License or Firmware files Download** – Verify required files download properly.  
4. **Image Upload** – Check successful capture, upload, and retries.
### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
