### PR TITLE
MS-988 Skip ROC license check on Setup screen if only SimFace is enabled for face

### DIFF
--- a/feature/setup/src/main/java/com/simprints/feature/setup/screen/SetupViewModel.kt
+++ b/feature/setup/src/main/java/com/simprints/feature/setup/screen/SetupViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.simprints.core.DeviceID
 import com.simprints.feature.setup.LocationStore
 import com.simprints.infra.authstore.AuthStore
+import com.simprints.infra.config.store.models.FaceConfiguration
 import com.simprints.infra.config.store.models.FingerprintConfiguration
 import com.simprints.infra.config.store.models.GeneralConfiguration
 import com.simprints.infra.config.store.models.ProjectConfiguration
@@ -108,7 +109,7 @@ internal class SetupViewModel @Inject constructor(
 private val ProjectConfiguration.requiredLicenses: List<Pair<Vendor, LicenseVersion>>
     get() = general.modalities.mapNotNull {
         when {
-            it == GeneralConfiguration.Modality.FACE -> {
+            it == GeneralConfiguration.Modality.FACE && shouldIncludeRankOne() -> {
                 Vendor.RankOne to LicenseVersion(face?.rankOne?.version.orEmpty())
             }
 
@@ -121,3 +122,5 @@ private val ProjectConfiguration.requiredLicenses: List<Pair<Vendor, LicenseVers
     }
 
 private fun ProjectConfiguration.shouldIncludeNec() = fingerprint?.allowedSDKs?.contains(FingerprintConfiguration.BioSdk.NEC) == true
+
+private fun ProjectConfiguration.shouldIncludeRankOne() = face?.allowedSDKs?.contains(FaceConfiguration.BioSdk.RANK_ONE) == true

--- a/feature/setup/src/test/java/com/simprints/feature/setup/screen/SetupViewModelTest.kt
+++ b/feature/setup/src/test/java/com/simprints/feature/setup/screen/SetupViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.jraska.livedata.test
 import com.simprints.feature.setup.LocationStore
 import com.simprints.infra.authstore.AuthStore
+import com.simprints.infra.config.store.models.FaceConfiguration
 import com.simprints.infra.config.store.models.FingerprintConfiguration
 import com.simprints.infra.config.store.models.GeneralConfiguration
 import com.simprints.infra.config.sync.ConfigManager
@@ -153,7 +154,10 @@ class SetupViewModelTest {
                 every { allowedSDKs } returns listOf(FingerprintConfiguration.BioSdk.NEC)
                 every { nec?.version } returns "1"
             }
-            every { face?.rankOne?.version } returns "1"
+            every { face } returns mockk {
+                every { allowedSDKs } returns listOf(FaceConfiguration.BioSdk.RANK_ONE)
+                every { rankOne?.version } returns "1"
+            }
         }
         every {
             licenseRepository.getLicenseStates(any(), any(), any(), any())
@@ -180,7 +184,10 @@ class SetupViewModelTest {
                     every { allowedSDKs } returns listOf(FingerprintConfiguration.BioSdk.NEC)
                     every { nec?.version } returns null
                 }
-                every { face?.rankOne } returns null
+                every { face } returns mockk {
+                    every { allowedSDKs } returns listOf(FaceConfiguration.BioSdk.RANK_ONE)
+                    every { rankOne?.version } returns null
+                }
             }
         }
         every {
@@ -200,7 +207,16 @@ class SetupViewModelTest {
         // Given
         coEvery { configManager.getProjectConfiguration() } returns mockk {
             every { general } returns mockk {
-                every { modalities } returns emptyList()
+                every { modalities } returns listOf(
+                    GeneralConfiguration.Modality.FINGERPRINT,
+                    GeneralConfiguration.Modality.FACE,
+                )
+                every { fingerprint } returns mockk {
+                    every { allowedSDKs } returns listOf(FingerprintConfiguration.BioSdk.SECUGEN_SIM_MATCHER)
+                }
+                every { face } returns mockk {
+                    every { allowedSDKs } returns listOf(FaceConfiguration.BioSdk.SIM_FACE)
+                }
             }
         }
 
@@ -225,7 +241,10 @@ class SetupViewModelTest {
                 every { allowedSDKs } returns listOf(FingerprintConfiguration.BioSdk.NEC)
                 every { nec?.version } returns ""
             }
-            every { face?.rankOne?.version } returns ""
+            every { face } returns mockk {
+                every { allowedSDKs } returns listOf(FaceConfiguration.BioSdk.RANK_ONE)
+                every { rankOne?.version } returns ""
+            }
         }
         coJustRun { saveLicenseCheckEvent(Vendor.RankOne, LicenseStatus.MISSING) }
         every {


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-988)
Will be released in: **version**

### Notable changes

* Only check for RankOne licence on Setup screen when it is actually configured.
* Missed a spot in the initial integration PR (wasn't able to check it before vulcan changes 🤦🏻 ) 

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
