### PR TITLE
Provide default base url if is none in the legacy prefs

### DIFF
--- a/infra/network/src/main/java/com/simprints/infra/network/url/BaseUrlProviderImpl.kt
+++ b/infra/network/src/main/java/com/simprints/infra/network/url/BaseUrlProviderImpl.kt
@@ -38,7 +38,7 @@ internal class BaseUrlProviderImpl @Inject constructor(
         // TODO Delete after there are no users below 2025.3.0
         if (!securePrefs.contains(API_BASE_URL_KEY)) {
             val prefs = context.getSharedPreferences(LEGACY_PREF_FILE_NAME, Context.MODE_PRIVATE)
-            securePrefs.edit(commit = true) { putString(API_BASE_URL_KEY, prefs.getString(API_BASE_URL_KEY, "")) }
+            securePrefs.edit(commit = true) { putString(API_BASE_URL_KEY, prefs.getString(API_BASE_URL_KEY, DEFAULT_BASE_URL)) }
             prefs.edit(commit = true) { clear() }
         }
         return securePrefs


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-122)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0**

* On a fresh install, there is no URL in the legacy prefs and no default value was provided.

### Notable changes

* Add default value when attempting to read value from the legacy URL prefs.

### Testing guidance

* Have a fresh install. Try to log in.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
