### PR TITLE
[MS-973] Fix sorting logic in MatchResultSet to handle equal confidence scores

### DIFF
--- a/feature/matcher/src/main/java/com/simprints/matcher/usecases/MatchResultSet.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/usecases/MatchResultSet.kt
@@ -8,10 +8,9 @@ internal class MatchResultSet<T : MatchResultItem>(
 ) {
     private var lowestConfidence: Float = 0f
 
-    private val treeSet = TreeSet { o1: T, o2: T ->
-        // Reverse order for descending sort
-        -1 * o1.confidence.compareTo(o2.confidence)
-    }
+    private val treeSet = TreeSet(
+        compareByDescending<T> { it.confidence }.thenByDescending { it.subjectId },
+    )
 
     fun add(element: T): MatchResultSet<T> {
         if (lowestConfidence > element.confidence) {

--- a/feature/matcher/src/test/java/com/simprints/matcher/usecases/MatchResultSetTest.kt
+++ b/feature/matcher/src/test/java/com/simprints/matcher/usecases/MatchResultSetTest.kt
@@ -46,4 +46,23 @@ class MatchResultSetTest {
             ),
         )
     }
+
+    // On equal confidence scores sort by id
+    @Test
+    fun `Stores results sorted descending by confidence and id`() {
+        val set = MatchResultSet<FingerprintMatchResult.Item>(3)
+
+        set.add(FingerprintMatchResult.Item("4", 0.4f))
+        set.add(FingerprintMatchResult.Item("1", 0.4f))
+        set.add(FingerprintMatchResult.Item("3", 0.3f))
+        set.add(FingerprintMatchResult.Item("2", 0.3f))
+
+        assertThat(set.toList()).isEqualTo(
+            listOf(
+                FingerprintMatchResult.Item("4", 0.4f),
+                FingerprintMatchResult.Item("1", 0.4f),
+                FingerprintMatchResult.Item("3", 0.3f),
+            ),
+        )
+    }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-973)
Will be released in: **2025.2.0**

### Root cause analysis (for bugfixes only)
When two subjects have the same confidence score during matching, only one is returned in the identification response. Please refer to the ticket for more details.


First known affected version: **All recent versions**

* Attached two videos one for the problem and the fix

### Notable changes

*  Improve sorting logic in MatchResultSet to handle equal confidence scores by subject ID

### Testing guidance

* Use the project cGKXBnPkLGKtK0V2TUxo, which contains many duplicate ROCv3 and simatcher subjects, and verify that subjects with the same confidence score are all included in the identification results.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)


https://github.com/user-attachments/assets/889549ed-dbeb-4386-b411-a9fde9dae7e6


https://github.com/user-attachments/assets/2dcc8454-676d-4d9c-af32-ac13e1a195ad




