### PR TITLE
[MS-1028] Fix pagination logic by adjusting pageSize calculation in RoomEnrolmentRecordLocalDataSource

### DIFF
--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSource.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSource.kt
@@ -159,7 +159,7 @@ internal class RoomEnrolmentRecordLocalDataSource @Inject constructor(
                     }
                     val identities = loadBiometricIdentities(
                         query = query.copy(afterSubjectId = afterSubjectId), // update query with the last seen subject ID
-                        pageSize = range.last - range.first,
+                        pageSize = range.last - range.first + 1,
                         format = format,
                         createIdentity = createIdentity,
                         onCandidateLoaded = onCandidateLoaded,

--- a/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSourceTest.kt
+++ b/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSourceTest.kt
@@ -890,8 +890,8 @@ class RoomEnrolmentRecordLocalDataSourceTest {
                 .loadFingerprintIdentities(
                     query = baseQuery,
                     ranges = listOf(
-                        0..1,
-                        2..3,
+                        0..0,
+                        1..1,
                     ),
                     project = project,
                     dataSource = Simprints,
@@ -904,7 +904,7 @@ class RoomEnrolmentRecordLocalDataSourceTest {
                 .loadFingerprintIdentities(
                     query = baseQuery,
                     ranges = listOf(
-                        0..2,
+                        0..1,
                     ),
                     project = project,
                     dataSource = Simprints,
@@ -1078,8 +1078,8 @@ class RoomEnrolmentRecordLocalDataSourceTest {
                 .loadFaceIdentities(
                     query = baseQuery,
                     ranges = listOf(
-                        0..1,
-                        2..3,
+                        0..0,
+                        1..1,
                     ),
                     project = project,
                     dataSource = Simprints,
@@ -1092,7 +1092,7 @@ class RoomEnrolmentRecordLocalDataSourceTest {
                 .loadFaceIdentities(
                     query = baseQuery,
                     ranges = listOf(
-                        0..2,
+                        0..1,
                     ),
                     project = project,
                     dataSource = Simprints,


### PR DESCRIPTION


[JIRA ticket](https://simprints.atlassian.net/browse/MS-1028)
Will be released in: **2025.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **not yet released**

Current logic calculates pageSize = range.last - range.first, which skips the last item in the range when range.last == range.first + pageSize.
Update to:
pageSize = range.last - range.first + 1
to include the full range.

### Testing guidance
Normal identification shows that the number of identified subjects in each range is off by one, typically one less than expected.
### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
