### PR TITLE
Bugfix Prevent a possible database corruption when checking encryption status

### DIFF
--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSource.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSource.kt
@@ -1,7 +1,5 @@
 package com.simprints.infra.enrolment.records.repository.local
 
-import android.database.sqlite.SQLiteDatabase
-import android.database.sqlite.SQLiteException
 import androidx.room.withTransaction
 import com.simprints.core.DispatcherIO
 import com.simprints.core.domain.face.FaceSample
@@ -17,6 +15,7 @@ import com.simprints.infra.enrolment.records.repository.domain.models.SubjectAct
 import com.simprints.infra.enrolment.records.repository.domain.models.SubjectQuery
 import com.simprints.infra.enrolment.records.repository.local.models.toDomain
 import com.simprints.infra.enrolment.records.repository.local.models.toRoomDb
+import com.simprints.infra.enrolment.records.room.store.BuildConfig.DB_ENCRYPTION
 import com.simprints.infra.enrolment.records.room.store.SubjectDao
 import com.simprints.infra.enrolment.records.room.store.SubjectsDatabase
 import com.simprints.infra.enrolment.records.room.store.SubjectsDatabaseFactory
@@ -229,7 +228,7 @@ internal class RoomEnrolmentRecordLocalDataSource @Inject constructor(
             val dbVersion = database.openHelper.readableDatabase.version
             val dbPath = database.openHelper.readableDatabase.path
             val dbSize = getTotalRoomDbSizeBytes(dbPath!!)
-            val isDBEncrypted = isDBEncrypted(dbPath)
+            val isDBEncrypted = DB_ENCRYPTION
             val subjectCount = subjectDao.countSubjects(queryBuilder.buildCountQuery(SubjectQuery()))
             "Room DB Info:\n" +
                 "Database Name: ${database.openHelper.databaseName}\n" +
@@ -239,19 +238,6 @@ internal class RoomEnrolmentRecordLocalDataSource @Inject constructor(
                 "Is Encrypted: $isDBEncrypted\n" +
                 "Number of Subjects: $subjectCount"
         }
-    }
-
-    private fun isDBEncrypted(fullDbPath: String): Boolean = try {
-        SQLiteDatabase.openDatabase(fullDbPath, null, SQLiteDatabase.OPEN_READONLY).use { db ->
-            db.rawQuery("PRAGMA schema_version;", null).use { cursor ->
-                cursor.moveToFirst()
-                // If we can read the schema version, it's not encrypted
-                false
-            }
-        }
-    } catch (_: SQLiteException) {
-        // Exception likely means the DB is encrypted
-        true
     }
 
     private fun getTotalRoomDbSizeBytes(fullDbPath: String): Long {


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1029)
Will be released in: **2025.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.2.0**

Using `SQLiteDatabase.openDatabase()` without a passphrase on an encrypted Room database caused SQLite to treat the DB as corrupted, triggering an **automatic wipe** during internal diagnostics.

```
Corruption reported by sqlite on database: /data/user/0/com.simprints.id/databases/db-subjects
DB wipe detected: package=com.simprints.id reason=corruption
...
at android.database.sqlite.SQLiteDatabase.openDatabase(SQLiteDatabase.java:1206)
at com.simprints.infra.enrolment.records.repository.local.RoomEnrolmentRecordLocalDataSource.isDBEncrypted(SourceFile:3)
```

###  Fix

* Removed unsafe direct DB access via `SQLiteDatabase.openDatabase()`.




### Testing guidance
Open the migration section in the troubleshooting screen when the active database is Room.

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
