### PR TITLE
[MS-1032] Schedule Realm to Room migration on project config refresh

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCase.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCase.kt
@@ -1,6 +1,7 @@
 package com.simprints.feature.dashboard.logout.usecase
 
 import com.simprints.infra.authlogic.AuthManager
+import com.simprints.infra.enrolment.records.repository.local.migration.RealmToRoomMigrationFlagsStore
 import com.simprints.infra.sync.SyncOrchestrator
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
@@ -8,6 +9,7 @@ import javax.inject.Inject
 internal class LogoutUseCase @Inject constructor(
     private val syncOrchestrator: SyncOrchestrator,
     private val authManager: AuthManager,
+    private val flagsStore: RealmToRoomMigrationFlagsStore,
 ) {
     operator fun invoke() = runBlocking {
         // Cancel all background sync
@@ -15,5 +17,7 @@ internal class LogoutUseCase @Inject constructor(
         syncOrchestrator.deleteEventSyncInfo()
         // sign out the user
         authManager.signOut()
+        // Reset migration flags
+        flagsStore.clearMigrationFlags()
     }
 }

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCaseTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.simprints.feature.dashboard.logout.usecase
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.simprints.infra.authlogic.AuthManager
+import com.simprints.infra.enrolment.records.repository.local.migration.RealmToRoomMigrationFlagsStore
 import com.simprints.infra.sync.SyncOrchestrator
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import io.mockk.MockKAnnotations
@@ -25,6 +26,9 @@ class LogoutUseCaseTest {
     @MockK
     private lateinit var authManager: AuthManager
 
+    @MockK
+    private lateinit var flagsStore: RealmToRoomMigrationFlagsStore
+
     private lateinit var useCase: LogoutUseCase
 
     @Before
@@ -34,6 +38,7 @@ class LogoutUseCaseTest {
         useCase = LogoutUseCase(
             syncOrchestrator = syncOrchestrator,
             authManager = authManager,
+            flagsStore = flagsStore,
         )
     }
 
@@ -45,6 +50,7 @@ class LogoutUseCaseTest {
             syncOrchestrator.cancelBackgroundWork()
             syncOrchestrator.deleteEventSyncInfo()
             authManager.signOut()
+            flagsStore.clearMigrationFlags()
         }
     }
 }

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/tools/di/FakeCoreModule.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/tools/di/FakeCoreModule.kt
@@ -1,5 +1,7 @@
 package com.simprints.feature.dashboard.tools.di
 
+import android.content.Context
+import androidx.work.WorkManager
 import com.simprints.core.AppScope
 import com.simprints.core.AvailableProcessors
 import com.simprints.core.CoreModule
@@ -17,6 +19,7 @@ import com.simprints.core.tools.utils.StringTokenizer
 import com.simprints.testtools.unit.EncodingUtilsImplForTests
 import dagger.Module
 import dagger.Provides
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
 import io.mockk.mockk
@@ -88,4 +91,9 @@ object FakeCoreModule {
     @Provides
     @Singleton
     fun provideEncodingUtils(): EncodingUtils = EncodingUtilsImplForTests
+
+    @Provides
+    fun provideWorkManager(
+        @ApplicationContext context: Context,
+    ): WorkManager = WorkManager.getInstance(context)
 }

--- a/infra/core/src/main/java/com/simprints/core/CoreModule.kt
+++ b/infra/core/src/main/java/com/simprints/core/CoreModule.kt
@@ -1,6 +1,7 @@
 package com.simprints.core
 
 import android.content.Context
+import androidx.work.WorkManager
 import com.lyft.kronos.AndroidClockFactory
 import com.simprints.core.tools.exceptions.AppCoroutineExceptionHandler
 import com.simprints.core.tools.extentions.deviceHardwareId
@@ -134,6 +135,11 @@ object CoreModule {
     ): CoroutineScope = CoroutineScope(
         SupervisorJob() + dispatcherMain + AppCoroutineExceptionHandler(),
     )
+
+    @Provides
+    fun provideWorkManager(
+        @ApplicationContext context: Context,
+    ): WorkManager = WorkManager.getInstance(context)
 }
 
 @Qualifier

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/migration/RealmToRoomMigrationFlagsStore.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/migration/RealmToRoomMigrationFlagsStore.kt
@@ -90,4 +90,12 @@ class RealmToRoomMigrationFlagsStore @Inject constructor(
         $KEY_DOWN_SYNC_STATUS: $downSync
         """.trimIndent()
     }
+
+    /**
+     * Clears all migration-related keys from the store.
+     */
+    fun clearMigrationFlags() {
+        prefs.edit { clear() }
+        Simber.i("[RealmToRoomMigrationFlagsStore] Migration flags cleared", tag = REALM_DB_MIGRATION)
+    }
 }

--- a/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/local/migration/RealmToRoomMigrationFlagsStoreTest.kt
+++ b/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/local/migration/RealmToRoomMigrationFlagsStoreTest.kt
@@ -300,4 +300,14 @@ class RealmToRoomMigrationFlagsStoreTest {
         verify { editor.putBoolean(RealmToRoomMigrationFlagsStore.KEY_DOWN_SYNC_STATUS, false) }
         verify { editor.apply() }
     }
+
+    @Test
+    fun `clearMigrationFlags should remove all migration-related keys`() {
+        // Given
+        every { editor.clear() } returns editor
+        // When
+        store.clearMigrationFlags()
+        // Then
+        verify { editor.clear() }
+    }
 }

--- a/infra/sync/src/main/java/com/simprints/infra/sync/SyncModule.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/SyncModule.kt
@@ -1,26 +1,13 @@
 package com.simprints.infra.sync
 
-import android.content.Context
-import androidx.work.WorkManager
 import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-object SyncModule {
-    @Provides
-    fun provideWorkManager(
-        @ApplicationContext context: Context,
-    ): WorkManager = WorkManager.getInstance(context)
-}
-
-@Module
-@InstallIn(SingletonComponent::class)
-abstract class SyncOrchestratorModule {
+abstract class SyncModule {
     @Binds
     internal abstract fun provideSyncOrchestrator(syncOrchestratorImpl: SyncOrchestratorImpl): SyncOrchestrator
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1032)
Will be released in: **2025.2.0**

### Notable changes

* Added logic to schedule the DB migration worker after project config refresh. This ensures the migration can run without requiring an app restart.
* Previously, the migration was only scheduled in Application.onCreate(), which doesn’t run unless the app is restarted. This change ensures migrations can be triggered proactively.


### Testing guidance

* Verify that the DB migration worker is scheduled after a config refresh

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
