### PR TITLE
[MS-1065] Adding 'metadata' field to the ConfirmationCalloutEventV3

### DIFF
--- a/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/ReportActionRequestEventsUseCase.kt
+++ b/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/ReportActionRequestEventsUseCase.kt
@@ -62,7 +62,13 @@ internal class ReportActionRequestEventsUseCase @Inject constructor(
                     verifyGuid,
                     metadata,
                 )
-                is ActionRequest.ConfirmIdentityActionRequest -> ConfirmationCalloutEvent(startTime, projectId, selectedGuid, sessionId)
+                is ActionRequest.ConfirmIdentityActionRequest -> ConfirmationCalloutEvent(
+                    createdAt = startTime,
+                    projectId = projectId,
+                    selectedGuid = selectedGuid,
+                    sessionId = sessionId,
+                    metadata = metadata
+                )
                 is ActionRequest.EnrolLastBiometricActionRequest -> EnrolmentLastBiometricsCalloutEvent(
                     startTime,
                     projectId,

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/callout/ApiCalloutPayload.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/callout/ApiCalloutPayload.kt
@@ -55,6 +55,7 @@ internal data class ApiCalloutPayload(
         ApiConfirmationCallout(
             domainPayload.selectedGuid,
             domainPayload.sessionId,
+            domainPayload.metadata,
         ),
     )
 

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/callout/ApiConfirmationCallout.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/callout/ApiConfirmationCallout.kt
@@ -6,5 +6,5 @@ import androidx.annotation.Keep
 internal data class ApiConfirmationCallout(
     val selectedGuid: String,
     val sessionId: String,
-    val metadata: String,
+    val metadata: String?,
 ) : ApiCallout(ApiCalloutType.Confirmation)

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/callout/ApiConfirmationCallout.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/callout/ApiConfirmationCallout.kt
@@ -6,4 +6,5 @@ import androidx.annotation.Keep
 internal data class ApiConfirmationCallout(
     val selectedGuid: String,
     val sessionId: String,
+    val metadata: String,
 ) : ApiCallout(ApiCalloutType.Confirmation)

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/EventValidationUtils.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/EventValidationUtils.kt
@@ -203,7 +203,8 @@ fun verifyCalloutConfirmationApiModel(json: JSONObject) {
     assertThat(json.getString("type")).isEqualTo("Confirmation")
     assertThat(json.getString("selectedGuid")).isNotNull()
     assertThat(json.getString("sessionId")).isNotNull()
-    assertThat(json.length()).isEqualTo(3)
+    assertThat(json.getString("metadata")).isNotNull()
+    assertThat(json.length()).isEqualTo(4)
 }
 
 fun validateAlertScreenEventApiModel(json: JSONObject) {

--- a/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
+++ b/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
@@ -181,10 +181,11 @@ fun createVerificationCallbackEventV2() = VerificationCallbackEvent(
 )
 
 fun createConfirmationCalloutEvent() = ConfirmationCalloutEvent(
-    CREATED_AT,
-    DEFAULT_PROJECT_ID,
-    GUID1,
-    GUID2,
+    createdAt = CREATED_AT,
+    projectId = DEFAULT_PROJECT_ID,
+    selectedGuid = GUID1,
+    sessionId = GUID2,
+    metadata = DEFAULT_METADATA,
 )
 
 fun createEnrolmentCalloutEvent(projectId: String = DEFAULT_PROJECT_ID) = EnrolmentCalloutEvent(

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEvent.kt
@@ -23,7 +23,7 @@ data class ConfirmationCalloutEvent(
         projectId: String,
         selectedGuid: String,
         sessionId: String,
-        metadata: String,
+        metadata: String?,
     ) : this(
         UUID.randomUUID().toString(),
         ConfirmationCalloutPayload(
@@ -48,7 +48,7 @@ data class ConfirmationCalloutEvent(
         val projectId: String,
         val selectedGuid: String,
         val sessionId: String,
-        val metadata: String,
+        val metadata: String?,
         override val endedAt: Timestamp? = null,
         override val type: EventType = CALLOUT_CONFIRMATION,
     ) : EventPayload() {

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEvent.kt
@@ -23,9 +23,17 @@ data class ConfirmationCalloutEvent(
         projectId: String,
         selectedGuid: String,
         sessionId: String,
+        metadata: String,
     ) : this(
         UUID.randomUUID().toString(),
-        ConfirmationCalloutPayload(createdAt, EVENT_VERSION, projectId, selectedGuid, sessionId),
+        ConfirmationCalloutPayload(
+            createdAt = createdAt,
+            eventVersion = EVENT_VERSION,
+            projectId = projectId,
+            selectedGuid = selectedGuid,
+            sessionId = sessionId,
+            metadata = metadata
+        ),
         CALLOUT_CONFIRMATION,
     )
 
@@ -40,6 +48,7 @@ data class ConfirmationCalloutEvent(
         val projectId: String,
         val selectedGuid: String,
         val sessionId: String,
+        val metadata: String,
         override val endedAt: Timestamp? = null,
         override val type: EventType = CALLOUT_CONFIRMATION,
     ) : EventPayload() {

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/EventPayloadTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/EventPayloadTest.kt
@@ -83,7 +83,13 @@ class EventPayloadTest {
             createdAt = CREATED_AT,
             score = CallbackComparisonScore(GUID1, 1, AppMatchConfidence.NONE),
         ),
-        ConfirmationCalloutEvent(CREATED_AT, DEFAULT_PROJECT_ID, GUID1, GUID2),
+        ConfirmationCalloutEvent(
+            createdAt = CREATED_AT,
+            projectId = DEFAULT_PROJECT_ID,
+            selectedGuid = GUID1,
+            sessionId = GUID2,
+            metadata = DEFAULT_METADATA
+        ),
         EnrolmentCalloutEvent(
             createdAt = CREATED_AT,
             projectId = DEFAULT_PROJECT_ID,

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEventTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/callout/ConfirmationCalloutEventTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.simprints.infra.events.event.domain.models.EventType.CALLOUT_CONFIRMATION
 import com.simprints.infra.events.event.domain.models.callout.ConfirmationCalloutEvent.Companion.EVENT_VERSION
 import com.simprints.infra.events.sampledata.SampleDefaults.CREATED_AT
+import com.simprints.infra.events.sampledata.SampleDefaults.DEFAULT_METADATA
 import com.simprints.infra.events.sampledata.SampleDefaults.DEFAULT_PROJECT_ID
 import com.simprints.infra.events.sampledata.SampleDefaults.GUID1
 import com.simprints.infra.events.sampledata.SampleDefaults.GUID2
@@ -14,7 +15,13 @@ import org.junit.Test
 class ConfirmationCalloutEventTest {
     @Test
     fun create_ConfirmationCalloutEvent() {
-        val event = ConfirmationCalloutEvent(CREATED_AT, DEFAULT_PROJECT_ID, GUID1, GUID2)
+        val event = ConfirmationCalloutEvent(
+            createdAt = CREATED_AT,
+            projectId = DEFAULT_PROJECT_ID,
+            selectedGuid = GUID1,
+            sessionId = GUID2,
+            metadata = DEFAULT_METADATA
+        )
 
         assertThat(event.id).isNotNull()
         assertThat(event.type).isEqualTo(CALLOUT_CONFIRMATION)
@@ -25,6 +32,7 @@ class ConfirmationCalloutEventTest {
             assertThat(projectId).isEqualTo(DEFAULT_PROJECT_ID)
             assertThat(selectedGuid).isEqualTo(GUID1)
             assertThat(sessionId).isEqualTo(GUID2)
+            assertThat(metadata).isEqualTo(DEFAULT_METADATA)
         }
     }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1065)
Will be released in: **2025.2.0**

### Notable changes

* The `ConfirmationCalloutEventV3` class now contains `metadata: String?` field 
* This field already exists in the confirmation callout request, and now is passed to the event
* The `metadata` field is now also passed to the BFSID

### Testing guidance

* Send the `metadata=test` field for the `com.simprints.id.CONFIRM_IDENTITY` request. Use the `Custom Intent` screen within the Intent Launcher app for that.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Test cases in Testiny are up to date ([ticket](https://app.testiny.io/SID/testcases/tcf/41/tc/259))
* [x] Other teams notified about the changes (BFSID on dev is ready)
