### PR TITLE
[MS-1015] Remove JSON annotations for ApiEventPayload (and their accompanying keys) as they are unused in practice

### DIFF
--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiEventPayload.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiEventPayload.kt
@@ -1,8 +1,6 @@
 package com.simprints.infra.eventsync.event.remote.models
 
 import androidx.annotation.Keep
-import com.fasterxml.jackson.annotation.JsonSubTypes
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.simprints.infra.config.store.models.TokenKeyType
 import com.simprints.infra.events.event.domain.models.AgeGroupSelectionEvent
 import com.simprints.infra.events.event.domain.models.AlertScreenEvent.AlertScreenPayload
@@ -91,7 +89,6 @@ import com.simprints.infra.events.event.domain.models.face.FaceOnboardingComplet
 import com.simprints.infra.events.event.domain.models.fingerprint.FingerprintCaptureBiometricsEvent.FingerprintCaptureBiometricsPayload
 import com.simprints.infra.events.event.domain.models.fingerprint.FingerprintCaptureEvent
 import com.simprints.infra.events.event.domain.models.upsync.EventUpSyncRequestEvent
-import com.simprints.infra.eventsync.event.remote.models.ApiEventPayloadType.Companion
 import com.simprints.infra.eventsync.event.remote.models.callback.ApiCallbackPayload
 import com.simprints.infra.eventsync.event.remote.models.callout.ApiCalloutPayload
 import com.simprints.infra.eventsync.event.remote.models.downsync.ApiEventDownSyncRequestPayload
@@ -102,40 +99,6 @@ import com.simprints.infra.eventsync.event.remote.models.face.ApiFaceFallbackCap
 import com.simprints.infra.eventsync.event.remote.models.face.ApiFaceOnboardingCompletePayload
 import com.simprints.infra.eventsync.event.remote.models.upsync.ApiEventUpSyncRequestPayload
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
-@JsonSubTypes(
-    JsonSubTypes.Type(value = ApiFaceCaptureConfirmationPayload::class, name = Companion.FACE_CAPTURE_CONFIRMATION_KEY),
-    JsonSubTypes.Type(value = ApiFaceCapturePayload::class, name = Companion.FACE_CAPTURE_KEY),
-    JsonSubTypes.Type(value = ApiFaceCaptureBiometricsPayload::class, name = Companion.FACE_CAPTURE_BIOMETRICS_KEY),
-    JsonSubTypes.Type(value = ApiFaceFallbackCapturePayload::class, name = Companion.FACE_FALLBACK_CAPTURE_KEY),
-    JsonSubTypes.Type(value = ApiFaceOnboardingCompletePayload::class, name = Companion.FACE_ONBOARDING_COMPLETE_KEY),
-    JsonSubTypes.Type(value = ApiAlertScreenPayload::class, name = Companion.ALERT_SCREEN_KEY),
-    JsonSubTypes.Type(value = ApiAuthenticationPayload::class, name = Companion.AUTHENTICATION_KEY),
-    JsonSubTypes.Type(value = ApiAuthorizationPayload::class, name = Companion.AUTHORIZATION_KEY),
-    JsonSubTypes.Type(value = ApiCandidateReadPayload::class, name = Companion.CANDIDATE_READ_KEY),
-    JsonSubTypes.Type(value = ApiCompletionCheckPayload::class, name = Companion.COMPLETION_CHECK_KEY),
-    JsonSubTypes.Type(value = ApiConnectivitySnapshotPayload::class, name = Companion.CONNECTIVITY_SNAPSHOT_KEY),
-    JsonSubTypes.Type(value = ApiConsentPayload::class, name = Companion.CONSENT_KEY),
-    JsonSubTypes.Type(value = ApiEnrolmentPayloadV4::class, name = Companion.ENROLMENT_KEY),
-    JsonSubTypes.Type(value = ApiFingerprintCapturePayload::class, name = Companion.FINGERPRINT_CAPTURE_KEY),
-    JsonSubTypes.Type(value = ApiFingerprintCaptureBiometricsPayload::class, name = Companion.FINGERPRINT_CAPTURE_BIOMETRICS_KEY),
-    JsonSubTypes.Type(value = ApiGuidSelectionPayload::class, name = Companion.GUID_SELECTION_KEY),
-    JsonSubTypes.Type(value = ApiIntentParsingPayload::class, name = Companion.INTENT_PARSING_KEY),
-    JsonSubTypes.Type(value = ApiInvalidIntentPayload::class, name = Companion.INVALID_INTENT_KEY),
-    JsonSubTypes.Type(value = ApiOneToManyMatchPayload::class, name = Companion.ONE_TO_MANY_MATCH_KEY),
-    JsonSubTypes.Type(value = ApiOneToOneMatchPayload::class, name = Companion.ONE_TO_ONE_MATCH_KEY),
-    JsonSubTypes.Type(value = ApiPersonCreationPayload::class, name = Companion.PERSON_CREATION_KEY),
-    JsonSubTypes.Type(value = ApiRefusalPayload::class, name = Companion.REFUSAL_KEY),
-    JsonSubTypes.Type(value = ApiScannerConnectionPayload::class, name = Companion.SCANNER_CONNECTION_KEY),
-    JsonSubTypes.Type(value = ApiScannerFirmwareUpdatePayload::class, name = Companion.SCANNER_FIRMWARE_UPDATE_KEY),
-    JsonSubTypes.Type(value = ApiSuspiciousIntentPayload::class, name = Companion.SUSPICIOUS_INTENT_KEY),
-    JsonSubTypes.Type(value = ApiVero2InfoSnapshotPayload::class, name = Companion.VERO_2_INFO_SNAPSHOT_KEY),
-    JsonSubTypes.Type(value = ApiCallbackPayload::class, name = Companion.CALLOUT_KEY),
-    JsonSubTypes.Type(value = ApiCalloutPayload::class, name = Companion.CALLBACK_KEY),
-    JsonSubTypes.Type(value = ApiEventDownSyncRequestPayload::class, name = Companion.EVENT_DOWN_SYNC_REQUEST_KEY),
-    JsonSubTypes.Type(value = ApiEventUpSyncRequestPayload::class, name = Companion.EVENT_UP_SYNC_REQUEST_KEY),
-    JsonSubTypes.Type(value = ApiBiometricReferenceCreationPayload::class, name = Companion.BIOMETRIC_REFERENCE_CREATION_KEY),
-)
 @Keep
 internal abstract class ApiEventPayload(
     open val startTime: ApiTimestamp,

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiEventPayloadType.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiEventPayloadType.kt
@@ -48,144 +48,40 @@ import com.simprints.infra.events.event.domain.models.EventType.VERO_2_INFO_SNAP
 
 @Keep
 internal enum class ApiEventPayloadType {
-    // a constant key is required to serialise/deserialize
-    // ApiEventPayload correctly with Jackson (see annotation in ApiEventPayload).
-    // Add a key in the companion object for each enum value
-
-    // key added: CALLOUT_KEY
     Callout,
-
-    // key added: CALLBACK_KEY
     Callback,
-
-    // key added: AUTHENTICATION_KEY
     Authentication,
-
-    // key added: CONSENT_KEY
     Consent,
-
-    // key added: ENROLMENT_KEY
     Enrolment,
-
-    // key added: AUTHORIZATION_KEY
     Authorization,
-
-    // key added: FINGERPRINT_CAPTURE_KEY
     FingerprintCapture,
-
-    // key added: FINGERPRINT_CAPTURE_BIOMETRICS_KEY
     FingerprintCaptureBiometrics,
-
-    // key added: ONE_TO_ONE_MATCH_KEY
     OneToOneMatch,
-
-    // key added: ONE_TO_MANY_MATCH_KEY
     OneToManyMatch,
-
-    // key added: PERSON_CREATION_KEY
     PersonCreation,
-
-    // key added: ALERT_SCREEN_KEY
     AlertScreen,
-
-    // key added: GUID_SELECTION_KEY
     GuidSelection,
-
-    // key added: CONNECTIVITY_SNAPSHOT_KEY
     ConnectivitySnapshot,
-
-    // key added: REFUSAL_KEY
     Refusal,
-
-    // key added: CANDIDATE_READ_KEY
     CandidateRead,
-
-    // key added: SCANNER_CONNECTION_KEY
     ScannerConnection,
-
-    // key added: VERO_2_INFO_SNAPSHOT_KEY
     Vero2InfoSnapshot,
-
-    // key added: SCANNER_FIRMWARE_UPDATE_KEY
     ScannerFirmwareUpdate,
-
-    // key added: INVALID_INTENT_KEY
     InvalidIntent,
-
-    // key added: SUSPICIOUS_INTENT_KEY
     SuspiciousIntent,
-
-    // key added: INTENT_PARSING_KEY
     IntentParsing,
-
-    // key added: COMPLETION_CHECK_KEY
     CompletionCheck,
-
-    // key added: FACE_ONBOARDING_COMPLETE_KEY
     FaceOnboardingComplete,
-
-    // key added: FACE_FALLBACK_CAPTURE_KEY
     FaceFallbackCapture,
-
-    // key added: FACE_CAPTURE_KEY
     FaceCapture,
-
-    // key added: FACE_CAPTURE_BIOMETRICS_KEY
     FaceCaptureBiometrics,
-
-    // key added: FACE_CAPTURE_CONFIRMATION_KEY
     FaceCaptureConfirmation,
-
-    // key added: EVENT_DOWN_SYNC_REQUEST_KEY
     EventDownSyncRequest,
-
-    // key added: EVENT_UP_SYNC_REQUEST_KEY
     EventUpSyncRequest,
-
-    // key added: LICENSE_CHECK_KEY
     LicenseCheck,
-
-    // key added: AGE_GROUP_SELECTION_KEY
     AgeGroupSelection,
-
-    // key added: BIOMETRIC_REFERENCE_CREATION_KEY
     BiometricReferenceCreation,
-
     ;
-
-    companion object {
-        const val CALLOUT_KEY = "Callout"
-        const val CALLBACK_KEY = "Callback"
-        const val AUTHENTICATION_KEY = "Authentication"
-        const val CONSENT_KEY = "Consent"
-        const val ENROLMENT_KEY = "Enrolment"
-        const val AUTHORIZATION_KEY = "Authorization"
-        const val FINGERPRINT_CAPTURE_KEY = "FingerprintCapture"
-        const val ONE_TO_ONE_MATCH_KEY = "OneToOneMatch"
-        const val ONE_TO_MANY_MATCH_KEY = "OneToManyMatch"
-        const val PERSON_CREATION_KEY = "PersonCreation"
-        const val ALERT_SCREEN_KEY = "AlertScreen"
-        const val GUID_SELECTION_KEY = "GuidSelection"
-        const val CONNECTIVITY_SNAPSHOT_KEY = "ConnectivitySnapshot"
-        const val REFUSAL_KEY = "Refusal"
-        const val CANDIDATE_READ_KEY = "CandidateRead"
-        const val SCANNER_CONNECTION_KEY = "ScannerConnection"
-        const val VERO_2_INFO_SNAPSHOT_KEY = "Vero2InfoSnapshot"
-        const val SCANNER_FIRMWARE_UPDATE_KEY = "ScannerFirmwareUpdate"
-        const val INVALID_INTENT_KEY = "InvalidIntent"
-        const val SUSPICIOUS_INTENT_KEY = "SuspiciousIntent"
-        const val INTENT_PARSING_KEY = "IntentParsing"
-        const val COMPLETION_CHECK_KEY = "CompletionCheck"
-        const val FACE_ONBOARDING_COMPLETE_KEY = "FaceOnboardingComplete"
-        const val FACE_FALLBACK_CAPTURE_KEY = "FaceFallbackCapture"
-        const val FACE_CAPTURE_KEY = "FaceCapture"
-        const val FACE_CAPTURE_CONFIRMATION_KEY = "FaceCaptureConfirmation"
-        const val FACE_CAPTURE_BIOMETRICS_KEY = "FaceCaptureBiometrics"
-        const val FINGERPRINT_CAPTURE_BIOMETRICS_KEY = "FingerprintCaptureBiometrics"
-        const val EVENT_DOWN_SYNC_REQUEST_KEY = "EventDownSyncRequest"
-        const val EVENT_UP_SYNC_REQUEST_KEY = "EventUpSyncRequest"
-        const val BIOMETRIC_REFERENCE_CREATION_KEY = "BiometricReferenceCreation"
-    }
 }
 
 internal fun EventType.fromDomainToApi(): ApiEventPayloadType = when (this) {


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1015)
Will be released in: **2025.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **long long ago**

Please find more info in the ticket and linked Slack thread

### Notable changes

Removes the JSON annotations for ApiEventPayload as they don't have any effect on the resulting JSON. Keys used for subtypes are deleted, too, as they become unused, too.

### Testing guidance

Create some sessions with various events and check that they are accepted by BFSID. If feeling bored - create a Retrofit interceptor and check the produced JSON does not differ from before the change.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
