### PR TITLE
[MS-971] Bump sqlCipher-core from 4.5.4 to 4.7.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ okttp_version = "4.12.0"
 jackson_version = "2.13.4"
 chuck_version = "4.1.0"
 
-sqlCipher_version = "4.5.4"
+sqlCipher_version = "4.7.2"
 fuzzywuzzy_version = "1.4.0"
 rootbeer_version = "0.1.1"
 commons_io_version = "2.18.0"
@@ -151,7 +151,7 @@ firebase-analytics = { module = "com.google.firebase:firebase-analytics", versio
 firebase-perf = { module = "com.google.firebase:firebase-perf", version.ref = "firebase_perf_version" }
 
 #SqlCipher
-sqlCipher-core = { module = "net.zetetic:android-database-sqlcipher", version.ref = "sqlCipher_version" }
+sqlCipher-core = { module = "net.zetetic:sqlcipher-android", version.ref = "sqlCipher_version" }
 
 #Realm
 realm_base = { module = "io.realm.kotlin:library-base", version.ref = "realm_version" }

--- a/id/proguard-rules.pro
+++ b/id/proguard-rules.pro
@@ -55,8 +55,8 @@
     public <init>(java.lang.reflect.Type);
 }
 
-#net.zetetic:android-database-sqlcipher
--keep class net.sqlcipher.** { *; }
+#net.zetetic:android-sqlcipher
+-keep class net.zetetic.database.sqlcipher.** { *; }
 
 # Dont warn about the missing files during the obfuscation
 -dontwarn com.simprints.**

--- a/id/src/main/java/com/simprints/id/Application.kt
+++ b/id/src/main/java/com/simprints/id/Application.kt
@@ -8,6 +8,7 @@ import com.simprints.core.CoreApplication
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
 import com.simprints.core.tools.extentions.deviceHardwareId
 import com.simprints.core.tools.utils.LanguageHelper
+import com.simprints.infra.eventsync.BuildConfig.DB_ENCRYPTION
 import com.simprints.infra.logging.LoggingConstants.CrashReportingCustomKeys.DEVICE_ID
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.logging.SimberBuilder
@@ -61,6 +62,9 @@ open class Application :
         appScope.launch {
             syncOrchestrator.cleanupWorkers()
             syncOrchestrator.scheduleBackgroundWork()
+        }
+        if (DB_ENCRYPTION) {
+            System.loadLibrary("sqlcipher")
         }
     }
 }

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/EventRoomDatabase.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/EventRoomDatabase.kt
@@ -24,7 +24,7 @@ import com.simprints.infra.events.event.local.migrations.EventMigration8to9
 import com.simprints.infra.events.event.local.migrations.EventMigration9to10
 import com.simprints.infra.events.event.local.models.DbEvent
 import com.simprints.infra.events.event.local.models.DbEventScope
-import net.sqlcipher.database.SupportFactory
+import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 
 @Database(
     entities = [
@@ -44,7 +44,7 @@ internal abstract class EventRoomDatabase : RoomDatabase() {
     companion object {
         fun getDatabase(
             context: Context,
-            factory: SupportFactory,
+            factory: SupportOpenHelperFactory,
             dbName: String,
         ): EventRoomDatabase {
             val builder = Room
@@ -68,7 +68,6 @@ internal abstract class EventRoomDatabase : RoomDatabase() {
             if (BuildConfig.DB_ENCRYPTION) {
                 builder.openHelperFactory(factory)
             }
-
             return builder.build()
         }
     }

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration14to15.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration14to15.kt
@@ -8,7 +8,7 @@ import com.simprints.core.tools.extentions.getLongWithColumnName
 import com.simprints.core.tools.extentions.getStringWithColumnName
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MIGRATION
 import com.simprints.infra.logging.Simber
-import net.sqlcipher.database.SQLiteDatabase
+import net.zetetic.database.sqlcipher.SQLiteDatabase
 import org.json.JSONObject
 
 internal class EventMigration14to15 : Migration(14, 15) {


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-971)
Will be released in: **2025.2.0**

### Notable changes

* Bump sqlCipher-core from 4.5.4 to 4.7.2
* Updates Event Database to use new SQLCipher API.
### What The new version provides:
* Addresses known vulnerabilities and strengthens encryption mechanisms.
* Optimizes database operations for faster execution.
*  Ensures better integration with newer platforms and tools.

### Testing guidance
This upgrade is backward-compatible with existing databases. However, it's recommended to test thoroughly to ensure seamless integration.
 Verify that an event database encrypted with an older version of SQLCipher can be successfully opened using the latest version.
### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
