### PR TITLE
[MS-936] Fix the db locked issue by Refactor EventDatabaseFactory to create a single instance of the event DB

### DIFF
--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/EventDatabaseFactoryTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/EventDatabaseFactoryTest.kt
@@ -31,19 +31,36 @@ internal class EventDatabaseFactoryTest {
     }
 
     @Test
-    fun `test build db success`() = runTest {
+    fun `test get db success`() = runTest {
         // Given
         coEvery { securityManager.getLocalDbKeyOrThrow(dbName) } returns localDbKey
         mockkObject(EventRoomDatabase)
         val db: EventRoomDatabase = mockk()
         every { EventRoomDatabase.getDatabase(context, any(), dbName) } returns db
         // When
-        Truth.assertThat(dbEventDatabaseFactory.build()).isEqualTo(db)
+        Truth.assertThat(dbEventDatabaseFactory.get()).isEqualTo(db)
         verify { securityManager.getLocalDbKeyOrThrow(dbName) }
     }
 
     @Test
-    fun `test build db creates key if not exist`() = runTest {
+    fun `get should return the same db instance on multiple calls`() = runTest {
+        // Given
+        coEvery { securityManager.getLocalDbKeyOrThrow(dbName) } returns localDbKey
+        mockkObject(EventRoomDatabase)
+        every { EventRoomDatabase.getDatabase(context, any(), dbName) } returns mockk()
+        // When and Then
+        val db1 = dbEventDatabaseFactory.get()
+        val db2 = dbEventDatabaseFactory.get()
+        Truth.assertThat(db1).isSameInstanceAs(db2)
+        // Verify that getLocalDbKeyOrThrow is called only once
+        verify(exactly = 1) {
+            securityManager.getLocalDbKeyOrThrow(dbName)
+            EventRoomDatabase.getDatabase(context, any(), dbName)
+        }
+    }
+
+    @Test
+    fun `test get db creates key if not exist`() = runTest {
         // Given
         coEvery { securityManager.getLocalDbKeyOrThrow(dbName) } throws Exception() andThen localDbKey
         justRun { securityManager.createLocalDatabaseKeyIfMissing(dbName) }
@@ -51,12 +68,12 @@ internal class EventDatabaseFactoryTest {
         val db: EventRoomDatabase = mockk()
         every { EventRoomDatabase.getDatabase(context, any(), dbName) } returns db
         // When and Then
-        Truth.assertThat(dbEventDatabaseFactory.build()).isEqualTo(db)
+        Truth.assertThat(dbEventDatabaseFactory.get()).isEqualTo(db)
         verify(exactly = 2) { securityManager.getLocalDbKeyOrThrow(dbName) }
     }
 
     @Test(expected = Exception::class)
-    fun `test build db falure`() = runTest {
+    fun `test get db falure`() = runTest {
         // Given
         coEvery { securityManager.getLocalDbKeyOrThrow(dbName) } throws Exception()
         justRun { securityManager.createLocalDatabaseKeyIfMissing(dbName) }
@@ -64,25 +81,22 @@ internal class EventDatabaseFactoryTest {
         val db: EventRoomDatabase = mockk()
         every { EventRoomDatabase.getDatabase(context, any(), dbName) } returns db
         // When calling build it should throw exception
-        dbEventDatabaseFactory.build()
+        dbEventDatabaseFactory.get()
     }
 
     @Test
-    fun deleteDatabase() {
-        // When
-        dbEventDatabaseFactory.deleteDatabase()
-
-        // Then
-        verify { context.deleteDatabase(dbName) }
-    }
-
-    @Test
-    fun recreateDatabaseKey() {
+    fun recreateDatabase() {
         // Given
         justRun { securityManager.recreateLocalDatabaseKey(dbName) }
+        coEvery { securityManager.getLocalDbKeyOrThrow(dbName) } returns localDbKey
+        justRun { securityManager.createLocalDatabaseKeyIfMissing(dbName) }
+        mockkObject(EventRoomDatabase)
+        val db: EventRoomDatabase = mockk()
+        every { EventRoomDatabase.getDatabase(context, any(), dbName) } returns db
         // When
-        dbEventDatabaseFactory.recreateDatabaseKey()
+        dbEventDatabaseFactory.recreateDatabase()
         // Then
+        verify { context.deleteDatabase(dbName) }
         verify { securityManager.recreateLocalDatabaseKey(dbName) }
     }
 }

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/EventLocalDataSourceTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/EventLocalDataSourceTest.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import android.database.sqlite.SQLiteDatabaseCorruptException
 import android.database.sqlite.SQLiteException
 import androidx.room.Room
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.common.truth.Truth.assertThat
+import androidx.test.core.app.*
+import androidx.test.ext.junit.runners.*
+import com.google.common.truth.Truth.*
 import com.simprints.core.tools.json.JsonHelper
 import com.simprints.infra.events.event.domain.models.Event
 import com.simprints.infra.events.event.domain.models.EventType.CALLBACK_ENROLMENT
@@ -20,7 +20,8 @@ import com.simprints.testtools.common.syntax.assertThrows
 import com.simprints.testtools.unit.robolectric.ShadowAndroidXMultiDex
 import dagger.hilt.android.testing.HiltTestApplication
 import io.mockk.*
-import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.impl.annotations.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -44,6 +45,7 @@ internal class EventLocalDataSourceTest {
     @RelaxedMockK
     lateinit var eventDatabaseFactory: EventDatabaseFactory
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun setup() {
         MockKAnnotations.init(this)
@@ -57,7 +59,7 @@ internal class EventLocalDataSourceTest {
         eventDao = db.eventDao
         scopeDao = db.scopeDao
 
-        every { eventDatabaseFactory.build() } returns db
+        every { eventDatabaseFactory.get() } returns db
         mockDaoLoadToMakeNothing()
 
         eventLocalDataSource = EventLocalDataSource(
@@ -78,9 +80,8 @@ internal class EventLocalDataSourceTest {
         eventLocalDataSource.loadAllEvents()
         // Then
         verify {
-            eventDatabaseFactory.deleteDatabase()
-            eventDatabaseFactory.recreateDatabaseKey()
-            eventDatabaseFactory.build()
+            eventDatabaseFactory.recreateDatabase()
+            eventDatabaseFactory.get()
         }
         coVerify(exactly = 2) { eventDao.loadAll() }
     }
@@ -95,9 +96,7 @@ internal class EventLocalDataSourceTest {
         eventLocalDataSource.loadAllEvents()
         // Then
         verify {
-            eventDatabaseFactory.deleteDatabase()
-            eventDatabaseFactory.recreateDatabaseKey()
-            eventDatabaseFactory.build()
+            eventDatabaseFactory.recreateDatabase()
         }
         coVerify(exactly = 2) { eventDao.loadAll() }
     }
@@ -110,7 +109,7 @@ internal class EventLocalDataSourceTest {
         assertThrows<SQLiteException> { eventLocalDataSource.loadAllEvents() }
         // Then
         verify(exactly = 0) {
-            eventDatabaseFactory.deleteDatabase()
+            eventDatabaseFactory.recreateDatabase()
         }
         coVerify(exactly = 1) { eventDao.loadAll() }
     }
@@ -123,7 +122,7 @@ internal class EventLocalDataSourceTest {
         assertThrows<Exception> { eventLocalDataSource.loadAllEvents() }
         // Then
         verify(exactly = 0) {
-            eventDatabaseFactory.deleteDatabase()
+            eventDatabaseFactory.recreateDatabase()
         }
         coVerify(exactly = 1) { eventDao.loadAll() }
     }
@@ -137,11 +136,7 @@ internal class EventLocalDataSourceTest {
         // When
         eventLocalDataSource.observeEventCount().toList()
         // Then
-        verify {
-            eventDatabaseFactory.deleteDatabase()
-            eventDatabaseFactory.recreateDatabaseKey()
-            eventDatabaseFactory.build()
-        }
+        verify { eventDatabaseFactory.recreateDatabase() }
         coVerify(exactly = 2) { eventDao.observeCount() }
     }
 
@@ -155,7 +150,7 @@ internal class EventLocalDataSourceTest {
         }
         // Then
         verify(exactly = 0) {
-            eventDatabaseFactory.deleteDatabase()
+            eventDatabaseFactory.recreateDatabase()
         }
         coVerify(exactly = 1) { eventDao.observeCount() }
     }
@@ -169,11 +164,7 @@ internal class EventLocalDataSourceTest {
         // When
         eventLocalDataSource.observeEventCount().toList()
         // Then
-        verify {
-            eventDatabaseFactory.deleteDatabase()
-            eventDatabaseFactory.recreateDatabaseKey()
-            eventDatabaseFactory.build()
-        }
+        verify { eventDatabaseFactory.recreateDatabase() }
         coVerify(exactly = 2) { eventDao.observeCount() }
     }
 
@@ -187,7 +178,7 @@ internal class EventLocalDataSourceTest {
         }
         // Then
         verify(exactly = 0) {
-            eventDatabaseFactory.deleteDatabase()
+            eventDatabaseFactory.recreateDatabase()
         }
         coVerify(exactly = 1) { eventDao.observeCount() }
     }
@@ -202,9 +193,7 @@ internal class EventLocalDataSourceTest {
         val count = eventLocalDataSource.observeEventCount().toList()
         // Then
         verify {
-            eventDatabaseFactory.deleteDatabase()
-            eventDatabaseFactory.recreateDatabaseKey()
-            eventDatabaseFactory.build()
+            eventDatabaseFactory.recreateDatabase()
         }
         coVerify(exactly = 2) { eventDao.observeCount() }
         assertThat(count).isEqualTo(listOf(1, 2, 3))
@@ -219,11 +208,7 @@ internal class EventLocalDataSourceTest {
         // When
         eventLocalDataSource.observeEventCount().toList()
         // Then
-        verify {
-            eventDatabaseFactory.deleteDatabase()
-            eventDatabaseFactory.recreateDatabaseKey()
-            eventDatabaseFactory.build()
-        }
+        verify { eventDatabaseFactory.recreateDatabase() }
         coVerify(exactly = 2) { eventDao.observeCount() }
     }
 
@@ -237,7 +222,7 @@ internal class EventLocalDataSourceTest {
                 eventLocalDataSource.observeEventCount().toList()
             }
             // Then
-            verify(exactly = 0) { eventDatabaseFactory.deleteDatabase() }
+            verify(exactly = 0) { eventDatabaseFactory.recreateDatabase() }
             coVerify(exactly = 1) { eventDao.observeCount() }
         }
 
@@ -252,9 +237,7 @@ internal class EventLocalDataSourceTest {
             eventLocalDataSource.observeEventCount().toList()
             // Then
             verify {
-                eventDatabaseFactory.deleteDatabase()
-                eventDatabaseFactory.recreateDatabaseKey()
-                eventDatabaseFactory.build()
+                eventDatabaseFactory.recreateDatabase()
             }
             coVerify(exactly = 2) { eventDao.observeCount() }
         }
@@ -268,7 +251,7 @@ internal class EventLocalDataSourceTest {
             eventLocalDataSource.observeEventCount().toList()
         }
         // Then
-        verify(exactly = 0) { eventDatabaseFactory.deleteDatabase() }
+        verify(exactly = 0) { eventDatabaseFactory.recreateDatabase() }
         coVerify(exactly = 1) { eventDao.observeCount() }
     }
 
@@ -282,9 +265,7 @@ internal class EventLocalDataSourceTest {
         val count = eventLocalDataSource.observeEventCount().toList()
         // Then
         verify {
-            eventDatabaseFactory.deleteDatabase()
-            eventDatabaseFactory.recreateDatabaseKey()
-            eventDatabaseFactory.build()
+            eventDatabaseFactory.recreateDatabase()
         }
         coVerify(exactly = 2) { eventDao.observeCount() }
         assertThat(count).isEqualTo(listOf(1, 2, 3))
@@ -301,9 +282,7 @@ internal class EventLocalDataSourceTest {
         }
         // Then
         verify {
-            eventDatabaseFactory.deleteDatabase()
-            eventDatabaseFactory.recreateDatabaseKey()
-            eventDatabaseFactory.build()
+            eventDatabaseFactory.recreateDatabase()
         }
         coVerify(exactly = 2) { eventDao.observeCount() }
     }
@@ -477,7 +456,7 @@ internal class EventLocalDataSourceTest {
         coEvery { scopeDao.count(any()) } returns 0
         every { db.eventDao } returns eventDao
         every { db.scopeDao } returns scopeDao
-        every { eventDatabaseFactory.build() } returns db
+        every { eventDatabaseFactory.get() } returns db
     }
 
     @After


### PR DESCRIPTION

[MS-936 ](https://simprints.atlassian.net/browse/MS-936)
Will be released in: **2025.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **it is happing in all versions 

As seen in the bug ticket and [Crashlytics](https://console.firebase.google.com/project/simprints-152315/crashlytics/app/android:com.simprints.id/issues/1e397ff40fcf20f006fc93041dc683da?utm_campaign=extensions&utm_medium=JIRA&utm_source=CRASHLYTICS_CONSOLE_MANUAL_ISSUE), we are encountering multiple errors where the events' database is locked. Upon reviewing the code, I found that we are not adhering to Room's [documentation guidelines](https://developer.android.com/training/data-storage/room#database). Specifically, As SID is creating multiple instances of the `EventRoomDatabase` object, whereas the documentation states that the database instance should be shared. Using the Android Profiler, I observed that multiple database objects are being created during the biometric capture workflow and when opening the app dashboard.  




### Notable changes


- Change EventDatabaseFactory to use `get()` instead of `build()` to retrieve the `EventRoomDatabase` instance, ensuring that the database is only built once.
- Replaced deleteDatabase() and recreateDatabaseKey() with single method `recreateDatabase()`
- Update the `EventLocalDataSource` to use `get()` for database retrieval.
- Improve `recreateDatabase()` functionality in `EventDatabaseFactory`
- Update the test suit accordingly.

### Testing guidance

* Every part of the app, including sync and biometric capture, is affected. A quick test is recommended.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
