### PR TITLE
MS-976 Close event scope after down-syncing a single subject

### DIFF
--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManagerImpl.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManagerImpl.kt
@@ -9,6 +9,7 @@ import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.ProjectConfiguration
 import com.simprints.infra.events.EventRepository
 import com.simprints.infra.events.event.domain.models.EventType
+import com.simprints.infra.events.event.domain.models.scope.EventScopeEndCause
 import com.simprints.infra.events.event.domain.models.scope.EventScopeType
 import com.simprints.infra.eventsync.event.remote.EventRemoteDataSource
 import com.simprints.infra.eventsync.status.down.EventDownSyncScopeRepository
@@ -101,6 +102,7 @@ internal class EventSyncManagerImpl @Inject constructor(
             ),
         )
         downSyncTask.downSync(this, op, eventScope, configRepository.getProject()).toList()
+        eventRepository.closeEventScope(eventScope, EventScopeEndCause.WORKFLOW_ENDED)
     }
 
     private fun getProjectModes(projectConfiguration: ProjectConfiguration) = projectConfiguration.general.modalities.map { it.toMode() }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorker.kt
@@ -97,6 +97,11 @@ class EventSyncMasterWorker @AssistedInject internal constructor(
                 }
 
                 if (configuration.isEventDownSyncAllowed()) {
+                    // TODO: Remove after all users have updated to 2025.3.0
+                    // In versions before 2025.3.0 a bug prevented single subject down-sync scopes from being closed and uploaded.
+                    // Attempting to close any such scopes and recover at least some of the data.
+                    eventRepository.closeAllOpenScopes(EventScopeType.DOWN_SYNC, null)
+
                     eventRepository.createEventScope(
                         EventScopeType.DOWN_SYNC,
                         downSyncWorkerScopeId,

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/EventSyncManagerTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/EventSyncManagerTest.kt
@@ -157,6 +157,7 @@ internal class EventSyncManagerTest {
         eventSyncManagerImpl.downSyncSubject(DEFAULT_PROJECT_ID, "subjectId")
 
         coVerify { downSyncTask.downSync(any(), any(), eventScope, any()) }
+        coVerify { eventRepository.closeEventScope(eventScope, any()) }
     }
 
     @Test


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-976)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2024.1.0**

* There was a discrepancy in the number of requests and upsynced events for those requests.
* Turns out we forgot to properly close event scopes. 

### Notable changes

* Added scope closing after subject request.
* Also force-close all existing down sync in the worker before creating a new one.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
