### PR TITLE
Disable file log writer on per-oreo Android versions

### DIFF
--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/overview/OverviewFragment.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/overview/OverviewFragment.kt
@@ -1,9 +1,11 @@
 package com.simprints.feature.troubleshooting.overview
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.core.content.FileProvider
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.simprints.feature.troubleshooting.R
@@ -68,6 +70,9 @@ internal class OverviewFragment : Fragment(R.layout.fragment_troubleshooting_ove
         binding.troubleshootOverviewPing.setOnClickListener {
             viewModel.pingServer()
         }
+
+        // Log export is only Available starting from Android 8
+        binding.troubleshootOverviewExportLogsBlock.isVisible = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
         binding.troubleshootOverviewExportLogs.setOnClickListener { v ->
             viewModel.exportLogs()
         }

--- a/feature/troubleshooting/src/main/res/layout/fragment_troubleshooting_overview.xml
+++ b/feature/troubleshooting/src/main/res/layout/fragment_troubleshooting_overview.xml
@@ -127,6 +127,7 @@
             android:textIsSelectable="true" />
 
         <LinearLayout
+            android:id="@+id/troubleshootOverviewExportLogsBlock"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginVertical="16dp"


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1060)
Will be released in: **2025.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.1.0**

* Log writer internally references Java 8 time API which is only available starting from Android 8. This causes NoClassDefFoundError exception on app start.

### Notable changes

* Only initialise the log writer starting from Android 8 (API 26)

### Testing guidance

* Install the release build of the app on Android 7 device - it should work, file logs should not be available.
* Do the same on Android 8 - file logs should be available.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
