### PR TITLE
Do not add RankOne config is SimFace is present during configuration migration

### DIFF
--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceBioSdkMigration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceBioSdkMigration.kt
@@ -16,7 +16,7 @@ class ProjectConfigFaceBioSdkMigration @Inject constructor() : DataMigration<Pro
     }
 
     override suspend fun shouldMigrate(currentData: ProtoProjectConfiguration) = with(currentData) {
-        hasFace() && (!face.hasRankOne() || face.allowedSdksCount == 0)
+        hasFace() && (!(face.hasRankOne() || face.hasSimFace()) || face.allowedSdksCount == 0)
     }
 
     override suspend fun migrate(currentData: ProtoProjectConfiguration): ProtoProjectConfiguration {

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceBioSdkMigrationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/local/migrations/ProjectConfigFaceBioSdkMigrationTest.kt
@@ -76,6 +76,23 @@ class ProjectConfigFaceBioSdkMigrationTest {
     }
 
     @Test
+    fun `should not migrate if face has simface config and allowedSdks is not empty`() = runTest {
+        val currentData = ProtoProjectConfiguration
+            .newBuilder()
+            .setFace(
+                ProtoFaceConfiguration
+                    .newBuilder()
+                    .setSimFace(
+                        ProtoFaceConfiguration.ProtoFaceSdkConfiguration.newBuilder().build(),
+                    ).addAllowedSdks(ProtoFaceConfiguration.ProtoBioSdk.SIM_FACE)
+                    .build(),
+            ).build()
+        val shouldMigrate = ProjectConfigFaceBioSdkMigration().shouldMigrate(currentData)
+
+        assertThat(shouldMigrate).isFalse()
+    }
+
+    @Test
     fun `should create rankone with value of the old face configuration`() = runTest {
         val imageSavingStrategy = ProtoFaceConfiguration.ImageSavingStrategy.NEVER
         val nbOfImagesToCapture = 2


### PR DESCRIPTION
### Root cause analysis (for bugfixes only)

First known affected version: **2025.2.0**

* Face configuration migration adds an unnecessary RankOne config since the RankOne is not present in SimFace-only projects

### Notable changes

* Added an additional check in the migration to avoid adding RankOne config when not necessary. 

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
