### PR TITLE
[MS-120] Skipping non-existent privacy notice download 404 logging

### DIFF
--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/ConfigRepositoryImpl.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/ConfigRepositoryImpl.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import retrofit2.HttpException
+import java.net.HttpURLConnection
 import javax.inject.Inject
 
 internal class ConfigRepositoryImpl @Inject constructor(
@@ -37,7 +38,6 @@ internal class ConfigRepositoryImpl @Inject constructor(
     companion object {
         @VisibleForTesting
         const val PRIVACY_NOTICE_FILE = "privacy_notice"
-        private const val NOT_FOUND_STATUS_CODE = 404
     }
 
     override suspend fun getProject(): Project = localDataSource.getProject()
@@ -127,7 +127,7 @@ internal class ConfigRepositoryImpl @Inject constructor(
             localDataSource.storePrivacyNotice(projectId, language, privacyNotice)
             flowCollector.emit(Succeed(language, privacyNotice))
         } catch (t: Throwable) {
-            if ((t.cause as? HttpException)?.code() != NOT_FOUND_STATUS_CODE) {
+            if ((t.cause as? HttpException)?.code() != HttpURLConnection.HTTP_NOT_FOUND) {
                 // Non-existence of resource isn't considered a download failure
                 Simber.i("Failed to download privacy notice", t)
             }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/ConfigRepositoryImplTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/ConfigRepositoryImplTest.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import java.net.HttpURLConnection
 
 class ConfigRepositoryImplTest {
     companion object {
@@ -276,7 +277,7 @@ class ConfigRepositoryImplTest {
 
     @Test
     fun `should log when failing to download privacy notice with non-404 response status code`() = runTest {
-        val code = 500
+        val code = HttpURLConnection.HTTP_INTERNAL_ERROR // 500
         val exception = Exception("Server error").apply {
             initCause(HttpException(Response.error<String>(code, "".toResponseBody(null))))
         }
@@ -295,7 +296,7 @@ class ConfigRepositoryImplTest {
 
     @Test
     fun `should not log when failing to download privacy notice with 404 response status code`() = runTest {
-        val code = 404
+        val code = HttpURLConnection.HTTP_NOT_FOUND
         val exception = Exception("Resource not found").apply {
             initCause(HttpException(Response.error<String>(code, "".toResponseBody(null))))
         }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-120)
Will be released in: **2025.2.0**

### Notable changes

Not user-facing, only affects logging:

When an API call for downloading a privacy notice occurs, and returns 404 (not found) - not logging this.