### PR TITLE
MS-122 Secure prefs everywhere

### DIFF
--- a/infra/core/src/main/java/com/simprints/core/tools/utils/LanguageHelper.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/utils/LanguageHelper.kt
@@ -3,6 +3,7 @@ package com.simprints.core.tools.utils
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Configuration
+import androidx.core.content.edit
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
 import java.util.Locale
 
@@ -15,11 +16,9 @@ object LanguageHelper {
 
     lateinit var prefs: SharedPreferences
     var language: String
-        get() {
-            return prefs.getString(SHARED_PREFS_LANGUAGE_KEY, SHARED_PREFS_LANGUAGE_DEFAULT)!!
-        }
+        get() = prefs.getString(SHARED_PREFS_LANGUAGE_KEY, SHARED_PREFS_LANGUAGE_DEFAULT)!!
         set(value) {
-            prefs.edit().putString(SHARED_PREFS_LANGUAGE_KEY, value).apply()
+            prefs.edit { putString(SHARED_PREFS_LANGUAGE_KEY, value) }
         }
 
     fun init(ctx: Context) {

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/EnrolmentRecordRepositoryImpl.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/EnrolmentRecordRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.simprints.infra.enrolment.records.repository
 
-import android.content.Context
 import androidx.core.content.edit
 import com.simprints.core.DispatcherIO
 import com.simprints.core.domain.tokenization.TokenizableString
@@ -16,14 +15,13 @@ import com.simprints.infra.enrolment.records.repository.local.SelectEnrolmentRec
 import com.simprints.infra.enrolment.records.repository.local.migration.InsertRecordsInRoomDuringMigrationUseCase
 import com.simprints.infra.enrolment.records.repository.remote.EnrolmentRecordRemoteDataSource
 import com.simprints.infra.logging.Simber
-import dagger.hilt.android.qualifiers.ApplicationContext
+import com.simprints.infra.security.SecurityManager
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 internal class EnrolmentRecordRepositoryImpl @Inject constructor(
-    @ApplicationContext context: Context,
     private val remoteDataSource: EnrolmentRecordRemoteDataSource,
     @CommCareDataSource private val commCareDataSource: IdentityDataSource,
     private val tokenizationProcessor: TokenizationProcessor,
@@ -31,8 +29,9 @@ internal class EnrolmentRecordRepositoryImpl @Inject constructor(
     @DispatcherIO private val dispatcher: CoroutineDispatcher,
     @EnrolmentBatchSize private val batchSize: Int,
     private val insertRecordsInRoomDuringMigration: InsertRecordsInRoomDuringMigrationUseCase,
+    securityManager: SecurityManager,
 ) : EnrolmentRecordRepository {
-    private val prefs = context.getSharedPreferences(PREF_FILE_NAME, Context.MODE_PRIVATE)
+    private val prefs = securityManager.buildEncryptedSharedPreferences(PREF_FILE_NAME)
 
     companion object {
         private const val PREF_FILE_NAME = "UPLOAD_ENROLMENT_RECORDS_PROGRESS"

--- a/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/EnrolmentRecordRepositoryImplTest.kt
+++ b/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/EnrolmentRecordRepositoryImplTest.kt
@@ -1,6 +1,5 @@
 package com.simprints.infra.enrolment.records.repository
 
-import android.content.Context
 import android.content.SharedPreferences
 import com.simprints.core.domain.tokenization.asTokenizableEncrypted
 import com.simprints.core.domain.tokenization.asTokenizableRaw
@@ -17,6 +16,7 @@ import com.simprints.infra.enrolment.records.repository.local.EnrolmentRecordLoc
 import com.simprints.infra.enrolment.records.repository.local.SelectEnrolmentRecordLocalDataSourceUseCase
 import com.simprints.infra.enrolment.records.repository.local.migration.InsertRecordsInRoomDuringMigrationUseCase
 import com.simprints.infra.enrolment.records.repository.remote.EnrolmentRecordRemoteDataSource
+import com.simprints.infra.security.SecurityManager
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
@@ -64,8 +64,8 @@ class EnrolmentRecordRepositoryImplTest {
     private val prefs = mockk<SharedPreferences> {
         every { edit() } returns prefsEditor
     }
-    private val ctx = mockk<Context> {
-        every { getSharedPreferences(any(), any()) } returns prefs
+    private val securityManager = mockk<SecurityManager> {
+        every { buildEncryptedSharedPreferences(any()) } returns prefs
     }
     private lateinit var repository: EnrolmentRecordRepositoryImpl
     private val project = mockk<Project>()
@@ -78,7 +78,6 @@ class EnrolmentRecordRepositoryImplTest {
         every { prefsEditor.remove(any()) } returns prefsEditor
         coEvery { selectEnrolmentRecordLocalDataSource() } returns localDataSource
         repository = EnrolmentRecordRepositoryImpl(
-            context = ctx,
             remoteDataSource = remoteDataSource,
             selectEnrolmentRecordLocalDataSource = selectEnrolmentRecordLocalDataSource,
             commCareDataSource = commCareDataSource,
@@ -86,6 +85,7 @@ class EnrolmentRecordRepositoryImplTest {
             dispatcher = UnconfinedTestDispatcher(),
             batchSize = BATCH_SIZE,
             insertRecordsInRoomDuringMigration = insertRecordsDuringMigration,
+            securityManager = securityManager,
         )
     }
 

--- a/infra/network/build.gradle.kts
+++ b/infra/network/build.gradle.kts
@@ -19,6 +19,7 @@ android {
 dependencies {
     implementation(project(":infra:logging"))
     implementation(project(":infra:logging-persistent"))
+    implementation(project(":infra:security"))
 
     debugImplementation(libs.chuck.debug) {
         exclude("androidx.lifecycle", "lifecycle-viewmodel-ktx")
@@ -47,7 +48,6 @@ dependencies {
 
     testImplementation(libs.testing.mockwebserver)
     testImplementation(libs.chuck.release)
-
 }
 
 configurations {

--- a/infra/network/src/main/java/com/simprints/infra/network/url/BaseUrlProviderImpl.kt
+++ b/infra/network/src/main/java/com/simprints/infra/network/url/BaseUrlProviderImpl.kt
@@ -6,17 +6,19 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.network.BuildConfig
+import com.simprints.infra.security.SecurityManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 internal class BaseUrlProviderImpl @Inject constructor(
-    @ApplicationContext context: Context,
+    @ApplicationContext private val context: Context,
+    securityManager: SecurityManager,
 ) : BaseUrlProvider {
     companion object {
-        private const val PREF_FILE_NAME = "b3f0cf9b-4f3f-4c5b-bf85-7b1f44eddd7a"
-        private const val PREF_MODE = Context.MODE_PRIVATE
+        private const val LEGACY_PREF_FILE_NAME = "b3f0cf9b-4f3f-4c5b-bf85-7b1f44eddd7a"
+        private const val SECURE_PREF_FILE_NAME = "97285f18-9742-469e-accf-3ed54def7a7e"
         private const val API_BASE_URL_KEY = "ApiBaseUrl"
         private const val API_VERSION = "v2"
         private const val BASE_URL_SUFFIX = "/androidapi/$API_VERSION/"
@@ -26,13 +28,27 @@ internal class BaseUrlProviderImpl @Inject constructor(
             "https://${BuildConfig.BASE_URL_PREFIX}.simprints-apis.com$BASE_URL_SUFFIX"
     }
 
-    val prefs: SharedPreferences = context.getSharedPreferences(PREF_FILE_NAME, PREF_MODE)
+    private val securePrefs = securityManager.buildEncryptedSharedPreferences(SECURE_PREF_FILE_NAME)
 
-    override fun getApiBaseUrl(): String = prefs
+    /**
+     * Ensures that data has been migrated to secure prefs before accessing it.
+     */
+    private fun getSecurePrefs(): SharedPreferences {
+        // Data has been migrated to secure prefs.
+        // TODO Delete after there are no users below 2025.3.0
+        if (!securePrefs.contains(API_BASE_URL_KEY)) {
+            val prefs = context.getSharedPreferences(LEGACY_PREF_FILE_NAME, Context.MODE_PRIVATE)
+            securePrefs.edit(commit = true) { putString(API_BASE_URL_KEY, prefs.getString(API_BASE_URL_KEY, "")) }
+            prefs.edit(commit = true) { clear() }
+        }
+        return securePrefs
+    }
+
+    override fun getApiBaseUrl(): String = getSecurePrefs()
         .getString(API_BASE_URL_KEY, DEFAULT_BASE_URL)!!
         .also { Simber.d("API base URL is $it") }
 
-    override fun getApiBaseUrlPrefix(): String = prefs
+    override fun getApiBaseUrlPrefix(): String = getSecurePrefs()
         .getString(API_BASE_URL_KEY, DEFAULT_BASE_URL)
         ?.removeSuffix(BASE_URL_SUFFIX)
         ?.also { Simber.d("API base URL prefix is $it") }!!
@@ -51,11 +67,11 @@ internal class BaseUrlProviderImpl @Inject constructor(
 
         Simber.d("Setting API base URL to $newValue")
 
-        prefs.edit(commit = true) { putString(API_BASE_URL_KEY, newValue) }
+        getSecurePrefs().edit(commit = true) { putString(API_BASE_URL_KEY, newValue) }
     }
 
     override fun resetApiBaseUrl() {
         Simber.d("Resetting API base")
-        prefs.edit(commit = true) { putString(API_BASE_URL_KEY, DEFAULT_BASE_URL) }
+        getSecurePrefs().edit(commit = true) { putString(API_BASE_URL_KEY, DEFAULT_BASE_URL) }
     }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-122)
Will be released in: **2025.3.0**

### Notable changes

* Moving a couple of remaining cases of shared prefs usage to the encrypted counterpart to avoid accidentally leaking some IDs/domain. The risk was always very low, but this ticket has been in the backlog for too long by now.
* Did not move the language helper since it is fine as-is (it stores only the language code), and the performance penalty from encryption might affect app startup times. 

### Testing guidance

* Use the app as usual - upsync progress should be reported correctly.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
