### PR TITLE
Hide DB info from troubleshooting screen when user isn't logged in

### DIFF
--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/recordsmigration/RealmToRoomRecordsMigrationViewModel.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/recordsmigration/RealmToRoomRecordsMigrationViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.simprints.feature.troubleshooting.adapter.TroubleshootingItemViewData
+import com.simprints.infra.authstore.AuthStore
 import com.simprints.infra.enrolment.records.repository.EnrolmentRecordRepository
 import com.simprints.infra.enrolment.records.repository.local.migration.RealmToRoomMigrationFlagsStore
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -15,6 +16,7 @@ import javax.inject.Inject
 internal class RealmToRoomRecordsMigrationViewModel @Inject constructor(
     private val flagStore: RealmToRoomMigrationFlagsStore,
     private val enrolmentRecordRepository: EnrolmentRecordRepository,
+    private val authStore: AuthStore,
 ) : ViewModel() {
     private val _logs = MutableLiveData<List<TroubleshootingItemViewData>>(emptyList())
     val logs: LiveData<List<TroubleshootingItemViewData>>
@@ -30,7 +32,11 @@ internal class RealmToRoomRecordsMigrationViewModel @Inject constructor(
                     ),
                     TroubleshootingItemViewData(
                         title = "Local db info",
-                        body = enrolmentRecordRepository.getLocalDBInfo(),
+                        body = if (authStore.signedInProjectId.isNotEmpty()) {
+                            enrolmentRecordRepository.getLocalDBInfo()
+                        } else {
+                            "No local db info available for logged out users."
+                        },
                     ),
                 ),
             )

--- a/infra/logging/src/main/java/com/simprints/infra/logging/ExcludedFromGeneratedTestCoverageReports.kt
+++ b/infra/logging/src/main/java/com/simprints/infra/logging/ExcludedFromGeneratedTestCoverageReports.kt
@@ -1,0 +1,6 @@
+package com.simprints.infra.logging
+
+@Retention(AnnotationRetention.BINARY)
+annotation class ExcludedFromGeneratedTestCoverageReports(
+    val reason: String,
+)

--- a/infra/logging/src/main/java/com/simprints/infra/logging/SimberBuilder.kt
+++ b/infra/logging/src/main/java/com/simprints/infra/logging/SimberBuilder.kt
@@ -11,6 +11,7 @@ import com.simprints.infra.logging.writers.AnalyticsPropertyLogWriter
 import com.simprints.infra.logging.writers.CrashlyticsLogWriter
 import com.simprints.infra.logging.writers.FileLogWriter
 
+@ExcludedFromGeneratedTestCoverageReports("it is impossible to mockk the build types")
 object SimberBuilder {
     /**
      * Initializes the Simber logging framework with appropriate writers and severity based on build type.


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1069)
Will be released in: **2025.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.2.0**

* Try to access the troubleshooting screen before login the app will crash as the database is not yet initialized. 

### Notable changes

* There’s no longer a need to check the database migration status before login, as it depends heavily on the specific project. 

### Testing guidance

* Describe how the reviewers can verify that issue is fixed

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
