### PR TITLE
[MS-1065] Adding 'metadata' field to the ConfirmationCalloutEventV3ˆ

### DIFF
--- a/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/ReportActionRequestEventsUseCase.kt
+++ b/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/ReportActionRequestEventsUseCase.kt
@@ -78,7 +78,14 @@ internal class ReportActionRequestEventsUseCase @Inject constructor(
                     metadata,
                     BiometricDataSource.fromString(biometricDataSource),
                 )
-                is ActionRequest.ConfirmIdentityActionRequest -> ConfirmationCalloutEventV3(startTime, projectId, selectedGuid, sessionId)
+                is ActionRequest.ConfirmIdentityActionRequest -> ConfirmationCalloutEventV3(
+                    createdAt = startTime,
+                    projectId = projectId,
+                    selectedGuid = selectedGuid,
+                    sessionId = sessionId,
+                    metadata = metadata
+                )
+
                 is ActionRequest.EnrolLastBiometricActionRequest -> EnrolmentLastBiometricsCalloutEventV3(
                     startTime,
                     projectId,

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/callout/ApiCalloutPayloadV3.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/callout/ApiCalloutPayloadV3.kt
@@ -58,6 +58,7 @@ internal data class ApiCalloutPayloadV3(
         ApiConfirmationCalloutV3(
             domainPayload.selectedGuid,
             domainPayload.sessionId,
+            domainPayload.metadata,
         ),
     )
 

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/callout/ApiConfirmationCalloutV3.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/callout/ApiConfirmationCalloutV3.kt
@@ -6,4 +6,5 @@ import androidx.annotation.Keep
 internal data class ApiConfirmationCalloutV3(
     val selectedGuid: String,
     val sessionId: String,
+    val metadata: String?,
 ) : ApiCallout(ApiCalloutType.Confirmation)

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/EventValidationUtils.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/EventValidationUtils.kt
@@ -266,7 +266,8 @@ fun verifyCalloutConfirmationApiModelV3(json: JSONObject) {
     assertThat(json.getString("type")).isEqualTo("Confirmation")
     assertThat(json.getString("selectedGuid")).isNotNull()
     assertThat(json.getString("sessionId")).isNotNull()
-    assertThat(json.length()).isEqualTo(3)
+    assertThat(json.getString("metadata")).isNotNull()
+    assertThat(json.length()).isEqualTo(4)
 }
 
 fun validateAlertScreenEventApiModel(json: JSONObject) {

--- a/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
+++ b/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
@@ -194,10 +194,11 @@ fun createConfirmationCalloutEventV2() = ConfirmationCalloutEventV2(
 )
 
 fun createConfirmationCalloutEventV3() = ConfirmationCalloutEventV3(
-    CREATED_AT,
-    DEFAULT_PROJECT_ID,
-    GUID1,
-    GUID2,
+    createdAt = CREATED_AT,
+    projectId = DEFAULT_PROJECT_ID,
+    selectedGuid = GUID1,
+    sessionId = GUID2,
+    metadata = DEFAULT_METADATA
 )
 
 fun createEnrolmentCalloutEventV2(projectId: String = DEFAULT_PROJECT_ID) = EnrolmentCalloutEventV2(

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEventV3.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEventV3.kt
@@ -23,9 +23,17 @@ data class ConfirmationCalloutEventV3(
         projectId: String,
         selectedGuid: String,
         sessionId: String,
+        metadata: String?,
     ) : this(
         UUID.randomUUID().toString(),
-        ConfirmationCalloutPayload(createdAt, EVENT_VERSION, projectId, selectedGuid, sessionId),
+        ConfirmationCalloutPayload(
+            createdAt = createdAt,
+            eventVersion = EVENT_VERSION,
+            projectId = projectId,
+            selectedGuid = selectedGuid,
+            sessionId = sessionId,
+            metadata = metadata
+        ),
         CALLOUT_CONFIRMATION_V3,
     )
 
@@ -40,6 +48,7 @@ data class ConfirmationCalloutEventV3(
         val projectId: String,
         val selectedGuid: String,
         val sessionId: String,
+        val metadata: String?,
         override val endedAt: Timestamp? = null,
         override val type: EventType = CALLOUT_CONFIRMATION_V3,
     ) : EventPayload() {

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/EventPayloadTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/EventPayloadTest.kt
@@ -84,7 +84,13 @@ class EventPayloadTest {
             createdAt = CREATED_AT,
             score = CallbackComparisonScore(GUID1, 1, AppMatchConfidence.NONE),
         ),
-        ConfirmationCalloutEventV3(CREATED_AT, DEFAULT_PROJECT_ID, GUID1, GUID2),
+        ConfirmationCalloutEventV3(
+            createdAt = CREATED_AT,
+            projectId = DEFAULT_PROJECT_ID,
+            selectedGuid = GUID1,
+            sessionId = GUID2,
+            metadata = DEFAULT_METADATA
+        ),
         EnrolmentCalloutEventV3(
             createdAt = CREATED_AT,
             projectId = DEFAULT_PROJECT_ID,

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEventV3Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEventV3Test.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.simprints.infra.events.event.domain.models.EventType.CALLOUT_CONFIRMATION_V3
 import com.simprints.infra.events.event.domain.models.callout.ConfirmationCalloutEventV3.Companion.EVENT_VERSION
 import com.simprints.infra.events.sampledata.SampleDefaults.CREATED_AT
+import com.simprints.infra.events.sampledata.SampleDefaults.DEFAULT_METADATA
 import com.simprints.infra.events.sampledata.SampleDefaults.DEFAULT_PROJECT_ID
 import com.simprints.infra.events.sampledata.SampleDefaults.GUID1
 import com.simprints.infra.events.sampledata.SampleDefaults.GUID2
@@ -14,7 +15,13 @@ import org.junit.Test
 class ConfirmationCalloutEventV3Test {
     @Test
     fun create_ConfirmationCalloutEvent() {
-        val event = ConfirmationCalloutEventV3(CREATED_AT, DEFAULT_PROJECT_ID, GUID1, GUID2)
+        val event = ConfirmationCalloutEventV3(
+            createdAt = CREATED_AT,
+            projectId = DEFAULT_PROJECT_ID,
+            selectedGuid = GUID1,
+            sessionId = GUID2,
+            metadata = DEFAULT_METADATA
+        )
 
         assertThat(event.id).isNotNull()
         assertThat(event.type).isEqualTo(CALLOUT_CONFIRMATION_V3)
@@ -30,7 +37,13 @@ class ConfirmationCalloutEventV3Test {
 
     @Test
     fun getTokenizableFields_returnsEmptyMap() {
-        val event = ConfirmationCalloutEventV3(CREATED_AT, DEFAULT_PROJECT_ID, GUID1, GUID2)
+        val event = ConfirmationCalloutEventV3(
+            createdAt = CREATED_AT,
+            projectId = DEFAULT_PROJECT_ID,
+            selectedGuid = GUID1,
+            sessionId = GUID2,
+            metadata = DEFAULT_METADATA
+        )
 
         assertThat(event.getTokenizableFields()).isEmpty()
     }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1065)
Will be released in: **2025.2.0**

### Notable changes

* The `ConfirmationCalloutEventV3` class now contains `metadata: String?` field 
* This field already exists in the confirmation callout request, and now is passed to the event
* The `metadata` field is now also passed to the BFSID

### Testing guidance

* Send the `metadata=test` field for the `com.simprints.id.CONFIRM_IDENTITY` request. Use the `Custom Intent` screen within the Intent Launcher app for that.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Test cases in Testiny are up to date ([ticket](https://app.testiny.io/SID/testcases/tcf/41/tc/259))
* [x] Other teams notified about the changes (BFSID on dev is ready)
