### PR TITLE
Do not keep sessions if project is paused or ended

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/usecases/DeleteSessionEventsIfNeededUseCase.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/usecases/DeleteSessionEventsIfNeededUseCase.kt
@@ -1,6 +1,8 @@
 package com.simprints.feature.clientapi.usecases
 
 import com.simprints.core.SessionCoroutineScope
+import com.simprints.infra.authstore.AuthStore
+import com.simprints.infra.config.store.models.ProjectState
 import com.simprints.infra.config.store.models.canSyncDataToSimprints
 import com.simprints.infra.config.sync.ConfigManager
 import com.simprints.infra.events.EventRepository
@@ -9,12 +11,16 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 internal class DeleteSessionEventsIfNeededUseCase @Inject constructor(
+    private val authStore: AuthStore,
     private val configManager: ConfigManager,
     private val eventRepository: EventRepository,
     @SessionCoroutineScope private val sessionCoroutineScope: CoroutineScope,
 ) {
     operator fun invoke(sessionId: String) = sessionCoroutineScope.launch {
-        if (!configManager.getProjectConfiguration().canSyncDataToSimprints()) {
+        val projectNotRunning = configManager.getProject(authStore.signedInProjectId).state != ProjectState.RUNNING
+        val simprintsDataSyncDisabled = !configManager.getProjectConfiguration().canSyncDataToSimprints()
+
+        if (simprintsDataSyncDisabled || projectNotRunning) {
             eventRepository.deleteEventScope(sessionId)
         }
     }


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2025.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.2.0?**

* When the project is in ending or paused state, sessions are still being kep,t which can result in an "alert-only" session being uploaded on the final sync attempt from the device.

### Notable changes

* When returning error response from the app, delete any session events if the project is not in the RUNNING state.

### Testing guidance

* Create a project, create some sessions, mark the project as ending, update the config on the device, but do not up-sync the data. 
* Try running some workflows and wait until the upsync.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
