### PR TITLE
MS-997 Reset local records when sync partitioning changes

### DIFF
--- a/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/ResetLocalRecordsIfConfigChangedUseCase.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/ResetLocalRecordsIfConfigChangedUseCase.kt
@@ -1,0 +1,30 @@
+package com.simprints.infra.sync.config.usecase
+
+import com.simprints.infra.config.store.models.ProjectConfiguration
+import com.simprints.infra.enrolment.records.repository.EnrolmentRecordRepository
+import com.simprints.infra.eventsync.EventSyncManager
+import com.simprints.infra.sync.SyncOrchestrator
+import javax.inject.Inject
+
+internal class ResetLocalRecordsIfConfigChangedUseCase @Inject constructor(
+    private val syncOrchestrator: SyncOrchestrator,
+    private val eventSyncManager: EventSyncManager,
+    private val enrolmentRecordRepository: EnrolmentRecordRepository,
+) {
+    suspend operator fun invoke(
+        oldConfig: ProjectConfiguration,
+        newConfig: ProjectConfiguration,
+    ) {
+        if (hasPartitionTypeChanged(oldConfig, newConfig)) {
+            syncOrchestrator.cancelEventSync()
+            eventSyncManager.resetDownSyncInfo()
+            enrolmentRecordRepository.deleteAll()
+            syncOrchestrator.rescheduleEventSync()
+        }
+    }
+
+    private fun hasPartitionTypeChanged(
+        oldConfig: ProjectConfiguration,
+        newConfig: ProjectConfiguration,
+    ) = oldConfig.synchronization.down.partitionType != newConfig.synchronization.down.partitionType
+}

--- a/infra/sync/src/main/java/com/simprints/infra/sync/config/worker/ProjectConfigDownSyncWorker.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/config/worker/ProjectConfigDownSyncWorker.kt
@@ -9,6 +9,7 @@ import com.simprints.infra.authstore.AuthStore
 import com.simprints.infra.config.sync.ConfigManager
 import com.simprints.infra.sync.config.usecase.HandleProjectStateUseCase
 import com.simprints.infra.sync.config.usecase.RescheduleWorkersIfConfigChangedUseCase
+import com.simprints.infra.sync.config.usecase.ResetLocalRecordsIfConfigChangedUseCase
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineDispatcher
@@ -22,6 +23,7 @@ internal class ProjectConfigDownSyncWorker @AssistedInject constructor(
     private val configManager: ConfigManager,
     private val handleProjectState: HandleProjectStateUseCase,
     private val rescheduleWorkersIfConfigChanged: RescheduleWorkersIfConfigChangedUseCase,
+    private val resetLocalRecordsIfConfigChanged: ResetLocalRecordsIfConfigChangedUseCase,
     @DispatcherBG private val dispatcher: CoroutineDispatcher,
 ) : SimCoroutineWorker(context, params) {
     override val tag = "ProjectConfigDownSync"
@@ -40,7 +42,7 @@ internal class ProjectConfigDownSyncWorker @AssistedInject constructor(
                 val (project, config) = configManager.refreshProject(projectId)
                 handleProjectState(project.state)
                 rescheduleWorkersIfConfigChanged(oldConfig, config)
-
+                resetLocalRecordsIfConfigChanged(oldConfig, config)
                 success()
             }
         } catch (t: Throwable) {

--- a/infra/sync/src/test/java/com/simprints/infra/sync/config/usecase/ResetLocalRecordsIfConfigChangedUseCaseTest.kt
+++ b/infra/sync/src/test/java/com/simprints/infra/sync/config/usecase/ResetLocalRecordsIfConfigChangedUseCaseTest.kt
@@ -1,0 +1,91 @@
+package com.simprints.infra.sync.config.usecase
+
+import com.simprints.infra.config.store.models.DownSynchronizationConfiguration
+import com.simprints.infra.enrolment.records.repository.EnrolmentRecordRepository
+import com.simprints.infra.eventsync.EventSyncManager
+import com.simprints.infra.sync.SyncOrchestrator
+import com.simprints.infra.sync.config.testtools.projectConfiguration
+import com.simprints.infra.sync.config.testtools.synchronizationConfiguration
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class ResetLocalRecordsIfConfigChangedUseCaseTest {
+    @MockK
+    private lateinit var syncOrchestrator: SyncOrchestrator
+
+    @MockK
+    private lateinit var eventSyncManager: EventSyncManager
+
+    @MockK
+    private lateinit var enrolmentRecordRepository: EnrolmentRecordRepository
+
+    private lateinit var useCase: ResetLocalRecordsIfConfigChangedUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        useCase = ResetLocalRecordsIfConfigChangedUseCase(
+            syncOrchestrator = syncOrchestrator,
+            eventSyncManager = eventSyncManager,
+            enrolmentRecordRepository = enrolmentRecordRepository,
+        )
+    }
+
+    @Test
+    fun `should not reset local records when partition type not changes`() = runTest {
+        useCase(
+            projectConfiguration.copy(
+                synchronization = synchronizationConfiguration.copy(
+                    down = synchronizationConfiguration.down.copy(
+                        partitionType = DownSynchronizationConfiguration.PartitionType.MODULE,
+                    ),
+                ),
+            ),
+            projectConfiguration.copy(
+                synchronization = synchronizationConfiguration.copy(
+                    down = synchronizationConfiguration.down.copy(
+                        partitionType = DownSynchronizationConfiguration.PartitionType.MODULE,
+                    ),
+                ),
+            ),
+        )
+
+        coVerify(exactly = 0) {
+            syncOrchestrator.cancelEventSync()
+            syncOrchestrator.rescheduleEventSync()
+            eventSyncManager.resetDownSyncInfo()
+            enrolmentRecordRepository.deleteAll()
+        }
+    }
+
+    @Test
+    fun `should reset local records when partition type not changes`() = runTest {
+        useCase(
+            projectConfiguration.copy(
+                synchronization = synchronizationConfiguration.copy(
+                    down = synchronizationConfiguration.down.copy(
+                        partitionType = DownSynchronizationConfiguration.PartitionType.PROJECT,
+                    ),
+                ),
+            ),
+            projectConfiguration.copy(
+                synchronization = synchronizationConfiguration.copy(
+                    down = synchronizationConfiguration.down.copy(
+                        partitionType = DownSynchronizationConfiguration.PartitionType.MODULE,
+                    ),
+                ),
+            ),
+        )
+
+        coVerify {
+            syncOrchestrator.cancelEventSync()
+            syncOrchestrator.rescheduleEventSync()
+            eventSyncManager.resetDownSyncInfo()
+            enrolmentRecordRepository.deleteAll()
+        }
+    }
+}

--- a/infra/sync/src/test/java/com/simprints/infra/sync/config/worker/ProjectConfigDownSyncWorkerTest.kt
+++ b/infra/sync/src/test/java/com/simprints/infra/sync/config/worker/ProjectConfigDownSyncWorkerTest.kt
@@ -9,6 +9,7 @@ import com.simprints.infra.sync.config.testtools.project
 import com.simprints.infra.sync.config.testtools.projectConfiguration
 import com.simprints.infra.sync.config.usecase.HandleProjectStateUseCase
 import com.simprints.infra.sync.config.usecase.RescheduleWorkersIfConfigChangedUseCase
+import com.simprints.infra.sync.config.usecase.ResetLocalRecordsIfConfigChangedUseCase
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -37,6 +38,9 @@ class ProjectConfigDownSyncWorkerTest {
     @MockK
     private lateinit var rescheduleWorkersIfConfigChangedUseCase: RescheduleWorkersIfConfigChangedUseCase
 
+    @MockK
+    private lateinit var resetLocalRecordsIfConfigChangedUseCase: ResetLocalRecordsIfConfigChangedUseCase
+
     private lateinit var projectConfigDownSyncWorker: ProjectConfigDownSyncWorker
 
     @Before
@@ -50,6 +54,7 @@ class ProjectConfigDownSyncWorkerTest {
             configManager = configManager,
             handleProjectState = handleProjectStateUseCase,
             rescheduleWorkersIfConfigChanged = rescheduleWorkersIfConfigChangedUseCase,
+            resetLocalRecordsIfConfigChanged = resetLocalRecordsIfConfigChangedUseCase,
             dispatcher = testCoroutineRule.testCoroutineDispatcher,
         )
     }
@@ -85,6 +90,7 @@ class ProjectConfigDownSyncWorkerTest {
         coVerify {
             handleProjectStateUseCase.invoke(any())
             rescheduleWorkersIfConfigChangedUseCase.invoke(any(), any())
+            resetLocalRecordsIfConfigChangedUseCase.invoke(any(), any())
         }
     }
 


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-997)
Will be released in: **version**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.1.0**

* When sync partitioning changes in the project configuration, already downloaded records remain in the local database, causing a mismatch in numbers.
* Additional local records might also affect the matching speed and results by returning records that shouldn't have been synced (if the ID pool type does not match sync partitioning).

### Notable changes

* On the project configuration sync, if the change in sync partitioning has been detected, all local records are wiped, and a new sync is scheduled.
* Change of sync partitioning is an extraordinary circumstance, and some disruption should be expected. Creating more complex diff handling is possible, but the ROI would not be justify it.

### Testing guidance

* Create/configure a project with project sync scope and some records.
* Log into SID and sync the records.
* Change sync scope to modules and re-add known module names in Vulcan.
* Open the SID dashboard settings and sync configuration.
* Go to Sync Info and select some modules to down sync.
* Check that the number of records in synced modules matches "Total on device".

[Testiny case](https://app.testiny.io/SID/testcases/tcf/41/tc/258/edit)

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
