### PR TITLE
Add explicit assertions on withArg in the unit tests

### DIFF
--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/ClientApiViewModelTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/ClientApiViewModelTest.kt
@@ -157,7 +157,7 @@ internal class ClientApiViewModelTest {
             deleteSessionEventsIfNeeded(any())
             persistentLogger.log(any(), any(), any(), any())
         }
-        verify { resultMapper.invoke(withArg { it is ActionResponse.EnrolActionResponse }) }
+        verify { resultMapper.invoke(match<ActionResponse> { it is ActionResponse.EnrolActionResponse }) }
         viewModel.returnResponse.test().assertHasValue()
     }
 
@@ -172,7 +172,7 @@ internal class ClientApiViewModelTest {
             simpleEventReporter.addCompletionCheckEvent(eq(true))
             persistentLogger.log(any(), any(), any(), any())
         }
-        verify { resultMapper.invoke(withArg { it is ActionResponse.IdentifyActionResponse }) }
+        verify { resultMapper.invoke(match<ActionResponse> { it is ActionResponse.IdentifyActionResponse }) }
         viewModel.returnResponse.test().assertHasValue()
     }
 
@@ -188,7 +188,7 @@ internal class ClientApiViewModelTest {
             deleteSessionEventsIfNeeded(any())
             persistentLogger.log(any(), any(), any(), any())
         }
-        verify { resultMapper.invoke(withArg { it is ActionResponse.ConfirmActionResponse }) }
+        verify { resultMapper.invoke(match<ActionResponse> { it is ActionResponse.ConfirmActionResponse }) }
         viewModel.returnResponse.test().assertHasValue()
     }
 
@@ -205,7 +205,7 @@ internal class ClientApiViewModelTest {
             deleteSessionEventsIfNeeded(any())
             persistentLogger.log(any(), any(), any(), any())
         }
-        verify { resultMapper.invoke(withArg { it is ActionResponse.VerifyActionResponse }) }
+        verify { resultMapper.invoke(match<ActionResponse> { it is ActionResponse.VerifyActionResponse }) }
         viewModel.returnResponse.test().assertHasValue()
     }
 
@@ -225,7 +225,7 @@ internal class ClientApiViewModelTest {
             deleteSessionEventsIfNeeded(any())
             persistentLogger.log(any(), any(), any(), any())
         }
-        verify { resultMapper.invoke(withArg { it is ActionResponse.ExitFormActionResponse }) }
+        verify { resultMapper.invoke(match<ActionResponse> { it is ActionResponse.ExitFormActionResponse }) }
         viewModel.returnResponse.test().assertHasValue()
     }
 
@@ -242,7 +242,7 @@ internal class ClientApiViewModelTest {
             deleteSessionEventsIfNeeded(any())
             persistentLogger.log(any(), any(), any(), any())
         }
-        verify { resultMapper.invoke(withArg { it is ActionResponse.ErrorActionResponse }) }
+        verify { resultMapper.invoke(match<ActionResponse> { it is ActionResponse.ErrorActionResponse }) }
         viewModel.returnResponse.test().assertHasValue()
     }
 

--- a/infra/logging-persistent/src/test/java/com/simprints/logging/persistent/DatabasePersistentLoggerTest.kt
+++ b/infra/logging-persistent/src/test/java/com/simprints/logging/persistent/DatabasePersistentLoggerTest.kt
@@ -60,7 +60,7 @@ class DatabasePersistentLoggerTest {
 
         coVerify {
             logEntryDao.save(
-                coWithArg {
+                match<DbLogEntry> {
                     it.timestampMs == 0L && it.title == "title" && it.body == "body"
                 },
             )
@@ -74,7 +74,7 @@ class DatabasePersistentLoggerTest {
 
         coVerify {
             logEntryDao.save(
-                coWithArg {
+                match<DbLogEntry> {
                     it.timestampMs == 1L && it.title == "title" && it.body == "body"
                 },
             )
@@ -88,7 +88,7 @@ class DatabasePersistentLoggerTest {
 
         coVerify {
             logEntryDao.save(
-                coWithArg {
+                match<DbLogEntry> {
                     it.timestampMs == 0L && it.title == "title" && it.body == "body"
                 },
             )
@@ -102,7 +102,7 @@ class DatabasePersistentLoggerTest {
 
         coVerify {
             logEntryDao.save(
-                coWithArg {
+                match<DbLogEntry> {
                     it.timestampMs == 1L && it.title == "title" && it.body == "body"
                 },
             )

--- a/infra/logging/src/test/java/com/simprints/infra/logging/writers/CrashlyticsLogWriterTest.kt
+++ b/infra/logging/src/test/java/com/simprints/infra/logging/writers/CrashlyticsLogWriterTest.kt
@@ -66,9 +66,7 @@ class CrashlyticsLogWriterTest {
 
         verify {
             crashMock.recordException(
-                withArg {
-                    it is Exception && it.message.contentEquals("Test Message")
-                },
+                match<Exception> { it.message?.contains("Test Message") == true }
             )
         }
     }
@@ -84,7 +82,7 @@ class CrashlyticsLogWriterTest {
         Simber.w("Test Message", custException)
 
         verify {
-            crashMock.log(withArg { it.contains("Test Message") })
+            crashMock.log(match<String> { it.contains("Test Message") })
         }
         verify {
             crashMock.recordException(custException)
@@ -102,7 +100,7 @@ class CrashlyticsLogWriterTest {
         Simber.e("Test Message", custException)
 
         verify {
-            crashMock.log(withArg { it.contains("Test Message") })
+            crashMock.log(match<String> { it.contains("Test Message") })
         }
         verify {
             crashMock.recordException(custException)


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2025.2.0**

### Root cause analysis (for bugfixes only)

Without an assert, a `withArg` does nothing*! Therefore we had lots of tests that checked nothing and yes, some of them were wrong.

*The only exception to that is if you specify the type in generic braces <>

### Notable changes

* Replaces `withArg`s that didn't have effect with match{}
* Modified two tests in `EventDownSyncTaskTest` that were no longer correct 

### Testing guidance

* Describe how the reviewers can verify that issue is fixed

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
