### PR TITLE
MS-1037 Also count enrolment v4 for record upload counter in sync info

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/main/sync/SyncViewModel.kt
@@ -187,7 +187,7 @@ internal class SyncViewModel @Inject constructor(
             _syncToBFSIDAllowed.postValue(configuration.canSyncDataToSimprints() || configuration.isEventDownSyncAllowed())
         }
         eventSyncManager
-            .countEventsToUpload(EventType.ENROLMENT_V2)
+            .countEventsToUpload(listOf(EventType.ENROLMENT_V2, EventType.ENROLMENT_V4))
             .collect { upSyncCountLiveData.postValue(it) }
     }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutViewModel.kt
@@ -78,7 +78,7 @@ internal class AboutViewModel @Inject constructor(
         }
     }
 
-    private suspend fun hasEventsToUpload(): Boolean = eventSyncManager.countEventsToUpload(type = null).first() > 0
+    private suspend fun hasEventsToUpload(): Boolean = eventSyncManager.countEventsToUpload().first() > 0
 
     private suspend fun canSyncDataToSimprints(): Boolean = configManager.getProjectConfiguration().canSyncDataToSimprints()
 

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/main/sync/SyncViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/main/sync/SyncViewModelTest.kt
@@ -28,6 +28,7 @@ import com.simprints.infra.config.store.models.UpSynchronizationConfiguration
 import com.simprints.infra.config.store.models.UpSynchronizationConfiguration.SimprintsUpSynchronizationConfiguration
 import com.simprints.infra.config.store.models.UpSynchronizationConfiguration.UpSynchronizationKind.ALL
 import com.simprints.infra.config.sync.ConfigManager
+import com.simprints.infra.events.event.domain.models.EventType
 import com.simprints.infra.eventsync.EventSyncManager
 import com.simprints.infra.eventsync.status.models.EventSyncState
 import com.simprints.infra.eventsync.status.models.EventSyncWorkerState
@@ -234,7 +235,7 @@ internal class SyncViewModelTest {
     @Test
     fun `should post a SyncPendingUpload card state if there are records to upload`() {
         coEvery { configManager.getDeviceConfiguration() } returns deviceConfiguration
-        coEvery { eventSyncManager.countEventsToUpload(any()) }.returns(flowOf(2))
+        coEvery { eventSyncManager.countEventsToUpload(any<List<EventType>>()) }.returns(flowOf(2))
 
         isConnected.value = true
         syncState.value = EventSyncState(

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/about/AboutViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/about/AboutViewModelTest.kt
@@ -203,9 +203,7 @@ class AboutViewModelTest {
             true -> 1
             false -> 0
         }
-        coEvery { eventSyncManager.countEventsToUpload(any()) } returns flowOf(
-            countEventsToUpload,
-        )
+        coEvery { eventSyncManager.countEventsToUpload() } returns flowOf(countEventsToUpload)
         coEvery { configManager.getProjectConfiguration() } returns buildProjectConfigurationMock(
             upSyncKind,
         )

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
@@ -101,18 +101,20 @@ class SyncInfoViewModelTest {
         stateLiveData = MutableLiveData<EventSyncState>()
         every { eventSyncManager.getLastSyncState() } returns stateLiveData
         coEvery { configManager.getProject(PROJECT_ID) } returns project
-        viewModel = SyncInfoViewModel(
-            configManager = configManager,
-            connectivityTracker = connectivityTracker,
-            enrolmentRecordRepository = enrolmentRecordRepository,
-            authStore = authStore,
-            imageRepository = imageRepository,
-            eventSyncManager = eventSyncManager,
-            syncOrchestrator = syncOrchestrator,
-            tokenizationProcessor = tokenizationProcessor,
-            recentUserActivityManager = recentUserActivityManager,
-        )
+        viewModel = createViewModel()
     }
+
+    private fun createViewModel() = SyncInfoViewModel(
+        configManager = configManager,
+        connectivityTracker = connectivityTracker,
+        enrolmentRecordRepository = enrolmentRecordRepository,
+        authStore = authStore,
+        imageRepository = imageRepository,
+        eventSyncManager = eventSyncManager,
+        syncOrchestrator = syncOrchestrator,
+        tokenizationProcessor = tokenizationProcessor,
+        recentUserActivityManager = recentUserActivityManager,
+    )
 
     @Test
     fun `should initialize the configuration live data correctly`() = runTest {
@@ -138,10 +140,11 @@ class SyncInfoViewModelTest {
     fun `should initialize the recordsToUpSync live data correctly`() = runTest {
         val number = 10
         coEvery {
-            eventSyncManager.countEventsToUpload(EventType.ENROLMENT_V2)
+            eventSyncManager.countEventsToUpload(listOf(EventType.ENROLMENT_V2, EventType.ENROLMENT_V4))
         } returns flowOf(number)
 
-        viewModel.refreshInformation()
+        // upSync count collected on init, so need to rebuild for mocking to take effect
+        viewModel = createViewModel()
 
         assertThat(viewModel.recordsToUpSync.getOrAwaitValue()).isEqualTo(number)
     }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManager.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManager.kt
@@ -18,7 +18,9 @@ interface EventSyncManager {
 
     fun getLastSyncState(): LiveData<EventSyncState>
 
-    suspend fun countEventsToUpload(type: EventType?): Flow<Int>
+    suspend fun countEventsToUpload(): Flow<Int>
+
+    suspend fun countEventsToUpload(types: List<EventType>): Flow<Int>
 
     suspend fun countEventsToDownload(): DownSyncCounts
 

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManagerImpl.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManagerImpl.kt
@@ -27,6 +27,7 @@ import com.simprints.infra.eventsync.sync.common.TAG_SUBJECTS_SYNC_ALL_WORKERS
 import com.simprints.infra.eventsync.sync.down.tasks.EventDownSyncTask
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -61,7 +62,11 @@ internal class EventSyncManagerImpl @Inject constructor(
 
     override fun getAllWorkerTag(): String = TAG_SUBJECTS_SYNC_ALL_WORKERS
 
-    override suspend fun countEventsToUpload(type: EventType?): Flow<Int> = eventRepository.observeEventCount(type)
+    override suspend fun countEventsToUpload(): Flow<Int> = eventRepository.observeEventCount(null)
+
+    override suspend fun countEventsToUpload(types: List<EventType>): Flow<Int> = combine(
+        types.map { eventRepository.observeEventCount(it) },
+    ) { it.sum() }
 
     override suspend fun countEventsToDownload(): DownSyncCounts {
         val projectConfig = configRepository.getProjectConfiguration()

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/EventSyncManagerTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/EventSyncManagerTest.kt
@@ -9,6 +9,7 @@ import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.events.EventRepository
 import com.simprints.infra.events.event.domain.EventCount
+import com.simprints.infra.events.event.domain.models.EventType
 import com.simprints.infra.events.event.domain.models.scope.EventScope
 import com.simprints.infra.events.sampledata.SampleDefaults.DEFAULT_MODULE_ID
 import com.simprints.infra.events.sampledata.SampleDefaults.DEFAULT_MODULE_ID_2
@@ -113,10 +114,17 @@ internal class EventSyncManagerTest {
     }
 
     @Test
-    fun `countEventsToUpload should call event repo`() = runTest {
-        eventSyncManagerImpl.countEventsToUpload(null).toList()
+    fun `countEventsToUpload without types should call event repo`() = runTest {
+        eventSyncManagerImpl.countEventsToUpload().toList()
 
-        coVerify { eventRepository.observeEventCount(any()) }
+        coVerify { eventRepository.observeEventCount(null) }
+    }
+
+    @Test
+    fun `countEventsToUpload with types should call event repo per type`() = runTest {
+        eventSyncManagerImpl.countEventsToUpload(listOf(EventType.ENROLMENT_V2, EventType.EVENT_UP_SYNC_REQUEST)).toList()
+
+        coVerify(exactly = 2) { eventRepository.observeEventCount(any<EventType>()) }
     }
 
     @Test

--- a/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/HandleProjectStateUseCase.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/HandleProjectStateUseCase.kt
@@ -18,7 +18,7 @@ internal class HandleProjectStateUseCase @Inject constructor(
     private suspend fun shouldSignOut(projectState: ProjectState): Boolean {
         val isProjectEnded = projectState == ProjectState.PROJECT_ENDED
         val isProjectEnding = projectState == ProjectState.PROJECT_ENDING
-        val hasNoEventsToUpload = eventSyncManager.countEventsToUpload(null).first() == 0
+        val hasNoEventsToUpload = eventSyncManager.countEventsToUpload().first() == 0
 
         return isProjectEnded || (isProjectEnding && hasNoEventsToUpload)
     }

--- a/infra/sync/src/test/java/com/simprints/infra/sync/config/usecase/HandleProjectStateUseCaseTest.kt
+++ b/infra/sync/src/test/java/com/simprints/infra/sync/config/usecase/HandleProjectStateUseCaseTest.kt
@@ -32,7 +32,7 @@ internal class HandleProjectStateUseCaseTest {
 
     @Test
     fun `Fully logs out when project has ended`() = runTest {
-        coEvery { eventSyncManager.countEventsToUpload(null) } returns flowOf(0)
+        coEvery { eventSyncManager.countEventsToUpload() } returns flowOf(0)
 
         useCase(ProjectState.PROJECT_ENDED)
 
@@ -41,7 +41,7 @@ internal class HandleProjectStateUseCaseTest {
 
     @Test
     fun `Logs out when project has ending and no items to upload`() = runTest {
-        coEvery { eventSyncManager.countEventsToUpload(null) } returns flowOf(0)
+        coEvery { eventSyncManager.countEventsToUpload() } returns flowOf(0)
 
         useCase(ProjectState.PROJECT_ENDING)
 
@@ -50,7 +50,7 @@ internal class HandleProjectStateUseCaseTest {
 
     @Test
     fun `Does not logs out when project has ending and has items to upload`() = runTest {
-        coEvery { eventSyncManager.countEventsToUpload(null) } returns flowOf(5)
+        coEvery { eventSyncManager.countEventsToUpload() } returns flowOf(5)
 
         useCase(ProjectState.PROJECT_ENDING)
 
@@ -59,7 +59,7 @@ internal class HandleProjectStateUseCaseTest {
 
     @Test
     fun `Does not logs out when project is running`() = runTest {
-        coEvery { eventSyncManager.countEventsToUpload(null) } returns flowOf(0)
+        coEvery { eventSyncManager.countEventsToUpload() } returns flowOf(0)
 
         useCase(ProjectState.RUNNING)
 


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1037)
Will be released in: **2025.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.2.0**

* When implementing record update we added a new schema version of enrolment events, but did not add the new type to be counted for upload.

### Notable changes

* Count both types of enrolment event versions in the sync info screen.
* Simplify the count method for "all" events by removing the optional type argument that is never provided. If it is needed in the future, the new list argument version can be used instead.

### Testing guidance

* Do a couple of enrolments (without sync)
* Check sync info screen, the "Records to Upload" should not be 0.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
