### PR TITLE
MS-969 Another stab at edge-to-edge support

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/confirmation/ConfirmationFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/confirmation/ConfirmationFragment.kt
@@ -12,6 +12,7 @@ import com.simprints.face.capture.databinding.FragmentConfirmationBinding
 import com.simprints.face.capture.screens.FaceCaptureViewModel
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -36,6 +37,8 @@ internal class ConfirmationFragment : Fragment(R.layout.fragment_confirmation) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
+
         Simber.i("ConfirmationFragment started", tag = ORCHESTRATION)
         startTime = faceTimeHelper.now()
 

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -33,6 +33,7 @@ import com.simprints.face.capture.screens.FaceCaptureViewModel
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.FACE_CAPTURE
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.view.setCheckedWithLeftDrawable
 import com.simprints.infra.uibase.viewbinding.viewBinding
@@ -76,6 +77,8 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
+
         Simber.i("LiveFeedbackFragment started", tag = ORCHESTRATION)
         initFragment()
     }

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedbackautocapture/LiveFeedbackAutoCaptureFragment.kt
@@ -32,6 +32,7 @@ import com.simprints.face.capture.models.FaceDetection
 import com.simprints.face.capture.screens.FaceCaptureViewModel
 import com.simprints.face.capture.screens.livefeedback.CropToTargetOverlayAnalyzer
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.view.setCheckedWithLeftDrawable
 import com.simprints.infra.uibase.viewbinding.viewBinding
@@ -75,6 +76,7 @@ internal class LiveFeedbackAutoCaptureFragment : Fragment(R.layout.fragment_live
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         initFragment()
     }
 

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/preparation/PreparationFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/preparation/PreparationFragment.kt
@@ -12,6 +12,7 @@ import com.simprints.face.capture.databinding.FragmentPreparationBinding
 import com.simprints.face.capture.screens.FaceCaptureViewModel
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -35,6 +36,7 @@ internal class PreparationFragment : Fragment(R.layout.fragment_preparation) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("PreparationFragment started", tag = ORCHESTRATION)
 
         startTime = faceTimeHelper.now()

--- a/feature/alert/src/main/java/com/simprints/feature/alert/screen/AlertFragment.kt
+++ b/feature/alert/src/main/java/com/simprints/feature/alert/screen/AlertFragment.kt
@@ -21,6 +21,7 @@ import com.simprints.feature.alert.databinding.FragmentAlertBinding
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ALERT
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.setResult
 import com.simprints.infra.uibase.system.Clipboard
 import com.simprints.infra.uibase.view.setTextWithFallbacks
@@ -39,6 +40,7 @@ internal class AlertFragment : Fragment(R.layout.fragment_alert) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("AlertFragment started", tag = ORCHESTRATION)
 
         val config = args.alertConfiguration

--- a/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/ConsentFragment.kt
+++ b/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/ConsentFragment.kt
@@ -18,6 +18,7 @@ import com.simprints.feature.exitform.ExitFormContract
 import com.simprints.feature.exitform.ExitFormResult
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.listeners.OnTabSelectedListener
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.navigation.handleResult
@@ -37,6 +38,7 @@ internal class ConsentFragment : Fragment(R.layout.fragment_consent) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("ConsentFragment started", tag = ORCHESTRATION)
 
         binding.consentPrivacyNotice.paintFlags = binding.consentPrivacyNotice.paintFlags or Paint.UNDERLINE_TEXT_FLAG

--- a/feature/consent/src/main/java/com/simprints/feature/consent/screens/privacy/PrivacyNoticeFragment.kt
+++ b/feature/consent/src/main/java/com/simprints/feature/consent/screens/privacy/PrivacyNoticeFragment.kt
@@ -12,6 +12,7 @@ import com.simprints.feature.consent.R
 import com.simprints.feature.consent.databinding.FragmentPrivacyBinding
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import com.simprints.infra.resources.R as IDR
@@ -26,6 +27,7 @@ internal class PrivacyNoticeFragment : Fragment(R.layout.fragment_privacy) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("PrivacyNoticeFragment started", tag = ORCHESTRATION)
 
         binding.privacyText.movementMethod = ScrollingMovementMethod()

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/debug/DebugFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/debug/DebugFragment.kt
@@ -19,6 +19,7 @@ import com.simprints.infra.events.EventRepository
 import com.simprints.infra.eventsync.EventSyncManager
 import com.simprints.infra.eventsync.status.models.EventSyncWorkerState
 import com.simprints.infra.sync.SyncOrchestrator
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineDispatcher
@@ -57,6 +58,7 @@ internal class DebugFragment : Fragment(R.layout.fragment_debug) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
 
         eventSyncManager.getLastSyncState().observe(viewLifecycleOwner) { state ->
             val states =

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/MainFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/MainFragment.kt
@@ -9,6 +9,7 @@ import androidx.navigation.fragment.findNavController
 import com.simprints.feature.dashboard.BuildConfig
 import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentMainBinding
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -23,6 +24,7 @@ internal class MainFragment : Fragment(R.layout.fragment_main) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         binding.dashboardToolbar.setOnMenuItemClickListener {
             menuItemClicked(it)
         }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
@@ -21,6 +21,7 @@ import com.simprints.feature.dashboard.databinding.FragmentSettingsBinding
 import com.simprints.feature.dashboard.settings.password.SettingsPasswordDialogFragment
 import com.simprints.infra.config.store.models.GeneralConfiguration
 import com.simprints.infra.config.store.models.GeneralConfiguration.Modality.FINGERPRINT
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -54,6 +55,8 @@ internal class SettingsFragment : PreferenceFragmentCompat() {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
+
         binding.settingsToolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutFragment.kt
@@ -19,6 +19,7 @@ import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentSettingsAboutBinding
 import com.simprints.feature.dashboard.settings.password.SettingsPasswordDialogFragment
 import com.simprints.infra.config.store.models.GeneralConfiguration.Modality.FINGERPRINT
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.system.Clipboard
 import com.simprints.infra.uibase.viewbinding.viewBinding
@@ -74,6 +75,7 @@ internal class AboutFragment : PreferenceFragmentCompat() {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         binding.settingsAboutToolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/fingerselection/FingerSelectionFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/fingerselection/FingerSelectionFragment.kt
@@ -9,6 +9,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentFingerSelectionBinding
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -24,6 +25,7 @@ internal class FingerSelectionFragment : Fragment(R.layout.fragment_finger_selec
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
 
         initRecyclerView()
         listenForItemChanges()

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
@@ -18,6 +18,7 @@ import com.simprints.infra.config.store.models.ProjectConfiguration
 import com.simprints.infra.config.store.models.SynchronizationConfiguration
 import com.simprints.infra.config.store.models.canSyncDataToSimprints
 import com.simprints.infra.config.store.models.isEventDownSyncAllowed
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.handleResult
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
@@ -39,6 +40,7 @@ internal class SyncInfoFragment : Fragment(R.layout.fragment_sync_info) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
 
         binding.selectedModulesView.adapter = moduleCountAdapter
         setupClickListeners()

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/ModuleSelectionFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/ModuleSelectionFragment.kt
@@ -29,6 +29,7 @@ import com.simprints.feature.dashboard.settings.syncinfo.moduleselection.excepti
 import com.simprints.feature.dashboard.settings.syncinfo.moduleselection.repository.Module
 import com.simprints.feature.dashboard.settings.syncinfo.moduleselection.tools.ChipClickListener
 import com.simprints.feature.dashboard.settings.syncinfo.moduleselection.tools.ModuleChipHelper
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import com.simprints.infra.resources.R as IDR
@@ -66,6 +67,7 @@ internal class ModuleSelectionFragment :
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
 
         configureOverlay()
         configureRecyclerView()

--- a/feature/dashboard/src/main/res/layout/fragment_main.xml
+++ b/feature/dashboard/src/main/res/layout/fragment_main.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     android:theme="@style/Theme.Simprints">
 
     <com.google.android.material.appbar.AppBarLayout

--- a/feature/enrol-last-biometric/src/main/java/com/simprints/feature/enrollast/screen/EnrolLastBiometricFragment.kt
+++ b/feature/enrol-last-biometric/src/main/java/com/simprints/feature/enrollast/screen/EnrolLastBiometricFragment.kt
@@ -25,6 +25,7 @@ import com.simprints.infra.config.store.models.GeneralConfiguration.Modality
 import com.simprints.infra.events.event.domain.models.AlertScreenEvent
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.navigation.handleResult
 import com.simprints.infra.uibase.navigation.navigateSafely
@@ -41,6 +42,7 @@ internal class EnrolLastBiometricFragment : Fragment(R.layout.fragment_enrol_las
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("EnrolLastBiometricFragment started", tag = ORCHESTRATION)
 
         findNavController().handleResult<AlertResult>(

--- a/feature/exit-form/src/main/java/com/simprints/feature/exitform/screen/ExitFormFragment.kt
+++ b/feature/exit-form/src/main/java/com/simprints/feature/exitform/screen/ExitFormFragment.kt
@@ -16,6 +16,7 @@ import com.simprints.feature.exitform.databinding.FragmentExitFormBinding
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.uibase.extensions.showToast
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.listeners.TextWatcherOnChangeListener
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.viewbinding.viewBinding
@@ -36,6 +37,7 @@ internal class ExitFormFragment : Fragment(R.layout.fragment_exit_form) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("ExitFormFragment started", tag = ORCHESTRATION)
 
         binding.exitFormTitle.setText(IDR.string.exit_form_title)

--- a/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/screen/FetchSubjectFragment.kt
+++ b/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/screen/FetchSubjectFragment.kt
@@ -15,6 +15,7 @@ import com.simprints.feature.fetchsubject.FetchSubjectResult
 import com.simprints.feature.fetchsubject.R
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.navigation.handleResult
 import com.simprints.infra.uibase.navigation.navigateSafely
@@ -30,6 +31,7 @@ internal class FetchSubjectFragment : Fragment(R.layout.fragment_subject_fetch) 
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("FetchSubjectFragment started", tag = ORCHESTRATION)
 
         with(findNavController()) {
@@ -62,7 +64,7 @@ internal class FetchSubjectFragment : Fragment(R.layout.fragment_subject_fetch) 
     private fun handleFetchState(state: FetchSubjectState) = when (state) {
         FetchSubjectState.FoundLocal,
         FetchSubjectState.FoundRemote,
-        -> finishWithResult(true)
+            -> finishWithResult(true)
 
         FetchSubjectState.NotFound -> openAlert(FetchSubjectAlerts.subjectNotFoundOnline().toArgs())
         FetchSubjectState.ConnectionError -> openAlert(FetchSubjectAlerts.subjectNotFoundOffline().toArgs())

--- a/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
@@ -42,6 +42,7 @@ import com.simprints.feature.login.tools.play.GooglePlayServicesAvailabilityChec
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.LOGIN
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.navigation.handleResult
 import com.simprints.infra.uibase.navigation.navigateSafely
@@ -77,6 +78,7 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("LoginFormFragment started", tag = ORCHESTRATION)
 
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {

--- a/feature/login/src/main/java/com/simprints/feature/login/screens/qrscanner/QrScannerFragment.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/qrscanner/QrScannerFragment.kt
@@ -17,6 +17,7 @@ import com.simprints.feature.login.databinding.FragmentQrScannerBinding
 import com.simprints.feature.login.tools.camera.CameraHelper
 import com.simprints.feature.login.tools.camera.QrCodeAnalyzer
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -50,6 +51,7 @@ internal class QrScannerFragment : Fragment(R.layout.fragment_qr_scanner) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {

--- a/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchFragment.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchFragment.kt
@@ -17,6 +17,7 @@ import com.simprints.core.tools.extentions.hasPermission
 import com.simprints.core.tools.extentions.permissionFromResult
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import com.simprints.matcher.R
@@ -51,6 +52,7 @@ internal class MatchFragment : Fragment(R.layout.fragment_matcher) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("MatchFragment started (isFace=${args.params.isFaceMatch()})", tag = ORCHESTRATION)
 
         observeViewModel()

--- a/feature/orchestrator/src/main/res/layout/activity_orchestrator.xml
+++ b/feature/orchestrator/src/main/res/layout/activity_orchestrator.xml
@@ -2,8 +2,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:layout_height="match_parent">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/orchestrationHost"

--- a/feature/select-subject-age-group/src/main/java/com/simprints/feature/selectagegroup/screen/SelectSubjectAgeGroupFragment.kt
+++ b/feature/select-subject-age-group/src/main/java/com/simprints/feature/selectagegroup/screen/SelectSubjectAgeGroupFragment.kt
@@ -17,6 +17,7 @@ import com.simprints.feature.selectagegroup.databinding.FragmentAgeGroupSelectio
 import com.simprints.infra.config.store.models.AgeGroup
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.navigation.handleResult
 import com.simprints.infra.uibase.navigation.navigateSafely
@@ -33,6 +34,7 @@ internal class SelectSubjectAgeGroupFragment : Fragment(R.layout.fragment_age_gr
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("SelectSubjectAgeGroupFragment started", tag = ORCHESTRATION)
 
         viewModel.ageGroups.observe(viewLifecycleOwner) { ageGroupsList ->

--- a/feature/select-subject/src/main/java/com/simprints/feature/selectsubject/screen/SelectSubjectFragment.kt
+++ b/feature/select-subject/src/main/java/com/simprints/feature/selectsubject/screen/SelectSubjectFragment.kt
@@ -10,6 +10,7 @@ import com.simprints.feature.selectsubject.R
 import com.simprints.feature.selectsubject.SelectSubjectResult
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.finishWithResult
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -23,6 +24,7 @@ internal class SelectSubjectFragment : Fragment(R.layout.fragment_select_subject
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("SelectSubjectFragment started", tag = ORCHESTRATION)
 
         viewModel.finish.observe(viewLifecycleOwner) {

--- a/feature/setup/src/main/java/com/simprints/feature/setup/screen/SetupFragment.kt
+++ b/feature/setup/src/main/java/com/simprints/feature/setup/screen/SetupFragment.kt
@@ -24,6 +24,7 @@ import com.simprints.infra.license.models.LicenseState.Started
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.LICENSE
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.navigation.handleResult
 import com.simprints.infra.uibase.navigation.navigateSafely
@@ -61,6 +62,7 @@ internal class SetupFragment : Fragment(R.layout.fragment_setup) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("SetupFragment started", tag = ORCHESTRATION)
 
         findNavController().handleResult<AlertResult>(

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/TroubleshootingFragment.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/TroubleshootingFragment.kt
@@ -8,6 +8,7 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.material.tabs.TabLayoutMediator
 import com.simprints.core.livedata.LiveDataEventWithContentObserver
 import com.simprints.feature.troubleshooting.databinding.FragmentTroubleshootingBinding
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -23,6 +24,7 @@ internal class TroubleshootingFragment : Fragment(R.layout.fragment_troubleshoot
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
 
         binding.troubleshootingToolbar.setNavigationOnClickListener {
             findNavController().popBackStack()

--- a/feature/validate-subject-pool/src/main/java/com/simprints/feature/validatepool/screen/ValidateSubjectPoolFragment.kt
+++ b/feature/validate-subject-pool/src/main/java/com/simprints/feature/validatepool/screen/ValidateSubjectPoolFragment.kt
@@ -14,6 +14,7 @@ import com.simprints.feature.validatepool.ValidateSubjectPoolResult
 import com.simprints.feature.validatepool.databinding.FragmentValidateSubjectPoolBinding
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -30,6 +31,7 @@ internal class ValidateSubjectPoolFragment : Fragment(R.layout.fragment_validate
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("ValidateSubjectPoolFragment started", tag = ORCHESTRATION)
 
         viewModel.state.observe(viewLifecycleOwner, LiveDataEventWithContentObserver(::renderState))

--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureFragment.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureFragment.kt
@@ -44,6 +44,7 @@ import com.simprints.infra.logging.LoggingConstants.CrashReportTag.FINGER_CAPTUR
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.uibase.extensions.showToast
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.navigation.handleResult
 import com.simprints.infra.uibase.navigation.navigateSafely
@@ -79,6 +80,7 @@ internal class FingerprintCaptureFragment : Fragment(R.layout.fragment_fingerpri
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         Simber.i("FingerprintCaptureFragment started", tag = ORCHESTRATION)
 
         findNavController().handleResult<AlertResult>(

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/connect/ConnectFragment.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/connect/ConnectFragment.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.activityViewModels
 import com.simprints.fingerprint.connect.R
 import com.simprints.fingerprint.connect.databinding.FragmentConnectBinding
 import com.simprints.fingerprint.connect.screens.ConnectScannerViewModel
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.viewbinding.viewBinding
 
 internal class ConnectFragment : Fragment(R.layout.fragment_connect) {
@@ -18,6 +19,7 @@ internal class ConnectFragment : Fragment(R.layout.fragment_connect) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
 
         viewModel.currentStep.observe(viewLifecycleOwner) { step ->
             binding.connectTitle.setText(step.messageRes)

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/bluetoothoff/BluetoothOffFragment.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/bluetoothoff/BluetoothOffFragment.kt
@@ -20,6 +20,7 @@ import com.simprints.fingerprint.connect.screens.ConnectScannerViewModel
 import com.simprints.fingerprint.connect.usecase.ReportAlertScreenEventUseCase
 import com.simprints.fingerprint.infra.scanner.component.bluetooth.ComponentBluetoothAdapter
 import com.simprints.infra.uibase.extensions.showToast
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -63,6 +64,7 @@ internal class BluetoothOffFragment : Fragment(R.layout.fragment_bluetooth_off) 
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         screenReporter.reportBluetoothNotEnabled()
 
         binding.turnOnBluetoothButton.setOnClickListener {

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/nfcoff/NfcOffFragment.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/nfcoff/NfcOffFragment.kt
@@ -12,6 +12,7 @@ import com.simprints.fingerprint.connect.R
 import com.simprints.fingerprint.connect.databinding.FragmentNfcOffBinding
 import com.simprints.fingerprint.connect.usecase.ReportAlertScreenEventUseCase
 import com.simprints.fingerprint.infra.scanner.NfcManager
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -43,6 +44,7 @@ internal class NfcOffFragment : Fragment(R.layout.fragment_nfc_off) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         screenReporter.reportNfcNotEnabled()
 
         if (!nfcManager.doesDeviceHaveNfcCapability()) {

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/nfcpair/NfcPairFragment.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/nfcpair/NfcPairFragment.kt
@@ -24,6 +24,7 @@ import com.simprints.fingerprint.infra.scanner.nfc.ComponentNfcTag
 import com.simprints.fingerprint.infra.scanner.tools.SerialNumberConverter
 import com.simprints.infra.recent.user.activity.RecentUserActivityManager
 import com.simprints.infra.uibase.extensions.showToast
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.system.Vibrate
 import com.simprints.infra.uibase.viewbinding.viewBinding
@@ -67,6 +68,7 @@ internal class NfcPairFragment : Fragment(R.layout.fragment_nfc_pair) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         screenReporter.reportNfcPairing()
 
         setupScannerPhoneTappingAnimation()

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/scanneroff/ScannerOffFragment.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/scanneroff/ScannerOffFragment.kt
@@ -12,6 +12,7 @@ import com.simprints.fingerprint.connect.R
 import com.simprints.fingerprint.connect.databinding.FragmentScannerOffBinding
 import com.simprints.fingerprint.connect.screens.ConnectScannerViewModel
 import com.simprints.fingerprint.connect.usecase.ReportAlertScreenEventUseCase
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -33,6 +34,7 @@ internal class ScannerOffFragment : Fragment(R.layout.fragment_scanner_off) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         screenReporter.reportScannerOff()
 
         binding.tryAgainButton.setOnClickListener {

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/serialentrypair/SerialEntryPairFragment.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/serialentrypair/SerialEntryPairFragment.kt
@@ -25,6 +25,7 @@ import com.simprints.fingerprint.infra.scanner.component.bluetooth.ComponentBlue
 import com.simprints.fingerprint.infra.scanner.tools.SerialNumberConverter
 import com.simprints.infra.recent.user.activity.RecentUserActivityManager
 import com.simprints.infra.uibase.extensions.showToast
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -63,6 +64,7 @@ internal class SerialEntryPairFragment : Fragment(R.layout.fragment_serial_entry
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
 
         screenReporter.reportSerialEntry()
 

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ota/OtaFragment.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ota/OtaFragment.kt
@@ -15,6 +15,7 @@ import com.simprints.fingerprint.connect.R
 import com.simprints.fingerprint.connect.databinding.FragmentOtaBinding
 import com.simprints.fingerprint.connect.screens.ConnectScannerViewModel
 import com.simprints.fingerprint.connect.usecase.ReportAlertScreenEventUseCase
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -39,6 +40,7 @@ internal class OtaFragment : Fragment(R.layout.fragment_ota) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         screenReporter.reportOta()
 
         listenForProgress()

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ota/failed/OtaFailedFragment.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ota/failed/OtaFailedFragment.kt
@@ -13,6 +13,7 @@ import com.simprints.fingerprint.connect.databinding.FragmentOtaFailedBinding
 import com.simprints.fingerprint.connect.screens.ConnectScannerViewModel
 import com.simprints.fingerprint.connect.screens.ota.FetchOtaResult
 import com.simprints.fingerprint.connect.usecase.ReportAlertScreenEventUseCase
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -42,6 +43,7 @@ internal class OtaFailedFragment : Fragment(R.layout.fragment_ota_failed) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         screenReporter.reportOtaFailed()
         connectScannerViewModel.setBackButtonToExitWithError()
 

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ota/recovery/OtaRecoveryFragment.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/ota/recovery/OtaRecoveryFragment.kt
@@ -12,6 +12,7 @@ import com.simprints.fingerprint.connect.databinding.FragmentOtaRecoveryBinding
 import com.simprints.fingerprint.connect.screens.ota.OtaFragmentParams
 import com.simprints.fingerprint.connect.usecase.ReportAlertScreenEventUseCase
 import com.simprints.fingerprint.infra.scanner.domain.ota.OtaRecoveryStrategy
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -36,6 +37,7 @@ internal class OtaRecoveryFragment : Fragment(R.layout.fragment_ota_recovery) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        applySystemBarInsets(view)
         screenReporter.reportOtaRecovery()
 
         setRecoveryStrategyInstructions()
@@ -55,7 +57,7 @@ internal class OtaRecoveryFragment : Fragment(R.layout.fragment_ota_recovery) {
                 OtaRecoveryStrategy.HARD_RESET -> IDR.string.fingerprint_connect_ota_recovery_hard_reset
                 OtaRecoveryStrategy.SOFT_RESET,
                 OtaRecoveryStrategy.SOFT_RESET_AFTER_DELAY,
-                -> IDR.string.fingerprint_connect_ota_recovery_soft_reset
+                    -> IDR.string.fingerprint_connect_ota_recovery_soft_reset
             },
         )
     }

--- a/infra/resources/src/main/res/values/theme.xml
+++ b/infra/resources/src/main/res/values/theme.xml
@@ -61,6 +61,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:listDivider"> @color/simprints_off_white</item>
+        <item name="android:fitsSystemWindows">false</item>
     </style>
 
     <!-- Theme variant with logo on a blue background, can be used for splash screen activities -->

--- a/infra/ui-base/src/main/java/com/simprints/infra/uibase/view/LayoutInsets.kt
+++ b/infra/ui-base/src/main/java/com/simprints/infra/uibase/view/LayoutInsets.kt
@@ -1,0 +1,51 @@
+package com.simprints.infra.uibase.view
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.children
+import androidx.core.view.updatePadding
+import com.google.android.material.appbar.AppBarLayout
+import java.util.LinkedList
+
+
+/**
+ * Automatically applies system bar inset paddings to the provided view.
+ *
+ * This function should be called on every fragment root view that is displayed to the user and has meaningful UI elements.
+ * Fragments that are only responsible for handling the internal navigation graph should not call this function to avoid double padding.
+ *
+ * Top padding is applied to either
+ *   - the first instance of [AppBarLayout] if present
+ *   - to the root view.
+ */
+fun applySystemBarInsets(view: View) {
+    ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+        val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+
+        val appBar = findAppBarLayout(LinkedList<View>().apply { add(v) })
+        if (appBar != null) {
+            appBar.updatePadding(top = bars.top)
+            v.updatePadding(bottom = bars.bottom)
+        } else {
+            v.updatePadding(top = bars.top, bottom = bars.bottom)
+        }
+        WindowInsetsCompat.CONSUMED
+    }
+}
+
+/**
+ * Recursively traverse the layout and find the first instance of AppBarLayout.
+ */
+private tailrec fun findAppBarLayout(views: LinkedList<View>): AppBarLayout? {
+    if (views.isEmpty()) return null
+    val currentView = views.removeFirst()
+    if (currentView is AppBarLayout) return currentView
+    if (currentView is ViewGroup) {
+        for (child in currentView.children) {
+            views.add(child)
+        }
+    }
+    return findAppBarLayout(views)
+}

--- a/infra/ui-base/src/main/java/com/simprints/infra/uibase/view/LayoutInsets.kt
+++ b/infra/ui-base/src/main/java/com/simprints/infra/uibase/view/LayoutInsets.kt
@@ -7,6 +7,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.children
 import androidx.core.view.updatePadding
 import com.google.android.material.appbar.AppBarLayout
+import com.simprints.infra.uibase.annotations.ExcludedFromGeneratedTestCoverageReports
 import java.util.LinkedList
 
 
@@ -20,6 +21,7 @@ import java.util.LinkedList
  *   - the first instance of [AppBarLayout] if present
  *   - to the root view.
  */
+@ExcludedFromGeneratedTestCoverageReports("UI code")
 fun applySystemBarInsets(view: View) {
     ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
         val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
@@ -38,6 +40,7 @@ fun applySystemBarInsets(view: View) {
 /**
  * Recursively traverse the layout and find the first instance of AppBarLayout.
  */
+@ExcludedFromGeneratedTestCoverageReports("UI code")
 private tailrec fun findAppBarLayout(views: LinkedList<View>): AppBarLayout? {
     if (views.isEmpty()) return null
     val currentView = views.removeFirst()


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-969)
Will be released in: **2025.2.0**

### Root cause analysis (for bugfixes only)

The first known affected version: **2025.1.0** and likely older ones.

* In Android 15 edge-to-edge is enabled by default. During the initial exploration, it all seemed to work as expected, something changed under the hood and on the Android 15 device the status bar padding is all over the place.
* Some screens had the white line under the status bar others had content under the status bar.
* Same random handling applied to the bottom bar.

### Notable changes

* Added a utility function that finds the system bar insets via compat library and applies inset values as top and bottom padding in the screen.
* Some screens have AppBarLayout, to avoid weird shadows at the top border of the bar, the top padding is applied to the AppBarLayout itself, effectively pushing it under the system bar.

### Testing guidance

* Compile and install the branch. 
* Start the dual modality enrollment flow, log in and capture fingerprints and the face.
* Bonus points to intentionally disable BT and unpair Vero to check as many of the connection flow screens as possible as well.
* Click through all screens in the dashboard.
* Start another flow and reject it to check exit form.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
