### PR TITLE
Fix SimFace initialisation in latest version

### DIFF
--- a/face/infra/bio-sdk-resolver/src/debug/java/com/simprints/face/infra/biosdkresolver/SimFaceBioSdk.kt
+++ b/face/infra/bio-sdk-resolver/src/debug/java/com/simprints/face/infra/biosdkresolver/SimFaceBioSdk.kt
@@ -15,9 +15,11 @@ class SimFaceBioSdk @Inject constructor(
     override val detector: SimFaceDetector,
     private val simFace: SimFace,
 ) : FaceBioSDK {
-    override val version: String = "1"
-    override val templateFormat: String = simFace.getTemplateVersion()
-    override val matcherName: String = "SIM_FACE"
+    override fun version(): String = "1"
+
+    override fun templateFormat(): String = simFace.getTemplateVersion()
+
+    override fun matcherName(): String = "SIM_FACE"
 
     override fun createMatcher(probeSamples: List<FaceSample>): FaceMatcher = SimFaceMatcher(simFace, probeSamples)
 }

--- a/face/infra/bio-sdk-resolver/src/main/java/com/simprints/face/infra/biosdkresolver/FaceBioSDK.kt
+++ b/face/infra/bio-sdk-resolver/src/main/java/com/simprints/face/infra/biosdkresolver/FaceBioSDK.kt
@@ -9,9 +9,11 @@ interface FaceBioSDK {
     val initializer: FaceBioSdkInitializer
     val detector: FaceDetector
 
-    val version: String
-    val templateFormat: String
-    val matcherName: String
+    fun version(): String
+
+    fun templateFormat(): String
+
+    fun matcherName(): String
 
     fun createMatcher(probeSamples: List<FaceSample>): FaceMatcher
 }

--- a/face/infra/bio-sdk-resolver/src/main/java/com/simprints/face/infra/biosdkresolver/ResolveRankOneVersionUseCase.kt
+++ b/face/infra/bio-sdk-resolver/src/main/java/com/simprints/face/infra/biosdkresolver/ResolveRankOneVersionUseCase.kt
@@ -16,6 +16,6 @@ internal class ResolveRankOneVersionUseCase @Inject constructor(
             ?.version
             ?.takeIf { it.isNotBlank() } // Ensures version is not null or empty
         requireNotNull(version) { "FaceBioSDK version is null or empty" }
-        return if (version == rocV3BioSdk.version) rocV3BioSdk else rocV1BioSdk
+        return if (version == rocV3BioSdk.version()) rocV3BioSdk else rocV1BioSdk
     }
 }

--- a/face/infra/bio-sdk-resolver/src/main/java/com/simprints/face/infra/biosdkresolver/RocV1BioSdk.kt
+++ b/face/infra/bio-sdk-resolver/src/main/java/com/simprints/face/infra/biosdkresolver/RocV1BioSdk.kt
@@ -14,9 +14,11 @@ class RocV1BioSdk @Inject constructor(
     override val initializer: RocV1Initializer,
     override val detector: RocV1Detector,
 ) : FaceBioSDK {
-    override val version: String = "1.23"
-    override val templateFormat: String = RANK_ONE_TEMPLATE_FORMAT_1_23
-    override val matcherName: String = "RANK_ONE"
+    override fun version(): String = "1.23"
+
+    override fun templateFormat(): String = RANK_ONE_TEMPLATE_FORMAT_1_23
+
+    override fun matcherName(): String = "RANK_ONE"
 
     override fun createMatcher(probeSamples: List<FaceSample>): FaceMatcher = RocV1Matcher(probeSamples)
 }

--- a/face/infra/bio-sdk-resolver/src/main/java/com/simprints/face/infra/biosdkresolver/RocV3BioSdk.kt
+++ b/face/infra/bio-sdk-resolver/src/main/java/com/simprints/face/infra/biosdkresolver/RocV3BioSdk.kt
@@ -14,9 +14,11 @@ class RocV3BioSdk @Inject constructor(
     override val initializer: RocV3Initializer,
     override val detector: RocV3Detector,
 ) : FaceBioSDK {
-    override val version: String = "3.1"
-    override val templateFormat: String = RANK_ONE_TEMPLATE_FORMAT_3_1
-    override val matcherName: String = "RANK_ONE"
+    override fun version(): String = "3.1"
+
+    override fun templateFormat(): String = RANK_ONE_TEMPLATE_FORMAT_3_1
+
+    override fun matcherName(): String = "RANK_ONE"
 
     override fun createMatcher(probeSamples: List<FaceSample>): FaceMatcher = RocV3Matcher(probeSamples)
 }

--- a/face/infra/bio-sdk-resolver/src/test/java/com/simprints/face/infra/biosdkresolver/ResolveRankOneVersionUseCaseTest.kt
+++ b/face/infra/bio-sdk-resolver/src/test/java/com/simprints/face/infra/biosdkresolver/ResolveRankOneVersionUseCaseTest.kt
@@ -70,7 +70,7 @@ class ResolveRankOneVersionUseCaseTest {
                 .face
                 ?.rankOne
                 ?.version
-        } returns rocV3BioSdk.version
+        } returns rocV3BioSdk.version()
 
         // When
         val result = resolveTheVersionUseCase.invoke()
@@ -89,7 +89,7 @@ class ResolveRankOneVersionUseCaseTest {
                 .face
                 ?.rankOne
                 ?.version
-        } returns rocV1BioSdk.version
+        } returns rocV1BioSdk.version()
 
         // When
         val result = resolveTheVersionUseCase.invoke()

--- a/feature/matcher/src/main/java/com/simprints/matcher/usecases/FaceMatcherUseCase.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/usecases/FaceMatcherUseCase.kt
@@ -43,19 +43,19 @@ internal class FaceMatcherUseCase @Inject constructor(
         val bioSdk = resolveFaceBioSdk(matchParams.faceSDK)
 
         if (matchParams.probeFaceSamples.isEmpty()) {
-            send(MatcherState.Success(emptyList(), 0, bioSdk.matcherName))
+            send(MatcherState.Success(emptyList(), 0, bioSdk.matcherName()))
             return@channelFlow
         }
         val samples = mapSamples(matchParams.probeFaceSamples)
         val queryWithSupportedFormat = matchParams.queryForCandidates.copy(
-            faceSampleFormat = bioSdk.templateFormat,
+            faceSampleFormat = bioSdk.templateFormat(),
         )
         val expectedCandidates = enrolmentRecordRepository.count(
             queryWithSupportedFormat,
             dataSource = matchParams.biometricDataSource,
         )
         if (expectedCandidates == 0) {
-            send(MatcherState.Success(emptyList(), 0, bioSdk.matcherName))
+            send(MatcherState.Success(emptyList(), 0, bioSdk.matcherName()))
             return@channelFlow
         }
 
@@ -81,7 +81,7 @@ internal class FaceMatcherUseCase @Inject constructor(
             }
 
         consumeAndMatch(candidatesChannel, samples, resultSet, bioSdk)
-        send(MatcherState.Success(resultSet.toList(), loadedCandidates.get(), bioSdk.matcherName))
+        send(MatcherState.Success(resultSet.toList(), loadedCandidates.get(), bioSdk.matcherName()))
     }.flowOn(dispatcherBG)
 
     suspend fun consumeAndMatch(


### PR DESCRIPTION
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0**

* The latest version of SimFace changes how models are handled - the template version/format is only available after the library is initialised, since it is dependent on the loaded model.

### Notable changes

* Changes SDK property accessors to functions.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
