### PR TITLE
[MS-1007] Log an exception when subjectActions are null

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/usecases/GetEnrolmentCreationEventForSubjectUseCase.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/usecases/GetEnrolmentCreationEventForSubjectUseCase.kt
@@ -14,6 +14,7 @@ import com.simprints.infra.enrolment.records.repository.domain.models.Subject
 import com.simprints.infra.enrolment.records.repository.domain.models.SubjectQuery
 import com.simprints.infra.events.event.cosync.CoSyncEnrolmentRecordEvents
 import com.simprints.infra.events.event.domain.models.subject.EnrolmentRecordCreationEvent
+import com.simprints.infra.logging.Simber
 import javax.inject.Inject
 
 internal class GetEnrolmentCreationEventForSubjectUseCase @Inject constructor(
@@ -36,7 +37,11 @@ internal class GetEnrolmentCreationEventForSubjectUseCase @Inject constructor(
             .load(SubjectQuery(projectId = projectId, subjectId = subjectId))
             .firstOrNull()
             ?.fromSubjectToEnrolmentCreationEvent()
-            ?: return null
+
+        if (recordCreationEvent == null) {
+            Simber.e("Couldn't find enrolment for subjectActions", IllegalStateException("No enrolment record found for subjectId: $subjectId"))
+            return null
+        }
 
         return jsonHelper.toJson(CoSyncEnrolmentRecordEvents(listOf(recordCreationEvent)), coSyncSerializationModule)
     }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1007)
Will be released in: **2025.2.0**

### Notable changes

* Added a logged exception in case `subjectActions` are null when they shouldn't

### Testing guidance

* Describe how the reviewers can verify that issue is fixed

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
