### PR TITLE
Add biometricDataSource to expectedKeys of Enrol, Identify and Verify requests

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/extractors/EnrolRequestExtractor.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/extractors/EnrolRequestExtractor.kt
@@ -1,7 +1,11 @@
 package com.simprints.feature.clientapi.mappers.request.extractors
 
+import com.simprints.libsimprints.Constants
+
 internal open class EnrolRequestExtractor(
     extras: Map<String, Any>,
 ) : ActionRequestExtractor(extras) {
-    override val expectedKeys = super.keys
+    override val expectedKeys = super.keys + listOf(
+        Constants.SIMPRINTS_BIOMETRIC_DATA_SOURCE,
+    )
 }

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/extractors/IdentifyRequestExtractor.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/extractors/IdentifyRequestExtractor.kt
@@ -1,7 +1,11 @@
 package com.simprints.feature.clientapi.mappers.request.extractors
 
+import com.simprints.libsimprints.Constants
+
 internal open class IdentifyRequestExtractor(
     extras: Map<String, Any>,
 ) : ActionRequestExtractor(extras) {
-    override val expectedKeys = super.keys
+    override val expectedKeys = super.keys + listOf(
+        Constants.SIMPRINTS_BIOMETRIC_DATA_SOURCE,
+    )
 }

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/extractors/VerifyRequestExtractor.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/request/extractors/VerifyRequestExtractor.kt
@@ -8,5 +8,8 @@ internal open class VerifyRequestExtractor(
 ) : ActionRequestExtractor(extras) {
     fun getVerifyGuid(): String = extras.extractString(Constants.SIMPRINTS_VERIFY_GUID)
 
-    override val expectedKeys = super.keys + listOf(Constants.SIMPRINTS_VERIFY_GUID)
+    override val expectedKeys = super.keys + listOf(
+        Constants.SIMPRINTS_VERIFY_GUID,
+        Constants.SIMPRINTS_BIOMETRIC_DATA_SOURCE,
+    )
 }


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2025.2.0**

### Root cause analysis (for bugfixes only)

When `biometricDataSource` was created, it was not added to `expectedKeys` to relevant requests. As a result it leads to SID generating a `SuspiciousIntent` event every time an Intent with `biometricDataSource` is received.

### Notable changes

* Title says it all

### Testing guidance

* Describe how the reviewers can verify that issue is fixed

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
