### PR TITLE
[MS-1033] Ensure DAO operations are performed on IO dispatcher 

### DIFF
--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSource.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSource.kt
@@ -193,7 +193,7 @@ internal class RoomEnrolmentRecordLocalDataSource @Inject constructor(
             }
     }
 
-    override suspend fun delete(queries: List<SubjectQuery>) {
+    override suspend fun delete(queries: List<SubjectQuery>): Unit = withContext(dispatcherIO) {
         Simber.i("[delete] Deleting subjects with queries: $queries", tag = ROOM_RECORDS_DB)
         database.withTransaction {
             queries.forEach { query ->
@@ -202,7 +202,7 @@ internal class RoomEnrolmentRecordLocalDataSource @Inject constructor(
         }
     }
 
-    override suspend fun deleteAll() {
+    override suspend fun deleteAll(): Unit = withContext(dispatcherIO) {
         Simber.i("[deleteAll] Deleting all subjects.", tag = ROOM_RECORDS_DB)
         subjectDao.deleteSubjects(queryBuilder.buildDeleteQuery(SubjectQuery()))
     }

--- a/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSourceTest.kt
+++ b/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSourceTest.kt
@@ -1544,4 +1544,19 @@ class RoomEnrolmentRecordLocalDataSourceTest {
 
         // Then: Exception expected
     }
+
+    @Test
+    fun `delete all - should delete all subjects`() = runTest {
+        // Given
+        setupInitialData()
+        val initialCount = dataSource.count()
+
+        // When
+        dataSource.deleteAll()
+
+        // Then
+        val finalCount = dataSource.count()
+        assertThat(finalCount).isEqualTo(0)
+        assertThat(initialCount).isGreaterThan(0)
+    }
 }


### PR DESCRIPTION


[JIRA ticket](https://simprints.atlassian.net/browse/MS-1033)
Will be released in: **2025.2.0**


### Notable changes

* The `delete` and `deleteAll` functions in `RoomEnrolmentRecordLocalDataSource` are updated to explicitly use the `dispatcherIO` context.



### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
