### PR TITLE
[MS-961] Remove templateQualityScore from FingerprintSample 

### DIFF
--- a/feature/enrol-last-biometric/src/main/java/com/simprints/feature/enrollast/screen/usecase/BuildSubjectUseCase.kt
+++ b/feature/enrol-last-biometric/src/main/java/com/simprints/feature/enrollast/screen/usecase/BuildSubjectUseCase.kt
@@ -47,7 +47,6 @@ internal class BuildSubjectUseCase @Inject constructor(
     ) = FingerprintSample(
         fromDomainToModuleApi(result.finger),
         result.template,
-        result.templateQualityScore,
         result.format,
         referenceId,
     )

--- a/feature/matcher/src/test/java/com/simprints/matcher/usecases/FingerprintMatcherUseCaseTest.kt
+++ b/feature/matcher/src/test/java/com/simprints/matcher/usecases/FingerprintMatcherUseCaseTest.kt
@@ -72,17 +72,18 @@ internal class FingerprintMatcherUseCaseTest {
 
     @Test
     fun `Skips matching if there are no probes`() = runTest {
-       val results = useCase.invoke(
-            MatchParams(
-                probeReferenceId = "referenceId",
-                probeFingerprintSamples = emptyList(),
-                fingerprintSDK = SECUGEN_SIM_MATCHER,
-                flowType = FlowType.VERIFY,
-                queryForCandidates = SubjectQuery(),
-                biometricDataSource = BiometricDataSource.Simprints,
-            ),
-           project
-        ).toList()
+        val results = useCase
+            .invoke(
+                MatchParams(
+                    probeReferenceId = "referenceId",
+                    probeFingerprintSamples = emptyList(),
+                    fingerprintSDK = SECUGEN_SIM_MATCHER,
+                    flowType = FlowType.VERIFY,
+                    queryForCandidates = SubjectQuery(),
+                    biometricDataSource = BiometricDataSource.Simprints,
+                ),
+                project,
+            ).toList()
 
         coVerify(exactly = 0) { bioSdkWrapper.match(any(), any(), any()) }
 
@@ -90,8 +91,8 @@ internal class FingerprintMatcherUseCaseTest {
             MatcherUseCase.MatcherState.Success(
                 matchResultItems = emptyList(),
                 totalCandidates = 0,
-                matcherName = ""
-            )
+                matcherName = "",
+            ),
         )
     }
 
@@ -101,23 +102,24 @@ internal class FingerprintMatcherUseCaseTest {
         coEvery { enrolmentRecordRepository.loadFaceIdentities(any(), any(), any(), project, onCandidateLoaded) } returns emptyList()
         coEvery { bioSdkWrapper.match(any(), any(), any()) } returns listOf()
 
-        val results = useCase.invoke(
-            MatchParams(
-                probeReferenceId = "referenceId",
-                probeFingerprintSamples = listOf(
-                    MatchParams.FingerprintSample(
-                        IFingerIdentifier.LEFT_3RD_FINGER,
-                        "format",
-                        byteArrayOf(1, 2, 3),
+        val results = useCase
+            .invoke(
+                MatchParams(
+                    probeReferenceId = "referenceId",
+                    probeFingerprintSamples = listOf(
+                        MatchParams.FingerprintSample(
+                            IFingerIdentifier.LEFT_3RD_FINGER,
+                            "format",
+                            byteArrayOf(1, 2, 3),
+                        ),
                     ),
+                    fingerprintSDK = SECUGEN_SIM_MATCHER,
+                    flowType = FlowType.VERIFY,
+                    queryForCandidates = SubjectQuery(),
+                    biometricDataSource = BiometricDataSource.Simprints,
                 ),
-                fingerprintSDK = SECUGEN_SIM_MATCHER,
-                flowType = FlowType.VERIFY,
-                queryForCandidates = SubjectQuery(),
-                biometricDataSource = BiometricDataSource.Simprints,
-            ),
-            project
-        ).toList()
+                project,
+            ).toList()
 
         coVerify(exactly = 0) { bioSdkWrapper.match(any(), any(), any()) }
 
@@ -125,8 +127,8 @@ internal class FingerprintMatcherUseCaseTest {
             MatcherUseCase.MatcherState.Success(
                 matchResultItems = emptyList(),
                 totalCandidates = 0,
-                matcherName = ""
-            )
+                matcherName = "",
+            ),
         )
     }
 
@@ -140,7 +142,7 @@ internal class FingerprintMatcherUseCaseTest {
                 any(),
                 any(),
                 project,
-                onCandidateLoaded
+                onCandidateLoaded,
             )
         } returns listOf(
             FingerprintIdentity(
@@ -161,26 +163,27 @@ internal class FingerprintMatcherUseCaseTest {
         )
         coEvery { bioSdkWrapper.match(any(), any(), any()) } returns listOf()
 
-        useCase.invoke(
-            matchParams = MatchParams(
-                probeReferenceId = "referenceId",
-                probeFingerprintSamples = listOf(
-                    MatchParams.FingerprintSample(
-                        IFingerIdentifier.LEFT_3RD_FINGER,
-                        "format",
-                        byteArrayOf(1, 2, 3),
+        useCase
+            .invoke(
+                matchParams = MatchParams(
+                    probeReferenceId = "referenceId",
+                    probeFingerprintSamples = listOf(
+                        MatchParams.FingerprintSample(
+                            IFingerIdentifier.LEFT_3RD_FINGER,
+                            "format",
+                            byteArrayOf(1, 2, 3),
+                        ),
                     ),
+                    fingerprintSDK = SECUGEN_SIM_MATCHER,
+                    flowType = FlowType.VERIFY,
+                    queryForCandidates = SubjectQuery(),
+                    biometricDataSource = BiometricDataSource.Simprints,
                 ),
-                fingerprintSDK = SECUGEN_SIM_MATCHER,
-                flowType = FlowType.VERIFY,
-                queryForCandidates = SubjectQuery(),
-                biometricDataSource = BiometricDataSource.Simprints,
-            ),
-            project
-        ).toList()
+                project,
+            ).toList()
 
         coVerify { bioSdkWrapper.match(any(), any(), any()) }
     }
 
-    private fun fingerprintSample(finger: IFingerIdentifier) = FingerprintSample(finger, byteArrayOf(1), 42, "format", "referenceId")
+    private fun fingerprintSample(finger: IFingerIdentifier) = FingerprintSample(finger, byteArrayOf(1), "format", "referenceId")
 }

--- a/infra/core/src/main/java/com/simprints/core/domain/fingerprint/FingerprintSample.kt
+++ b/infra/core/src/main/java/com/simprints/core/domain/fingerprint/FingerprintSample.kt
@@ -10,7 +10,6 @@ import java.util.UUID
 data class FingerprintSample(
     val fingerIdentifier: IFingerIdentifier,
     val template: ByteArray,
-    val templateQualityScore: Int,
     val format: String,
     val referenceId: String,
     val id: String = UUID.randomUUID().toString(),
@@ -23,7 +22,6 @@ data class FingerprintSample(
 
         if (fingerIdentifier != other.fingerIdentifier) return false
         if (!template.contentEquals(other.template)) return false
-        if (templateQualityScore != other.templateQualityScore) return false
 
         return true
     }
@@ -31,7 +29,6 @@ data class FingerprintSample(
     override fun hashCode(): Int {
         var result = fingerIdentifier.hashCode()
         result = 31 * result + template.contentHashCode()
-        result = 31 * result + templateQualityScore
         return result
     }
 }

--- a/infra/enrolment-records/realm-store/src/main/java/com/simprints/infra/enrolment/records/realm/store/models/DbFingerprintSample.kt
+++ b/infra/enrolment-records/realm-store/src/main/java/com/simprints/infra/enrolment/records/realm/store/models/DbFingerprintSample.kt
@@ -13,6 +13,5 @@ class DbFingerprintSample : RealmObject {
     var referenceId = ""
     var fingerIdentifier: Int = -1
     var template: ByteArray = byteArrayOf()
-    var templateQualityScore: Int = -1
     var format: String = ""
 }

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/commcare/CommCareIdentityDataSource.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/commcare/CommCareIdentityDataSource.kt
@@ -3,6 +3,7 @@ package com.simprints.infra.enrolment.records.repository.commcare
 import android.content.Context
 import android.database.Cursor
 import android.net.Uri
+import androidx.core.net.toUri
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.simprints.core.DispatcherIO
@@ -41,9 +42,9 @@ internal class CommCareIdentityDataSource @Inject constructor(
     @ApplicationContext private val context: Context,
     @DispatcherIO private val dispatcher: CoroutineDispatcher,
 ) : IdentityDataSource {
-    private fun getCaseMetadataUri(packageName: String): Uri = Uri.parse("content://$packageName.case/casedb/case")
+    private fun getCaseMetadataUri(packageName: String): Uri = "content://$packageName.case/casedb/case".toUri()
 
-    private fun getCaseDataUri(packageName: String): Uri = Uri.parse("content://$packageName.case/casedb/data")
+    private fun getCaseDataUri(packageName: String): Uri = "content://$packageName.case/casedb/data".toUri()
 
     override suspend fun loadFingerprintIdentities(
         query: SubjectQuery,
@@ -65,7 +66,6 @@ internal class CommCareIdentityDataSource @Inject constructor(
                             fingerprintReference.templates.map { fingerprintTemplate ->
                                 FingerprintSample(
                                     fingerIdentifier = fingerprintTemplate.finger,
-                                    templateQualityScore = fingerprintTemplate.quality,
                                     template = encoder.base64ToBytes(fingerprintTemplate.template),
                                     format = fingerprintReference.format,
                                     referenceId = fingerprintReference.id,

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/models/DbFingerprintSample.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/models/DbFingerprintSample.kt
@@ -8,7 +8,6 @@ internal fun DbFingerprintSample.fromDbToDomain(): FingerprintSample = Fingerpri
     id = id,
     fingerIdentifier = IFingerIdentifier.entries[fingerIdentifier],
     template = template,
-    templateQualityScore = templateQualityScore,
     format = format,
     referenceId = referenceId,
 )
@@ -18,6 +17,5 @@ internal fun FingerprintSample.fromDomainToDb(): DbFingerprintSample = DbFingerp
     sample.referenceId = referenceId
     sample.fingerIdentifier = fingerIdentifier.ordinal
     sample.template = template
-    sample.templateQualityScore = templateQualityScore
     sample.format = format
 }

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/remote/models/fingerprint/ApiFingerprintReference.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/remote/models/fingerprint/ApiFingerprintReference.kt
@@ -18,7 +18,6 @@ internal fun List<FingerprintSample>.toApi(encoder: EncodingUtils): ApiFingerpri
         first().referenceId,
         map {
             ApiFingerprintTemplate(
-                it.templateQualityScore,
                 encoder.byteArrayToBase64(it.template),
                 it.fingerIdentifier.toApi(),
             )

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/remote/models/fingerprint/ApiFingerprintTemplate.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/remote/models/fingerprint/ApiFingerprintTemplate.kt
@@ -4,7 +4,6 @@ import androidx.annotation.Keep
 
 @Keep
 internal data class ApiFingerprintTemplate(
-    val quality: Int,
     val template: String,
     val finger: ApiFinger,
 )

--- a/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/commcare/CommCareIdentityDataSourceTest.kt
+++ b/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/commcare/CommCareIdentityDataSourceTest.kt
@@ -52,14 +52,12 @@ class CommCareIdentityDataSourceTest {
                 fingerprints = listOf(
                     FingerprintSample(
                         fingerIdentifier = LEFT_THUMB,
-                        templateQualityScore = 99,
                         template = byteArrayOf(),
                         format = "ISO_19794_2",
                         referenceId = "referenceId",
                     ),
                     FingerprintSample(
                         fingerIdentifier = LEFT_INDEX_FINGER,
-                        templateQualityScore = 88,
                         template = byteArrayOf(),
                         format = "ISO_19794_2",
                         referenceId = "referenceId",
@@ -71,14 +69,12 @@ class CommCareIdentityDataSourceTest {
                 fingerprints = listOf(
                     FingerprintSample(
                         fingerIdentifier = LEFT_THUMB,
-                        templateQualityScore = 77,
                         template = byteArrayOf(),
                         format = "ISO_19794_2",
                         referenceId = "referenceId",
                     ),
                     FingerprintSample(
                         fingerIdentifier = LEFT_INDEX_FINGER,
-                        templateQualityScore = 66,
                         template = byteArrayOf(),
                         format = "ISO_19794_2",
                         referenceId = "referenceId",
@@ -245,7 +241,6 @@ class CommCareIdentityDataSourceTest {
                         expected.fingerprints
                             .zip(actual.fingerprints) { expectedFingerprint, actualFingerprint ->
                                 expectedFingerprint.fingerIdentifier == actualFingerprint.fingerIdentifier &&
-                                    expectedFingerprint.templateQualityScore == actualFingerprint.templateQualityScore &&
                                     expectedFingerprint.template.contentEquals(
                                         actualFingerprint.template,
                                     ) &&
@@ -338,7 +333,6 @@ class CommCareIdentityDataSourceTest {
                         expected.fingerprints
                             .zip(actual.fingerprints) { expectedFingerprint, actualFingerprint ->
                                 expectedFingerprint.fingerIdentifier == actualFingerprint.fingerIdentifier &&
-                                    expectedFingerprint.templateQualityScore == actualFingerprint.templateQualityScore &&
                                     expectedFingerprint.template.contentEquals(
                                         actualFingerprint.template,
                                     ) &&
@@ -425,7 +419,6 @@ class CommCareIdentityDataSourceTest {
                         expected.fingerprints
                             .zip(actual.fingerprints) { expectedFingerprint, actualFingerprint ->
                                 expectedFingerprint.fingerIdentifier == actualFingerprint.fingerIdentifier &&
-                                    expectedFingerprint.templateQualityScore == actualFingerprint.templateQualityScore &&
                                     expectedFingerprint.template.contentEquals(
                                         actualFingerprint.template,
                                     ) &&
@@ -573,7 +566,6 @@ class CommCareIdentityDataSourceTest {
                         expected.fingerprints
                             .zip(actual.fingerprints) { expectedFingerprint, actualFingerprint ->
                                 expectedFingerprint.fingerIdentifier == actualFingerprint.fingerIdentifier &&
-                                    expectedFingerprint.templateQualityScore == actualFingerprint.templateQualityScore &&
                                     expectedFingerprint.template.contentEquals(
                                         actualFingerprint.template,
                                     ) &&

--- a/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/local/EnrolmentRecordLocalDataSourceImplTest.kt
+++ b/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/local/EnrolmentRecordLocalDataSourceImplTest.kt
@@ -408,5 +408,5 @@ class EnrolmentRecordLocalDataSourceImplTest {
     private fun getRandomFingerprintSample(
         id: String = UUID.randomUUID().toString(),
         referenceId: String = "referenceId",
-    ) = FingerprintSample(IFingerIdentifier.LEFT_3RD_FINGER, Random.nextBytes(64), 42, "fingerprintTemplateFormat", referenceId, id)
+    ) = FingerprintSample(IFingerIdentifier.LEFT_3RD_FINGER, Random.nextBytes(64), "fingerprintTemplateFormat", referenceId, id)
 }

--- a/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/local/models/DbSubjectTest.kt
+++ b/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/local/models/DbSubjectTest.kt
@@ -30,7 +30,6 @@ class DbSubjectTest {
         val fingerprintSample = FingerprintSample(
             IFingerIdentifier.RIGHT_3RD_FINGER,
             Random.nextBytes(64),
-            30,
             "NEC_1",
             REFERENCE_ID,
         )
@@ -68,7 +67,6 @@ class DbSubjectTest {
         val fingerprintSample = DbFingerprintSample().apply {
             fingerIdentifier = IFingerIdentifier.RIGHT_3RD_FINGER.ordinal
             template = Random.nextBytes(64)
-            templateQualityScore = 30
             format = "NEC_1"
             referenceId = REFERENCE_ID
         }

--- a/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/remote/EnrolmentRecordRemoteDataSourceImplTest.kt
+++ b/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/remote/EnrolmentRecordRemoteDataSourceImplTest.kt
@@ -75,7 +75,6 @@ class EnrolmentRecordRemoteDataSourceImplTest {
                 FingerprintSample(
                     IFingerIdentifier.LEFT_3RD_FINGER,
                     FINGERPRINT_TEMPLATE,
-                    50,
                     "ISO_19794_2",
                     "5289df73-7df5-3326-bcdd-22597afb1fac",
                 ),
@@ -91,7 +90,6 @@ class EnrolmentRecordRemoteDataSourceImplTest {
                     id = "5289df73-7df5-3326-bcdd-22597afb1fac",
                     templates = listOf(
                         ApiFingerprintTemplate(
-                            quality = 50,
                             template = BASE64_FINGERPRINT_TEMPLATE,
                             finger = ApiFinger.LEFT_3RD_FINGER,
                         ),

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/subject/biometricref/ApiBiometricReference.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/subject/biometricref/ApiBiometricReference.kt
@@ -4,7 +4,6 @@ import androidx.annotation.Keep
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.simprints.core.domain.fingerprint.IFingerIdentifier
-import com.simprints.infra.events.event.domain.models.subject.BiometricReference
 import com.simprints.infra.events.event.domain.models.subject.FaceTemplate
 import com.simprints.infra.events.event.domain.models.subject.FingerprintTemplate
 import com.simprints.infra.eventsync.event.remote.models.subject.biometricref.face.ApiFaceReference
@@ -40,15 +39,6 @@ internal enum class ApiBiometricReferenceType {
     FingerprintReference,
 }
 
-internal fun BiometricReference.fromDomainToApi() = when (this) {
-    is DomainFaceReference -> {
-        ApiFaceReference(id, templates.map { it.fromDomainToApi() }, format, metadata)
-    }
-    is DomainFingerprintReference -> {
-        ApiFingerprintReference(id, templates.map { it.fromDomainToApi() }, format, metadata)
-    }
-}
-
 internal fun ApiBiometricReference.fromApiToDomain() = when (this.type) {
     ApiBiometricReferenceType.FaceReference -> (this as ApiFaceReference).fromApiToDomain()
     ApiBiometricReferenceType.FingerprintReference -> (this as ApiFingerprintReference).fromApiToDomain()
@@ -63,6 +53,4 @@ internal fun FaceTemplate.fromDomainToApi() = ApiFaceTemplate(template)
 internal fun ApiFingerprintReference.fromApiToDomain() =
     DomainFingerprintReference(id, templates.map { it.fromApiToDomain() }, format, metadata)
 
-internal fun ApiFingerprintTemplate.fromApiToDomain() = FingerprintTemplate(quality, template, IFingerIdentifier.valueOf(finger.name))
-
-internal fun FingerprintTemplate.fromDomainToApi() = ApiFingerprintTemplate(quality, template, finger)
+internal fun ApiFingerprintTemplate.fromApiToDomain() = FingerprintTemplate(template, IFingerIdentifier.valueOf(finger.name))

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/subject/biometricref/fingerprint/ApiFingerprintTemplate.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/subject/biometricref/fingerprint/ApiFingerprintTemplate.kt
@@ -5,7 +5,6 @@ import com.simprints.core.domain.fingerprint.IFingerIdentifier
 
 @Keep
 internal data class ApiFingerprintTemplate(
-    val quality: Int,
     val template: String,
     val finger: IFingerIdentifier,
 )

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/SubjectFactory.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/SubjectFactory.kt
@@ -109,7 +109,6 @@ class SubjectFactory @Inject constructor(
                 FingerprintSample(
                     captureResult.identifier,
                     sample.template,
-                    sample.templateQualityScore,
                     sample.format,
                     fingerprintResponse.referenceId,
                 )
@@ -133,7 +132,6 @@ class SubjectFactory @Inject constructor(
     ): FingerprintSample = FingerprintSample(
         fingerIdentifier = template.finger,
         template = encodingUtils.base64ToBytes(template.template),
-        templateQualityScore = template.quality,
         format = format,
         referenceId = referenceId,
     )

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/subject/ApiEnrolmentRecordCreationEventTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/subject/ApiEnrolmentRecordCreationEventTest.kt
@@ -22,7 +22,7 @@ class ApiEnrolmentRecordCreationEventTest {
                 ApiFingerprintReference(
                     "fpRefId",
                     listOf(
-                        ApiFingerprintTemplate(10, "template", IFingerIdentifier.LEFT_THUMB),
+                        ApiFingerprintTemplate("template", IFingerIdentifier.LEFT_THUMB),
                     ),
                     "NEC_1",
                 ),
@@ -37,7 +37,7 @@ class ApiEnrolmentRecordCreationEventTest {
                 FingerprintReference(
                     "fpRefId",
                     listOf(
-                        FingerprintTemplate(10, "template", IFingerIdentifier.LEFT_THUMB),
+                        FingerprintTemplate("template", IFingerIdentifier.LEFT_THUMB),
                     ),
                     "NEC_1",
                 ),

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/subject/ApiEnrolmentRecordMoveEventTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/subject/ApiEnrolmentRecordMoveEventTest.kt
@@ -23,7 +23,7 @@ class ApiEnrolmentRecordMoveEventTest {
                     ApiFingerprintReference(
                         "fpRefId",
                         listOf(
-                            ApiFingerprintTemplate(10, "template", IFingerIdentifier.LEFT_THUMB),
+                            ApiFingerprintTemplate("template", IFingerIdentifier.LEFT_THUMB),
                         ),
                         "NEC_1",
                     ),
@@ -46,7 +46,7 @@ class ApiEnrolmentRecordMoveEventTest {
                     FingerprintReference(
                         "fpRefId",
                         listOf(
-                            FingerprintTemplate(10, "template", IFingerIdentifier.LEFT_THUMB),
+                            FingerprintTemplate("template", IFingerIdentifier.LEFT_THUMB),
                         ),
                         "NEC_1",
                     ),

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/subject/ApiEnrolmentRecordUpdateEventTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/subject/ApiEnrolmentRecordUpdateEventTest.kt
@@ -22,7 +22,7 @@ class ApiEnrolmentRecordUpdateEventTest {
                 ApiFingerprintReference(
                     "fpRefId",
                     listOf(
-                        ApiFingerprintTemplate(10, "template", IFingerIdentifier.LEFT_THUMB),
+                        ApiFingerprintTemplate("template", IFingerIdentifier.LEFT_THUMB),
                     ),
                     "NEC_1",
                 ),
@@ -39,7 +39,7 @@ class ApiEnrolmentRecordUpdateEventTest {
             listOf(
                 FingerprintReference(
                     "fpRefId",
-                    listOf(FingerprintTemplate(10, "template", IFingerIdentifier.LEFT_THUMB)),
+                    listOf(FingerprintTemplate("template", IFingerIdentifier.LEFT_THUMB)),
                     "NEC_1",
                 ),
                 FaceReference(

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/down/tasks/SubjectFactoryTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/down/tasks/SubjectFactoryTest.kt
@@ -72,7 +72,6 @@ class SubjectFactoryTest {
                 FingerprintSample(
                     fingerIdentifier = IDENTIFIER,
                     template = BASE_64_BYTES,
-                    templateQualityScore = QUALITY,
                     format = REFERENCE_FORMAT,
                     referenceId = REFERENCE_ID,
                 ),
@@ -108,7 +107,6 @@ class SubjectFactoryTest {
                 FingerprintSample(
                     fingerIdentifier = IDENTIFIER,
                     template = BASE_64_BYTES,
-                    templateQualityScore = QUALITY,
                     format = REFERENCE_FORMAT,
                     referenceId = REFERENCE_ID,
                 ),
@@ -135,14 +133,12 @@ class SubjectFactoryTest {
                 FingerprintSample(
                     fingerIdentifier = IDENTIFIER,
                     template = BASE_64_BYTES,
-                    templateQualityScore = QUALITY,
                     format = REFERENCE_FORMAT,
                     referenceId = "referenceId-finger-1",
                 ),
                 FingerprintSample(
                     fingerIdentifier = IDENTIFIER,
                     template = BASE_64_BYTES,
-                    templateQualityScore = QUALITY,
                     format = REFERENCE_FORMAT,
                     referenceId = "referenceId-finger-2",
                 ),
@@ -170,7 +166,6 @@ class SubjectFactoryTest {
                     format = REFERENCE_FORMAT,
                     templates = listOf(
                         FingerprintTemplate(
-                            quality = QUALITY,
                             template = BASE_64_BYTES.toString(),
                             finger = IFingerIdentifier.LEFT_THUMB,
                         ),
@@ -194,14 +189,12 @@ class SubjectFactoryTest {
                 FingerprintSample(
                     fingerIdentifier = IDENTIFIER,
                     template = BASE_64_BYTES,
-                    templateQualityScore = QUALITY,
                     format = REFERENCE_FORMAT,
                     referenceId = "referenceId-finger-1",
                 ),
                 FingerprintSample(
                     fingerIdentifier = IDENTIFIER,
                     template = BASE_64_BYTES,
-                    templateQualityScore = QUALITY,
                     format = REFERENCE_FORMAT,
                     referenceId = "referenceId-finger-5",
                 ),
@@ -236,7 +229,6 @@ class SubjectFactoryTest {
                 FingerprintSample(
                     fingerIdentifier = IDENTIFIER,
                     template = BASE_64_BYTES,
-                    templateQualityScore = QUALITY,
                     format = REFERENCE_FORMAT,
                     referenceId = REFERENCE_ID,
                 ),
@@ -300,7 +292,6 @@ class SubjectFactoryTest {
                 FingerprintSample(
                     fingerIdentifier = IDENTIFIER,
                     template = BASE_64_BYTES,
-                    templateQualityScore = QUALITY,
                     format = REFERENCE_FORMAT,
                     referenceId = REFERENCE_ID,
                 ),
@@ -342,7 +333,6 @@ class SubjectFactoryTest {
             format = REFERENCE_FORMAT,
             templates = listOf(
                 FingerprintTemplate(
-                    quality = QUALITY,
                     template = TEMPLATE_NAME,
                     finger = IDENTIFIER,
                 ),

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/subject/EnrolmentRecordCreationEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/subject/EnrolmentRecordCreationEvent.kt
@@ -65,7 +65,6 @@ data class EnrolmentRecordCreationEvent(
                 fingerprintSamples.first().referenceId,
                 fingerprintSamples.map {
                     FingerprintTemplate(
-                        it.templateQualityScore,
                         encoder.byteArrayToBase64(it.template),
                         it.fingerIdentifier,
                     )

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/subject/FingerprintTemplate.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/subject/FingerprintTemplate.kt
@@ -5,7 +5,6 @@ import com.simprints.core.domain.fingerprint.IFingerIdentifier
 
 @Keep
 data class FingerprintTemplate(
-    val quality: Int,
     val template: String,
     val finger: IFingerIdentifier,
 )


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-961)
Will be released in: **2025.2.0**
Based on the [Slack discussion](https://simprints.slack.com/archives/G01B5GC5AH3/p1742801326612559), the `templateQualityScore` field is unnecessary and does not need to be stored in the records database.

