### PR TITLE
[MS-580] Removing remaining NavController::navigate - from READMEs

### DIFF
--- a/feature/alert/README.md
+++ b/feature/alert/README.md
@@ -59,7 +59,8 @@ findNavController().handleResult<AlertResult>(
 ) { }
 
 // Navigate to screen
-findNavController(R.id.host_fragment).navigate(
+findNavController(R.id.host_fragment).navigateSafely(
+    this,
     R.id.action_global_errorFragment,
     alertConfiguration { /* configuration */ }.toArgs(),
 )

--- a/feature/exit-form/README.md
+++ b/feature/exit-form/README.md
@@ -54,7 +54,8 @@ findNavController().handleResult<ExitFormResult>(
 ) { }
 
 // Navigate to screen
-findNavController(R.id.host_fragment).navigate(
+findNavController(R.id.host_fragment).navigateSafely(
+    this,
     R.id.action_global_refusalFragment,
     exitFormConfiguration { /* configuration */ }.toArgs(),
 )


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-580)
Will be released in: **2025.2.0**

### Notable changes

* `NavController::navigate` is already replaced with `NavController::navigateSafely` extension, but examples in `README` files remained. Updated them.

### Additional work checklist

This is a small change in development-only docs.

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
