### PR TITLE
Add AI exclusions file according to best practices

### DIFF
--- a/.aiexclude
+++ b/.aiexclude
@@ -1,0 +1,28 @@
+# Exclude all build outputs
+**/build/**
+.kotlin/
+# NDK build outputs
+**/.cxx/**
+**/.cxx_parts/**
+
+
+# Exclude dependency caches and wrappers
+.gradle/
+gradle/wrapper/gradle-wrapper.jar
+**/libs/**
+**/vendor/**
+
+# Exclude IDE-specific files and folders
+.idea/
+*.iml
+*.ipr
+*.iws
+.gradle/
+.DS_Store # macOS specific
+
+# Exclude local configuration files
+local.properties
+signing_info.gradle.kts
+*.keystore
+*.jks
+google-services.json


### PR DESCRIPTION
* According to the Gemini doc, this file works similarly to gitignore, but for the AI code generators ingesting the contents of the repo.
* This is something we should have done before any bots on the code, but better later than never.
