### PR TITLE
[MS-1091] Handle fetching specific caseIds from CommCare

### DIFF
--- a/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/FetchSubjectContract.kt
+++ b/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/FetchSubjectContract.kt
@@ -6,5 +6,6 @@ object FetchSubjectContract {
     fun getParams(
         projectId: String,
         subjectId: String,
-    ) = FetchSubjectParams(projectId, subjectId)
+        metadata: String,
+    ) = FetchSubjectParams(projectId, subjectId, metadata)
 }

--- a/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/FetchSubjectParams.kt
+++ b/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/FetchSubjectParams.kt
@@ -7,4 +7,5 @@ import com.simprints.core.domain.step.StepParams
 data class FetchSubjectParams(
     val projectId: String,
     val subjectId: String,
+    val metadata: String,
 ) : StepParams

--- a/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/screen/FetchSubjectFragment.kt
+++ b/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/screen/FetchSubjectFragment.kt
@@ -44,7 +44,7 @@ internal class FetchSubjectFragment : Fragment(R.layout.fragment_subject_fetch) 
             state?.getContentIfNotHandled()?.let(::handleFetchState)
         }
 
-        viewModel.onViewCreated(params.projectId, params.subjectId)
+        viewModel.onViewCreated(params.projectId, params.subjectId, params.metadata)
     }
 
     private fun handleAlertResult(alertResult: AlertResult) {
@@ -59,7 +59,7 @@ internal class FetchSubjectFragment : Fragment(R.layout.fragment_subject_fetch) 
     }
 
     private fun tryFetchSubject() {
-        viewModel.fetchSubject(params.projectId, params.subjectId)
+        viewModel.fetchSubject(params.projectId, params.subjectId, params.metadata)
     }
 
     private fun handleFetchState(state: FetchSubjectState) = when (state) {

--- a/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/screen/FetchSubjectViewModel.kt
+++ b/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/screen/FetchSubjectViewModel.kt
@@ -27,20 +27,22 @@ internal class FetchSubjectViewModel @Inject constructor(
     fun onViewCreated(
         projectId: String,
         subjectId: String,
+        metadata: String,
     ) {
         if (!fetchWasAttempted) {
-            fetchSubject(projectId, subjectId)
+            fetchSubject(projectId, subjectId, metadata)
         }
     }
 
     fun fetchSubject(
         projectId: String,
         subjectId: String,
+        metadata: String,
     ) {
         viewModelScope.launch {
             fetchWasAttempted = true
             val subjectFetchStartTime = timeHelper.now()
-            val subjectState = fetchSubjectUseCase(projectId, subjectId)
+            val subjectState = fetchSubjectUseCase(projectId, subjectId, metadata)
 
             _subjectState.send(subjectState)
 

--- a/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/screen/usecase/FetchSubjectUseCase.kt
+++ b/feature/fetch-subject/src/main/java/com/simprints/feature/fetchsubject/screen/usecase/FetchSubjectUseCase.kt
@@ -16,6 +16,7 @@ internal class FetchSubjectUseCase @Inject constructor(
     suspend operator fun invoke(
         projectId: String,
         subjectId: String,
+        metadata: String,
     ): FetchSubjectState {
         Simber.d("Fetching $subjectId", tag = TAG)
         try {
@@ -25,7 +26,7 @@ internal class FetchSubjectUseCase @Inject constructor(
                 return FetchSubjectState.FoundLocal
             }
 
-            eventSyncManager.downSyncSubject(projectId, subjectId)
+            eventSyncManager.downSyncSubject(projectId, subjectId, metadata)
             Simber.d("Network request done", tag = TAG)
 
             val remoteSubject = loadFromDatabase(projectId, subjectId)

--- a/feature/fetch-subject/src/test/java/com/simprints/feature/fetchsubject/screen/FetchSubjectViewModelTest.kt
+++ b/feature/fetch-subject/src/test/java/com/simprints/feature/fetchsubject/screen/FetchSubjectViewModelTest.kt
@@ -52,41 +52,41 @@ internal class FetchSubjectViewModelTest {
 
     @Test
     fun `tries fetching subject`() = runTest {
-        coEvery { fetchSubjectUseCase.invoke(any(), any()) } returns FetchSubjectState.NotFound
+        coEvery { fetchSubjectUseCase.invoke(any(), any(), METADATA) } returns FetchSubjectState.NotFound
 
-        viewModel.fetchSubject(PROJECT_ID, SUBJECT_ID)
+        viewModel.fetchSubject(PROJECT_ID, SUBJECT_ID, METADATA)
         val result = viewModel.subjectState.test()
 
         assertThat(result.value().getContentIfNotHandled()).isNotNull()
-        coVerify { fetchSubjectUseCase.invoke(any(), any()) }
+        coVerify { fetchSubjectUseCase.invoke(any(), any(), METADATA) }
     }
 
     @Test
     fun `onViewCreated tries fetching subject when it wasn't attempted yet`() = runTest {
-        coEvery { fetchSubjectUseCase.invoke(any(), any()) } returns FetchSubjectState.NotFound
+        coEvery { fetchSubjectUseCase.invoke(any(), any(), METADATA) } returns FetchSubjectState.NotFound
 
-        viewModel.onViewCreated(PROJECT_ID, SUBJECT_ID)
+        viewModel.onViewCreated(PROJECT_ID, SUBJECT_ID, METADATA)
         val result = viewModel.subjectState.test()
 
         assertThat(result.value().getContentIfNotHandled()).isNotNull()
-        coVerify { fetchSubjectUseCase.invoke(any(), any()) }
+        coVerify { fetchSubjectUseCase.invoke(any(), any(), METADATA) }
     }
 
     @Test
     fun `onViewCreated doesn't try fetching subject when it was already attempted`() = runTest {
-        coEvery { fetchSubjectUseCase.invoke(any(), any()) } returns FetchSubjectState.NotFound
+        coEvery { fetchSubjectUseCase.invoke(any(), any(), METADATA) } returns FetchSubjectState.NotFound
 
-        viewModel.onViewCreated(PROJECT_ID, SUBJECT_ID)
-        viewModel.onViewCreated(PROJECT_ID, SUBJECT_ID)
+        viewModel.onViewCreated(PROJECT_ID, SUBJECT_ID, METADATA)
+        viewModel.onViewCreated(PROJECT_ID, SUBJECT_ID, METADATA)
 
-        coVerify(exactly = 1) { fetchSubjectUseCase.invoke(any(), any()) }
+        coVerify(exactly = 1) { fetchSubjectUseCase.invoke(any(), any(), METADATA) }
     }
 
     @Test
     fun `saves event after fetching subject`() = runTest {
-        coEvery { fetchSubjectUseCase.invoke(any(), any()) } returns FetchSubjectState.NotFound
+        coEvery { fetchSubjectUseCase.invoke(any(), any(), METADATA) } returns FetchSubjectState.NotFound
 
-        viewModel.fetchSubject(PROJECT_ID, SUBJECT_ID)
+        viewModel.fetchSubject(PROJECT_ID, SUBJECT_ID, METADATA)
 
         coVerify { saveSubjectFetchEventUseCase.invoke(any(), any(), any(), any()) }
     }
@@ -103,5 +103,7 @@ internal class FetchSubjectViewModelTest {
         private val TIMESTAMP = Timestamp(1L)
         private const val PROJECT_ID = "projectId"
         private const val SUBJECT_ID = "subjectId"
+
+        private const val METADATA = "metadata"
     }
 }

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCase.kt
@@ -79,6 +79,7 @@ internal class BuildStepsUseCase @Inject constructor(
                 subjectId = action.verifyGuid,
                 biometricDataSource = action.biometricDataSource,
                 callerPackageName = action.actionIdentifier.callerPackageName,
+                metadata = action.metadata,
             ),
             buildConsentStepIfNeeded(ConsentType.VERIFY, projectConfiguration),
             buildCaptureAndMatchStepsForVerify(action, projectConfiguration),
@@ -238,6 +239,7 @@ internal class BuildStepsUseCase @Inject constructor(
         subjectId: String,
         biometricDataSource: String,
         callerPackageName: String,
+        metadata: String,
     ) = when (
         BiometricDataSource.fromString(
             value = biometricDataSource,
@@ -249,7 +251,7 @@ internal class BuildStepsUseCase @Inject constructor(
                 id = StepId.FETCH_GUID,
                 navigationActionId = R.id.action_orchestratorFragment_to_fetchSubject,
                 destinationId = FetchSubjectContract.DESTINATION,
-                params = FetchSubjectContract.getParams(projectId, subjectId),
+                params = FetchSubjectContract.getParams(projectId, subjectId, metadata),
             ),
         )
 

--- a/infra/core/src/main/java/com/simprints/core/tools/utils/ExtractCommCareCaseIdUseCase.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/utils/ExtractCommCareCaseIdUseCase.kt
@@ -1,0 +1,18 @@
+package com.simprints.core.tools.utils
+
+import com.simprints.core.tools.json.JsonHelper
+import javax.inject.Inject
+
+class ExtractCommCareCaseIdUseCase @Inject constructor() {
+    operator fun invoke(metadata: String?): String? = metadata?.takeUnless { it.isBlank() }?.let {
+        try {
+            JsonHelper.fromJson<Map<String, Any>>(it)[ARG_CASE_ID] as? String
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    companion object {
+        private const val ARG_CASE_ID = "caseId"
+    }
+}

--- a/infra/core/src/test/java/com/simprints/core/tools/utils/ExtractCommCareCaseIdUseCaseTest.kt
+++ b/infra/core/src/test/java/com/simprints/core/tools/utils/ExtractCommCareCaseIdUseCaseTest.kt
@@ -1,0 +1,86 @@
+package com.simprints.core.tools.utils
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ExtractCommCareCaseIdUseCaseTest {
+    private val useCase = ExtractCommCareCaseIdUseCase()
+
+    @Test
+    fun `returns null when metadata is null`() {
+        val result = useCase(null)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null when metadata is empty`() {
+        val result = useCase("")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null when metadata is blank`() {
+        val result = useCase(" ")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null when metadata is invalid JSON`() {
+        val result = useCase("invalid json")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null when metadata doesn't contain caseId`() {
+        val metadata = """{"otherField": "value"}"""
+        val result = useCase(metadata)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns null when caseId is not a string`() {
+        val metadata = """{"caseId": 123}"""
+        val result = useCase(metadata)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns caseId when metadata contains valid caseId string`() {
+        val expectedCaseId = "case-123-abc"
+        val metadata = """{"caseId": "$expectedCaseId"}"""
+        val result = useCase(metadata)
+
+        assertThat(result).isEqualTo(expectedCaseId)
+    }
+
+    @Test
+    fun `returns caseId when metadata contains valid caseId with other fields`() {
+        val expectedCaseId = "case-456-def"
+        val metadata = """{"caseId": "$expectedCaseId", "otherField": "value", "number": 42}"""
+        val result = useCase(metadata)
+
+        assertThat(result).isEqualTo(expectedCaseId)
+    }
+
+    @Test
+    fun `returns empty string when caseId is empty string in JSON`() {
+        val metadata = """{"caseId": ""}"""
+        val result = useCase(metadata)
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `handles malformed JSON gracefully`() {
+        val malformedJson = """{"caseId": "test", "incomplete": }"""
+        val result = useCase(malformedJson)
+
+        assertThat(result).isNull()
+    }
+}

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/EnrolmentRecordsStoreModule.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/EnrolmentRecordsStoreModule.kt
@@ -5,6 +5,7 @@ import com.simprints.core.AvailableProcessors
 import com.simprints.core.DispatcherIO
 import com.simprints.core.tools.json.JsonHelper
 import com.simprints.core.tools.utils.EncodingUtils
+import com.simprints.core.tools.utils.ExtractCommCareCaseIdUseCase
 import com.simprints.infra.enrolment.records.repository.commcare.CommCareIdentityDataSource
 import com.simprints.infra.enrolment.records.repository.remote.EnrolmentRecordRemoteDataSource
 import com.simprints.infra.enrolment.records.repository.remote.EnrolmentRecordRemoteDataSourceImpl
@@ -41,6 +42,7 @@ class IdentityDataSourceModule {
         encoder: EncodingUtils,
         jsonHelper: JsonHelper,
         compareImplicitTokenizedStringsUseCase: CompareImplicitTokenizedStringsUseCase,
+        extractCommCareCaseIdUseCase: ExtractCommCareCaseIdUseCase,
         @AvailableProcessors availableProcessors: Int,
         @ApplicationContext context: Context,
         @DispatcherIO dispatcher: CoroutineDispatcher,
@@ -48,6 +50,7 @@ class IdentityDataSourceModule {
         encoder = encoder,
         jsonHelper = jsonHelper,
         compareImplicitTokenizedStringsUseCase = compareImplicitTokenizedStringsUseCase,
+        extractCommCareCaseId = extractCommCareCaseIdUseCase,
         availableProcessors = availableProcessors,
         context = context,
         dispatcher = dispatcher,

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/commcare/CommCareIdentityDataSource.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/commcare/CommCareIdentityDataSource.kt
@@ -15,6 +15,7 @@ import com.simprints.core.domain.tokenization.serialization.TokenizationClassNam
 import com.simprints.core.domain.tokenization.serialization.TokenizationClassNameSerializer
 import com.simprints.core.tools.json.JsonHelper
 import com.simprints.core.tools.utils.EncodingUtils
+import com.simprints.core.tools.utils.ExtractCommCareCaseIdUseCase
 import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.config.store.models.TokenKeyType
 import com.simprints.infra.enrolment.records.repository.IdentityDataSource
@@ -41,13 +42,13 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
-import org.json.JSONException
 import javax.inject.Inject
 
 internal class CommCareIdentityDataSource @Inject constructor(
     private val encoder: EncodingUtils,
     private val jsonHelper: JsonHelper,
     private val compareImplicitTokenizedStringsUseCase: CompareImplicitTokenizedStringsUseCase,
+    private val extractCommCareCaseId: ExtractCommCareCaseIdUseCase,
     @AvailableProcessors private val availableProcessors: Int,
     @ApplicationContext private val context: Context,
     @DispatcherBG private val dispatcher: CoroutineDispatcher,
@@ -91,7 +92,7 @@ internal class CommCareIdentityDataSource @Inject constructor(
     ): List<EnrolmentRecordCreationEvent> {
         val enrolmentRecordCreationEvents: MutableList<EnrolmentRecordCreationEvent> = mutableListOf()
         try {
-            val caseId = attemptExtractingCaseId(query.metadata)
+            val caseId = extractCommCareCaseId(query.metadata)
             if (caseId != null) {
                 return loadEnrolmentRecordCreationEvents(caseId, callerPackageName, query, project)
             }
@@ -120,14 +121,6 @@ internal class CommCareIdentityDataSource @Inject constructor(
         }
 
         return enrolmentRecordCreationEvents
-    }
-
-    private fun attemptExtractingCaseId(metadata: String?) = metadata?.takeUnless { it.isEmpty() }?.let {
-        try {
-            JsonHelper.fromJson<Map<String, Any>>(it)[ARG_CASE_ID] as? String
-        } catch (_: JSONException) {
-            null
-        }
     }
 
     private suspend fun loadFaceIdentities(
@@ -332,6 +325,5 @@ internal class CommCareIdentityDataSource @Inject constructor(
         const val COLUMN_CASE_ID = "case_id"
         const val COLUMN_DATUM_ID = "datum_id"
         const val COLUMN_VALUE = "value"
-        const val ARG_CASE_ID = "caseId"
     }
 }

--- a/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/commcare/CommCareIdentityDataSourceTest.kt
+++ b/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/commcare/CommCareIdentityDataSourceTest.kt
@@ -11,6 +11,7 @@ import com.simprints.core.domain.fingerprint.IFingerIdentifier.LEFT_THUMB
 import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.core.tools.json.JsonHelper
 import com.simprints.core.tools.utils.EncodingUtils
+import com.simprints.core.tools.utils.ExtractCommCareCaseIdUseCase
 import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.enrolment.records.repository.commcare.CommCareIdentityDataSource.Companion.COLUMN_DATUM_ID
 import com.simprints.infra.enrolment.records.repository.commcare.CommCareIdentityDataSource.Companion.COLUMN_VALUE
@@ -153,6 +154,9 @@ class CommCareIdentityDataSourceTest {
     @MockK
     private lateinit var useCase: CompareImplicitTokenizedStringsUseCase
 
+    @MockK
+    private lateinit var extractCommCareCaseIdUseCase: ExtractCommCareCaseIdUseCase
+
     private lateinit var mockMetadataCursor: Cursor
 
     private lateinit var mockDataCursor: Cursor
@@ -202,11 +206,13 @@ class CommCareIdentityDataSourceTest {
 
         every { encoder.base64ToBytes(any()) } returns byteArrayOf()
         every { useCase.invoke(any(), any(), any(), any()) } returns true
+        every { extractCommCareCaseIdUseCase.invoke(any()) } returns null
 
         dataSource = CommCareIdentityDataSource(
             encoder,
             JsonHelper,
             useCase,
+            extractCommCareCaseIdUseCase,
             4,
             context,
             testCoroutineRule.testCoroutineDispatcher,

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManager.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/EventSyncManager.kt
@@ -27,6 +27,7 @@ interface EventSyncManager {
     suspend fun downSyncSubject(
         projectId: String,
         subjectId: String,
+        metadata: String,
     )
 
     suspend fun deleteModules(unselectedModules: List<String>)

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/status/down/domain/RemoteEventQuery.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/status/down/domain/RemoteEventQuery.kt
@@ -11,6 +11,7 @@ internal data class RemoteEventQuery(
     val moduleId: String? = null,
     val subjectId: String? = null,
     val lastEventId: String? = null,
+    val externalIds: List<String>? = null,
     val modes: List<Modes>,
 ) {
     internal fun fromDomainToApi() = ApiRemoteEventQuery(

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/CommCareEventSyncTask.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/down/tasks/CommCareEventSyncTask.kt
@@ -23,20 +23,20 @@ internal class CommCareEventSyncTask @Inject constructor(
     eventRepository: EventRepository,
     private val commCareEventDataSource: CommCareEventDataSource,
 ) : BaseEventDownSyncTask(
-    enrolmentRecordRepository,
-    eventDownSyncScopeRepository,
-    subjectFactory,
-    configManager,
-    timeHelper,
-    eventRepository,
-) {
+        enrolmentRecordRepository,
+        eventDownSyncScopeRepository,
+        subjectFactory,
+        configManager,
+        timeHelper,
+        eventRepository,
+    ) {
     override suspend fun fetchEvents(
         operation: EventDownSyncOperation,
         scope: CoroutineScope,
         requestId: String,
     ): EventFetchResult {
         Simber.i("CommCareEventSyncTask started", tag = COMMCARE_SYNC)
-        val result = commCareEventDataSource.getEvents()
+        val result = commCareEventDataSource.getEvents(operation.queryEvent)
 
         return EventFetchResult(
             eventFlow = result.eventFlow,
@@ -50,6 +50,5 @@ internal class CommCareEventSyncTask @Inject constructor(
     }
 
     // Override to track subject IDs present in CommCare and update CommCareSyncCache
-    override suspend fun onEventsProcessed(events: List<EnrolmentRecordEvent>) =
-        commCareEventDataSource.onEventsProcessed(events)
+    override suspend fun onEventsProcessed(events: List<EnrolmentRecordEvent>) = commCareEventDataSource.onEventsProcessed(events)
 }

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/EventSyncManagerTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/EventSyncManagerTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.common.Partitioning
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
+import com.simprints.core.tools.utils.ExtractCommCareCaseIdUseCase
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.events.EventRepository
@@ -21,6 +22,7 @@ import com.simprints.infra.eventsync.status.models.DownSyncCounts
 import com.simprints.infra.eventsync.status.up.EventUpSyncScopeRepository
 import com.simprints.infra.eventsync.sync.EventSyncStateProcessor
 import com.simprints.infra.eventsync.sync.common.EventSyncCache
+import com.simprints.infra.eventsync.sync.down.tasks.CommCareEventSyncTask
 import com.simprints.infra.eventsync.sync.down.tasks.SimprintsEventDownSyncTask
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import io.mockk.MockKAnnotations
@@ -65,7 +67,10 @@ internal class EventSyncManagerTest {
     lateinit var eventRepository: EventRepository
 
     @MockK
-    lateinit var downSyncTask: SimprintsEventDownSyncTask
+    lateinit var simprintsDownSyncTask: SimprintsEventDownSyncTask
+
+    @MockK
+    lateinit var commCareDownSyncTask: CommCareEventSyncTask
 
     @MockK
     lateinit var eventRemoteDataSource: EventRemoteDataSource
@@ -79,6 +84,9 @@ internal class EventSyncManagerTest {
     @MockK
     lateinit var project: Project
 
+    @MockK
+    lateinit var extractCommCareCaseIdUseCase: ExtractCommCareCaseIdUseCase
+
     private lateinit var eventSyncManagerImpl: EventSyncManagerImpl
 
     @Before
@@ -89,7 +97,9 @@ internal class EventSyncManagerTest {
         coEvery { configRepository.getProjectConfiguration() } returns mockk {
             every { general.modalities } returns listOf()
             every {
-                synchronization.down.simprints?.partitionType?.toDomain()
+                synchronization.down.simprints
+                    ?.partitionType
+                    ?.toDomain()
             } returns Partitioning.MODULE
         }
 
@@ -101,9 +111,11 @@ internal class EventSyncManagerTest {
             upSyncScopeRepo = eventUpSyncScopeRepository,
             eventSyncCache = eventSyncCache,
             commCareSyncCache = commCareSyncCache,
-            simprintsDownSyncTask = downSyncTask,
+            simprintsDownSyncTask = simprintsDownSyncTask,
+            commCareSyncTask = commCareDownSyncTask,
             eventRemoteDataSource = eventRemoteDataSource,
             configRepository = configRepository,
+            extractCommCareCaseId = extractCommCareCaseIdUseCase,
             dispatcher = testCoroutineRule.testCoroutineDispatcher,
         )
     }
@@ -154,14 +166,98 @@ internal class EventSyncManagerTest {
     }
 
     @Test
-    fun `downSync should call down sync helper`() = runTest {
+    fun `downSyncSubject should call CommCare sync when CommCare config is present`() = runTest {
+        val metadata = """{"caseId": "case123"}"""
+        val expectedCaseId = "case123"
+
+        // Mock CommCare configuration
+        coEvery { configRepository.getProjectConfiguration() } returns mockk {
+            every { general.modalities } returns listOf()
+            every { synchronization.down.simprints } returns null
+            every { synchronization.down.commCare } returns mockk()
+        }
+        every { extractCommCareCaseIdUseCase.invoke(metadata) } returns expectedCaseId
         coEvery { eventRepository.createEventScope(any()) } returns eventScope
-        coEvery { downSyncTask.downSync(any(), any(), eventScope, any()) } returns emptyFlow()
+        coEvery { commCareDownSyncTask.downSync(any(), any(), eventScope, any()) } returns emptyFlow()
 
-        eventSyncManagerImpl.downSyncSubject(DEFAULT_PROJECT_ID, "subjectId")
+        eventSyncManagerImpl.downSyncSubject(DEFAULT_PROJECT_ID, "subjectId", metadata)
 
-        coVerify { downSyncTask.downSync(any(), any(), eventScope, any()) }
+        coVerify { extractCommCareCaseIdUseCase.invoke(metadata) }
+        coVerify {
+            commCareDownSyncTask.downSync(
+                any(),
+                match { operation ->
+                    operation.queryEvent.externalIds == listOf(expectedCaseId)
+                },
+                eventScope,
+                any(),
+            )
+        }
         coVerify { eventRepository.closeEventScope(eventScope, any()) }
+        coVerify(exactly = 0) { simprintsDownSyncTask.downSync(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `downSyncSubject should call CommCare sync with null externalIds when caseId is null`() = runTest {
+        val metadata = """{"otherField": "value"}"""
+
+        // Mock CommCare configuration
+        coEvery { configRepository.getProjectConfiguration() } returns mockk {
+            every { general.modalities } returns listOf()
+            every { synchronization.down.simprints } returns null
+            every { synchronization.down.commCare } returns mockk()
+        }
+        every { extractCommCareCaseIdUseCase.invoke(metadata) } returns null
+        coEvery { eventRepository.createEventScope(any()) } returns eventScope
+        coEvery { commCareDownSyncTask.downSync(any(), any(), eventScope, any()) } returns emptyFlow()
+
+        eventSyncManagerImpl.downSyncSubject(DEFAULT_PROJECT_ID, "subjectId", metadata)
+
+        coVerify { extractCommCareCaseIdUseCase.invoke(metadata) }
+        coVerify {
+            commCareDownSyncTask.downSync(
+                any(),
+                match { operation ->
+                    operation.queryEvent.externalIds == null
+                },
+                eventScope,
+                any(),
+            )
+        }
+        coVerify { eventRepository.closeEventScope(eventScope, any()) }
+        coVerify(exactly = 0) { simprintsDownSyncTask.downSync(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `downSyncSubject should call Simprints sync when Simprints config is present`() = runTest {
+        // Mock Simprints configuration (restore original config from setup)
+        coEvery { configRepository.getProjectConfiguration() } returns mockk {
+            every { general.modalities } returns listOf()
+            every { synchronization.down.simprints } returns mockk {
+                every { partitionType.toDomain() } returns Partitioning.MODULE
+            }
+            every { synchronization.down.commCare } returns null
+        }
+        coEvery { eventRepository.createEventScope(any()) } returns eventScope
+        coEvery { simprintsDownSyncTask.downSync(any(), any(), eventScope, any()) } returns emptyFlow()
+
+        eventSyncManagerImpl.downSyncSubject(DEFAULT_PROJECT_ID, "subjectId", "metadata")
+
+        coVerify {
+            simprintsDownSyncTask.downSync(
+                any(),
+                match { operation ->
+                    operation.queryEvent.subjectId == "subjectId" &&
+                        operation.queryEvent.projectId == DEFAULT_PROJECT_ID &&
+                        operation.queryEvent.externalIds == null
+                },
+                eventScope,
+                any(),
+            )
+        }
+        coVerify { eventRepository.closeEventScope(eventScope, any()) }
+        coVerify(exactly = 0) { commCareDownSyncTask.downSync(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { extractCommCareCaseIdUseCase.invoke(any()) }
     }
 
     @Test

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/commcare/CommCareEventDataSourceTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/commcare/CommCareEventDataSourceTest.kt
@@ -8,6 +8,7 @@ import com.simprints.core.tools.json.JsonHelper
 import com.simprints.infra.config.store.LastCallingPackageStore
 import com.simprints.infra.events.event.domain.models.subject.EnrolmentRecordCreationEvent
 import com.simprints.infra.events.event.domain.models.subject.EnrolmentRecordDeletionEvent
+import com.simprints.infra.events.sampledata.SampleDefaults.DEFAULT_PROJECT_ID
 import com.simprints.infra.eventsync.event.commcare.CommCareEventDataSource.Companion.BATCH_SIZE
 import com.simprints.infra.eventsync.event.commcare.CommCareEventDataSource.Companion.COLUMN_CASE_ID
 import com.simprints.infra.eventsync.event.commcare.CommCareEventDataSource.Companion.COLUMN_DATUM_ID
@@ -15,6 +16,7 @@ import com.simprints.infra.eventsync.event.commcare.CommCareEventDataSource.Comp
 import com.simprints.infra.eventsync.event.commcare.CommCareEventDataSource.Companion.COLUMN_VALUE
 import com.simprints.infra.eventsync.event.commcare.cache.CommCareSyncCache
 import com.simprints.infra.eventsync.event.commcare.cache.SyncedCaseEntity
+import com.simprints.infra.eventsync.status.down.domain.RemoteEventQuery
 import com.simprints.infra.logging.LoggingConstants
 import com.simprints.infra.logging.Simber
 import com.simprints.libsimprints.Constants.SIMPRINTS_COSYNC_SUBJECT_ACTIONS
@@ -50,8 +52,11 @@ class CommCareEventDataSourceTest {
         private const val COLUMN_INDEX_CASE_ID = 2
         private const val COLUMN_INDEX_LAST_MODIFIED = 3
 
+        private val emptyEventQuery = RemoteEventQuery(projectId = DEFAULT_PROJECT_ID, modes = emptyList())
+
         // Helper to format date strings as CommCare does (using US locale to match Java's Date.toString())
         private val commCareDateFormat = SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US)
+
         private fun formatCommCareDate(millis: Long): String = commCareDateFormat.format(Date(millis))
 
         @JvmStatic
@@ -64,16 +69,21 @@ class CommCareEventDataSourceTest {
         lateinit var mockDataCaseIdUri: Uri
 
         @JvmStatic
+        lateinit var mockMetadataCaseIdUri: Uri
+
+        @JvmStatic
         @BeforeClass
         fun setupClass() {
             mockkObject(Simber)
             mockMetadataUri = mockk(relaxed = true)
             mockDataUri = mockk(relaxed = true)
             mockDataCaseIdUri = mockk(relaxed = true)
+            mockMetadataCaseIdUri = mockk(relaxed = true)
             mockkStatic(Uri::class)
             every { Uri.parse("content://$TEST_PACKAGE_NAME.case/casedb/case") } returns mockMetadataUri
             every { Uri.parse("content://$TEST_PACKAGE_NAME.case/casedb/data") } returns mockDataUri
             every { mockDataUri.buildUpon().appendPath(any()).build() } returns mockDataCaseIdUri
+            every { mockMetadataUri.buildUpon().appendPath(any()).build() } returns mockMetadataCaseIdUri
         }
 
         @JvmStatic
@@ -155,6 +165,16 @@ class CommCareEventDataSourceTest {
             )
         } returns mockDataCursor
 
+        every {
+            mockContentResolver.query(
+                mockMetadataCaseIdUri,
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns mockMetadataCursor
+
         dataSource = CommCareEventDataSource(
             JsonHelper,
             mockCommCareSyncCache,
@@ -172,11 +192,11 @@ class CommCareEventDataSourceTest {
         every { mockMetadataCursor.moveToNext() } returnsMany listOf(true, true, false)
         every { mockMetadataCursor.getString(COLUMN_INDEX_CASE_ID) } returnsMany listOf(caseId1, caseId2)
 
-        every { mockDataCursor.moveToNext() } returnsMany listOf(true, true, false) //datum_id, value for each case
+        every { mockDataCursor.moveToNext() } returnsMany listOf(true, true, false) // datum_id, value for each case
         every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
         every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returnsMany listOf(SUBJECT_ACTIONS_EVENT_1, SUBJECT_ACTIONS_EVENT_2)
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
 
         assertEquals(expectedCount, result.totalCount)
         val events = result.eventFlow.toList()
@@ -210,11 +230,11 @@ class CommCareEventDataSourceTest {
         // Setup previously synced cases
         val previouslySyncedCases = listOf(
             SyncedCaseEntity(caseIdPresent, "some_sid", 5000L),
-            SyncedCaseEntity(caseIdMissing, simprintsIdForMissingCase, 5000L)
+            SyncedCaseEntity(caseIdMissing, simprintsIdForMissingCase, 5000L),
         )
         coEvery { mockCommCareSyncCache.getAllSyncedCases() } returns previouslySyncedCases
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(1, result.totalCount)
@@ -237,11 +257,11 @@ class CommCareEventDataSourceTest {
 
         // Setup previously synced cases
         val previouslySyncedCases = listOf(
-            SyncedCaseEntity(caseIdMissing, simprintsIdForMissingCase, 5000L)
+            SyncedCaseEntity(caseIdMissing, simprintsIdForMissingCase, 5000L),
         )
         coEvery { mockCommCareSyncCache.getAllSyncedCases() } returns previouslySyncedCases
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(0, result.totalCount)
@@ -261,11 +281,11 @@ class CommCareEventDataSourceTest {
 
         // Setup previously synced case
         val previouslySyncedCases = listOf(
-            SyncedCaseEntity(caseId, "some_sid", lastSyncedTimestamp)
+            SyncedCaseEntity(caseId, "some_sid", lastSyncedTimestamp),
         )
         coEvery { mockCommCareSyncCache.getAllSyncedCases() } returns previouslySyncedCases
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(1, result.totalCount)
@@ -291,11 +311,11 @@ class CommCareEventDataSourceTest {
 
         // Setup previously synced case
         val previouslySyncedCases = listOf(
-            SyncedCaseEntity(caseId, "some_sid", lastSyncedTimestamp)
+            SyncedCaseEntity(caseId, "some_sid", lastSyncedTimestamp),
         )
         coEvery { mockCommCareSyncCache.getAllSyncedCases() } returns previouslySyncedCases
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(1, result.totalCount)
@@ -309,7 +329,7 @@ class CommCareEventDataSourceTest {
         val expectedCount = 5
         every { mockMetadataCursor.count } returns expectedCount
 
-        val result = dataSource.getEvents() // count is called internally
+        val result = dataSource.getEvents(emptyEventQuery) // count is called internally
 
         assertEquals(expectedCount, result.totalCount)
         verify { mockContentResolver.query(mockMetadataUri, null, null, null, null) }
@@ -327,18 +347,18 @@ class CommCareEventDataSourceTest {
             )
         } returns null
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
 
         assertEquals(0, result.totalCount)
         verify { mockContentResolver.query(mockMetadataUri, null, null, null, null) }
     }
 
     @Test
-    fun `loadDataFromCommCare handles empty case list`() = runTest {
+    fun `syncAllUpdatedCases handles empty case list`() = runTest {
         every { mockMetadataCursor.count } returns 0
         every { mockMetadataCursor.moveToNext() } returns false
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(0, result.totalCount)
@@ -347,12 +367,12 @@ class CommCareEventDataSourceTest {
     }
 
     @Test
-    fun `loadDataFromCommCare handles null case id`() = runTest {
+    fun `syncAllUpdatedCases handles null case id`() = runTest {
         every { mockMetadataCursor.count } returns 1
         every { mockMetadataCursor.moveToNext() } returnsMany listOf(true, false)
         every { mockMetadataCursor.getString(COLUMN_INDEX_CASE_ID) } returns null
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(1, result.totalCount)
@@ -361,12 +381,12 @@ class CommCareEventDataSourceTest {
     }
 
     @Test
-    fun `loadDataFromCommCare handles empty case id`() = runTest {
+    fun `syncAllUpdatedCases handles empty case id`() = runTest {
         every { mockMetadataCursor.count } returns 1
         every { mockMetadataCursor.moveToNext() } returnsMany listOf(true, false)
         every { mockMetadataCursor.getString(COLUMN_INDEX_CASE_ID) } returns ""
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(1, result.totalCount)
@@ -389,7 +409,7 @@ class CommCareEventDataSourceTest {
             )
         } returns null
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
 
         try {
             result.eventFlow.toList()
@@ -413,7 +433,7 @@ class CommCareEventDataSourceTest {
         every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returnsMany listOf("someOtherKey", "anotherKey")
         every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returnsMany listOf("someValue", "anotherValue")
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(1, result.totalCount)
@@ -432,7 +452,7 @@ class CommCareEventDataSourceTest {
         every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
         every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns INVALID_JSON
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(1, result.totalCount)
@@ -453,7 +473,7 @@ class CommCareEventDataSourceTest {
         every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
         every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns ""
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(1, result.totalCount)
@@ -463,7 +483,7 @@ class CommCareEventDataSourceTest {
     }
 
     @Test
-    fun `loadDataFromCommCare processes events in batches`() = runTest {
+    fun `syncAllUpdatedCases processes events in batches`() = runTest {
         val caseCount = BATCH_SIZE + 5
         every { mockMetadataCursor.count } returns caseCount
 
@@ -473,13 +493,13 @@ class CommCareEventDataSourceTest {
         every { mockMetadataCursor.getString(COLUMN_INDEX_CASE_ID) } returnsMany caseIds
 
         // Mock data cursor for each case, assuming one subjectActions per case
-        val moveNextResultsData = (1..caseCount).map { true } + List(caseCount) {false} // true then false for each caseId
+        val moveNextResultsData = (1..caseCount).map { true } + List(caseCount) { false } // true then false for each caseId
         every { mockDataCursor.moveToNext() } returnsMany moveNextResultsData
         every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
         val subjectActionsData = (1..caseCount).map { SUBJECT_ACTIONS_EVENT_1 }
         every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returnsMany subjectActionsData
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(caseCount, result.totalCount)
@@ -502,7 +522,7 @@ class CommCareEventDataSourceTest {
         every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
         every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns SUBJECT_ACTIONS_EVENT_1
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(1, result.totalCount)
@@ -522,7 +542,7 @@ class CommCareEventDataSourceTest {
         every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
         every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns SUBJECT_ACTIONS_EVENT_1
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(1, result.totalCount)
@@ -543,7 +563,7 @@ class CommCareEventDataSourceTest {
         every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
         every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns SUBJECT_ACTIONS_EVENT_1
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(1, result.totalCount)
@@ -568,7 +588,7 @@ class CommCareEventDataSourceTest {
         every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
         every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns SUBJECT_ACTIONS_EVENT_1
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         // Call onEventsProcessed with the collected events
@@ -579,9 +599,9 @@ class CommCareEventDataSourceTest {
             mockCommCareSyncCache.addSyncedCase(
                 match<SyncedCaseEntity> {
                     it.caseId == caseId &&
-                    it.simprintsId == subjectId &&
-                    it.lastSyncedTimestamp == lastModifiedTime
-                }
+                        it.simprintsId == subjectId &&
+                        it.lastSyncedTimestamp == lastModifiedTime
+                },
             )
         }
     }
@@ -604,11 +624,11 @@ class CommCareEventDataSourceTest {
         // Setup previously synced cases - one present in CommCare, one missing
         val previouslySyncedCases = listOf(
             SyncedCaseEntity(caseIdPresent, "some_sid", 5000L),
-            SyncedCaseEntity(caseIdMissing, simprintsIdForMissingCase, 5000L)
+            SyncedCaseEntity(caseIdMissing, simprintsIdForMissingCase, 5000L),
         )
         coEvery { mockCommCareSyncCache.getAllSyncedCases() } returns previouslySyncedCases
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         // Should have one creation event for present case and one deletion event for missing case
@@ -631,8 +651,8 @@ class CommCareEventDataSourceTest {
             mockCommCareSyncCache.addSyncedCase(
                 match<SyncedCaseEntity> {
                     it.caseId == caseIdPresent &&
-                    it.simprintsId == SUBJECT_ACTIONS_EVENT_1_SUBJECT_ID
-                }
+                        it.simprintsId == SUBJECT_ACTIONS_EVENT_1_SUBJECT_ID
+                },
             )
         }
     }
@@ -654,11 +674,11 @@ class CommCareEventDataSourceTest {
         // Setup previously synced cases - one present in CommCare, one missing with empty simprintsId
         val previouslySyncedCases = listOf(
             SyncedCaseEntity(caseIdPresent, "some_sid", 5000L),
-            SyncedCaseEntity(caseIdMissingWithEmptySimprints, "", 5000L) // Empty simprintsId
+            SyncedCaseEntity(caseIdMissingWithEmptySimprints, "", 5000L), // Empty simprintsId
         )
         coEvery { mockCommCareSyncCache.getAllSyncedCases() } returns previouslySyncedCases
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         // Should have one creation event for present case, no deletion event for missing case with empty simprintsId
@@ -691,7 +711,7 @@ class CommCareEventDataSourceTest {
         every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
         every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns "" // This will cause null parsing
 
-        val result = dataSource.getEvents()
+        val result = dataSource.getEvents(emptyEventQuery)
         val events = result.eventFlow.toList()
 
         assertEquals(1, result.totalCount)
@@ -702,9 +722,371 @@ class CommCareEventDataSourceTest {
             mockCommCareSyncCache.addSyncedCase(
                 match<SyncedCaseEntity> {
                     it.caseId == caseId &&
-                    it.simprintsId == "" &&
-                    it.lastSyncedTimestamp == lastModifiedTime
-                }
+                        it.simprintsId == "" &&
+                        it.lastSyncedTimestamp == lastModifiedTime
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `getEvents with externalIds syncs specific cases only`() = runTest {
+        val specificCaseIds = listOf("case123", "case456")
+        val queryWithExternalIds = RemoteEventQuery(
+            projectId = DEFAULT_PROJECT_ID,
+            modes = emptyList(),
+            externalIds = specificCaseIds,
+        )
+
+        // Create separate cursors for each case to simulate individual queries
+        val mockMetadataCursor1 = mockk<Cursor>(relaxed = true)
+        val mockMetadataCursor2 = mockk<Cursor>(relaxed = true)
+        val mockDataCursor1 = mockk<Cursor>(relaxed = true)
+        val mockDataCursor2 = mockk<Cursor>(relaxed = true)
+
+        // Mock metadata cursors for individual case queries
+        every { mockMetadataCursor1.moveToNext() } returnsMany listOf(true, false)
+        every { mockMetadataCursor1.getString(COLUMN_INDEX_LAST_MODIFIED) } returns formatCommCareDate(15000L)
+        every { mockMetadataCursor1.getColumnIndexOrThrow(COLUMN_LAST_MODIFIED) } returns COLUMN_INDEX_LAST_MODIFIED
+        every { mockMetadataCursor1.close() } just Runs
+
+        every { mockMetadataCursor2.moveToNext() } returnsMany listOf(true, false)
+        every { mockMetadataCursor2.getString(COLUMN_INDEX_LAST_MODIFIED) } returns formatCommCareDate(20000L)
+        every { mockMetadataCursor2.getColumnIndexOrThrow(COLUMN_LAST_MODIFIED) } returns COLUMN_INDEX_LAST_MODIFIED
+        every { mockMetadataCursor2.close() } just Runs
+
+        // Mock data cursors for individual case queries
+        every { mockDataCursor1.moveToNext() } returnsMany listOf(true, false)
+        every { mockDataCursor1.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
+        every { mockDataCursor1.getString(COLUMN_INDEX_VALUE) } returns SUBJECT_ACTIONS_EVENT_1
+        every { mockDataCursor1.getColumnIndexOrThrow(COLUMN_DATUM_ID) } returns COLUMN_INDEX_DATUM_ID
+        every { mockDataCursor1.getColumnIndexOrThrow(COLUMN_VALUE) } returns COLUMN_INDEX_VALUE
+        every { mockDataCursor1.close() } just Runs
+
+        every { mockDataCursor2.moveToNext() } returnsMany listOf(true, false)
+        every { mockDataCursor2.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
+        every { mockDataCursor2.getString(COLUMN_INDEX_VALUE) } returns SUBJECT_ACTIONS_EVENT_2
+        every { mockDataCursor2.getColumnIndexOrThrow(COLUMN_DATUM_ID) } returns COLUMN_INDEX_DATUM_ID
+        every { mockDataCursor2.getColumnIndexOrThrow(COLUMN_VALUE) } returns COLUMN_INDEX_VALUE
+        every { mockDataCursor2.close() } just Runs
+
+        // Override content resolver to return different cursors for different queries
+        every {
+            mockContentResolver.query(mockMetadataCaseIdUri, arrayOf(COLUMN_CASE_ID, COLUMN_LAST_MODIFIED), any(), any(), any())
+        } returnsMany listOf(mockMetadataCursor1, mockMetadataCursor2)
+
+        every {
+            mockContentResolver.query(mockDataCaseIdUri, any(), any(), any(), any())
+        } returnsMany listOf(mockDataCursor1, mockDataCursor2)
+
+        val result = dataSource.getEvents(queryWithExternalIds)
+        val events = result.eventFlow.toList()
+
+        assertEquals(specificCaseIds.size, result.totalCount)
+        assertEquals(2, events.size)
+        assertTrue(events.all { it is EnrolmentRecordCreationEvent })
+
+        // Verify specific case metadata queries were made
+        verify(
+            exactly = 2,
+        ) { mockContentResolver.query(mockMetadataCaseIdUri, arrayOf(COLUMN_CASE_ID, COLUMN_LAST_MODIFIED), any(), any(), any()) }
+        verify(exactly = 2) { mockContentResolver.query(mockDataCaseIdUri, any(), any(), any(), any()) }
+
+        // Verify general metadata query was NOT made (only for all cases sync)
+        verify(
+            exactly = 0,
+        ) { mockContentResolver.query(mockMetadataUri, arrayOf(COLUMN_CASE_ID, COLUMN_LAST_MODIFIED), any(), any(), any()) }
+    }
+
+    @Test
+    fun `getEvents with single externalId processes successfully`() = runTest {
+        val singleCaseId = "case789"
+        val queryWithSingleId = RemoteEventQuery(
+            projectId = DEFAULT_PROJECT_ID,
+            modes = emptyList(),
+            externalIds = listOf(singleCaseId),
+        )
+
+        // Mock metadata cursor for the single case
+        every { mockMetadataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockMetadataCursor.getString(COLUMN_INDEX_LAST_MODIFIED) } returns formatCommCareDate(12000L)
+
+        // Mock data cursor for subjectActions
+        every { mockDataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
+        every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns SUBJECT_ACTIONS_EVENT_1
+
+        val result = dataSource.getEvents(queryWithSingleId)
+        val events = result.eventFlow.toList()
+
+        assertEquals(1, result.totalCount)
+        assertEquals(1, events.size)
+        assertTrue(events[0] is EnrolmentRecordCreationEvent)
+
+        val event = events[0] as EnrolmentRecordCreationEvent
+        assertEquals(SUBJECT_ACTIONS_EVENT_1_SUBJECT_ID, event.payload.subjectId)
+
+        verify(
+            exactly = 1,
+        ) { mockContentResolver.query(mockMetadataCaseIdUri, arrayOf(COLUMN_CASE_ID, COLUMN_LAST_MODIFIED), any(), any(), any()) }
+        verify(exactly = 1) { mockContentResolver.query(mockDataCaseIdUri, any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `getEvents with empty externalIds list syncs all cases`() = runTest {
+        val queryWithEmptyExternalIds = RemoteEventQuery(
+            projectId = DEFAULT_PROJECT_ID,
+            modes = emptyList(),
+            externalIds = emptyList(),
+        )
+
+        // Mock general case sync behavior
+        every { mockMetadataCursor.count } returns 1
+        every { mockMetadataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockMetadataCursor.getString(COLUMN_INDEX_CASE_ID) } returns "case1"
+
+        every { mockDataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
+        every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns SUBJECT_ACTIONS_EVENT_1
+
+        val result = dataSource.getEvents(queryWithEmptyExternalIds)
+        val events = result.eventFlow.toList()
+
+        assertEquals(1, result.totalCount)
+        assertEquals(1, events.size)
+
+        // Should use syncAllUpdatedCases path (general metadata query)
+        verify { mockContentResolver.query(mockMetadataUri, arrayOf(COLUMN_CASE_ID, COLUMN_LAST_MODIFIED), any(), any(), any()) }
+        verify(exactly = 0) { mockContentResolver.query(mockMetadataCaseIdUri, any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `getEvents with null externalIds list syncs all cases`() = runTest {
+        val queryWithEmptyExternalIds = RemoteEventQuery(
+            projectId = DEFAULT_PROJECT_ID,
+            modes = emptyList(),
+            externalIds = null,
+        )
+
+        // Mock general case sync behavior
+        every { mockMetadataCursor.count } returns 1
+        every { mockMetadataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockMetadataCursor.getString(COLUMN_INDEX_CASE_ID) } returns "case1"
+
+        every { mockDataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
+        every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns SUBJECT_ACTIONS_EVENT_1
+
+        val result = dataSource.getEvents(queryWithEmptyExternalIds)
+        val events = result.eventFlow.toList()
+
+        assertEquals(1, result.totalCount)
+        assertEquals(1, events.size)
+
+        // Should use syncAllUpdatedCases path (general metadata query)
+        verify { mockContentResolver.query(mockMetadataUri, arrayOf(COLUMN_CASE_ID, COLUMN_LAST_MODIFIED), any(), any(), any()) }
+        verify(exactly = 0) { mockContentResolver.query(mockMetadataCaseIdUri, any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `syncSpecificCases handles case with no lastModified data`() = runTest {
+        val caseId = "case_no_metadata"
+        val queryWithExternalIds = RemoteEventQuery(
+            projectId = DEFAULT_PROJECT_ID,
+            modes = emptyList(),
+            externalIds = listOf(caseId),
+        )
+
+        // Mock metadata cursor returning no data (empty result set)
+        every { mockMetadataCursor.moveToNext() } returns false
+
+        // Mock data cursor for subjectActions (still should get called)
+        every { mockDataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
+        every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns SUBJECT_ACTIONS_EVENT_1
+
+        val result = dataSource.getEvents(queryWithExternalIds)
+        val events = result.eventFlow.toList()
+
+        assertEquals(1, result.totalCount) // Count is based on externalIds size
+        assertEquals(1, events.size) // Event still created with default timestamp (0L)
+
+        verify(
+            exactly = 1,
+        ) { mockContentResolver.query(mockMetadataCaseIdUri, arrayOf(COLUMN_CASE_ID, COLUMN_LAST_MODIFIED), any(), any(), any()) }
+        verify(exactly = 1) { mockContentResolver.query(mockDataCaseIdUri, any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `syncSpecificCases handles case with multiple lastModified entries`() = runTest {
+        val caseId = "case_multiple_metadata"
+        val queryWithExternalIds = RemoteEventQuery(
+            projectId = DEFAULT_PROJECT_ID,
+            modes = emptyList(),
+            externalIds = listOf(caseId),
+        )
+
+        // Mock metadata cursor returning multiple entries (should use last one)
+        every { mockMetadataCursor.moveToNext() } returnsMany listOf(true, true, false)
+        every { mockMetadataCursor.getString(COLUMN_INDEX_LAST_MODIFIED) } returnsMany listOf(
+            formatCommCareDate(10000L),
+            formatCommCareDate(20000L),
+        )
+
+        // Mock data cursor for subjectActions
+        every { mockDataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
+        every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns SUBJECT_ACTIONS_EVENT_1
+
+        val result = dataSource.getEvents(queryWithExternalIds)
+        val events = result.eventFlow.toList()
+
+        assertEquals(1, result.totalCount)
+        assertEquals(1, events.size)
+
+        verify(
+            exactly = 1,
+        ) { mockContentResolver.query(mockMetadataCaseIdUri, arrayOf(COLUMN_CASE_ID, COLUMN_LAST_MODIFIED), any(), any(), any()) }
+        verify(exactly = 1) { mockContentResolver.query(mockDataCaseIdUri, any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `syncSpecificCases handles case with invalid lastModified date`() = runTest {
+        val caseId = "case_invalid_date"
+        val queryWithExternalIds = RemoteEventQuery(
+            projectId = DEFAULT_PROJECT_ID,
+            modes = emptyList(),
+            externalIds = listOf(caseId),
+        )
+
+        // Mock metadata cursor with invalid date
+        every { mockMetadataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockMetadataCursor.getString(COLUMN_INDEX_LAST_MODIFIED) } returns "invalid date string"
+
+        // Mock data cursor for subjectActions
+        every { mockDataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
+        every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns SUBJECT_ACTIONS_EVENT_1
+
+        val result = dataSource.getEvents(queryWithExternalIds)
+        val events = result.eventFlow.toList()
+
+        assertEquals(1, result.totalCount)
+        assertEquals(1, events.size) // Event created with 0L timestamp due to invalid date
+
+        // Should log date parsing errors
+        verify(atLeast = 2) { Simber.e(any(), ofType<Exception>(), tag = LoggingConstants.CrashReportTag.COMMCARE_SYNC) }
+        verify { Simber.w(any(), tag = LoggingConstants.CrashReportTag.COMMCARE_SYNC) }
+    }
+
+    @Test
+    fun `syncSpecificCases throws exception when data cursor is null for specific case`() = runTest {
+        val caseId = "case_null_data_cursor"
+        val queryWithExternalIds = RemoteEventQuery(
+            projectId = DEFAULT_PROJECT_ID,
+            modes = emptyList(),
+            externalIds = listOf(caseId),
+        )
+
+        // Mock metadata cursor
+        every { mockMetadataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockMetadataCursor.getString(COLUMN_INDEX_LAST_MODIFIED) } returns formatCommCareDate(15000L)
+
+        // Mock null data cursor for the specific case
+        every {
+            mockContentResolver.query(
+                mockDataCaseIdUri,
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns null
+
+        val result = dataSource.getEvents(queryWithExternalIds)
+
+        try {
+            result.eventFlow.toList()
+            assert(false) { "Expected IllegalStateException" }
+        } catch (e: IllegalStateException) {
+            assertEquals("Cursor for caseId $caseId is null", e.message)
+        }
+
+        verify(
+            exactly = 1,
+        ) { mockContentResolver.query(mockMetadataCaseIdUri, arrayOf(COLUMN_CASE_ID, COLUMN_LAST_MODIFIED), any(), any(), any()) }
+        verify(exactly = 1) { mockContentResolver.query(mockDataCaseIdUri, any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `syncSpecificCases handles case with no subjectActions data`() = runTest {
+        val caseId = "case_no_subject_actions"
+        val queryWithExternalIds = RemoteEventQuery(
+            projectId = DEFAULT_PROJECT_ID,
+            modes = emptyList(),
+            externalIds = listOf(caseId),
+        )
+
+        // Mock metadata cursor
+        every { mockMetadataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockMetadataCursor.getString(COLUMN_INDEX_LAST_MODIFIED) } returns formatCommCareDate(15000L)
+
+        // Mock data cursor with no subjectActions
+        every { mockDataCursor.moveToNext() } returnsMany listOf(true, true, false)
+        every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returnsMany listOf("other_key", "another_key")
+        every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returnsMany listOf("other_value", "another_value")
+
+        val result = dataSource.getEvents(queryWithExternalIds)
+        val events = result.eventFlow.toList()
+
+        assertEquals(1, result.totalCount)
+        assertEquals(0, events.size) // No events because no subjectActions found
+
+        verify(
+            exactly = 1,
+        ) { mockContentResolver.query(mockMetadataCaseIdUri, arrayOf(COLUMN_CASE_ID, COLUMN_LAST_MODIFIED), any(), any(), any()) }
+        verify(exactly = 1) { mockContentResolver.query(mockDataCaseIdUri, any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `syncSpecificCases adds processed cases to pendingSyncedCases correctly`() = runTest {
+        val caseId = "test_case_pending"
+        val queryWithExternalIds = RemoteEventQuery(
+            projectId = DEFAULT_PROJECT_ID,
+            modes = emptyList(),
+            externalIds = listOf(caseId),
+        )
+        val expectedLastModifiedTime = 18000L
+
+        // Mock metadata cursor
+        every { mockMetadataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockMetadataCursor.getString(COLUMN_INDEX_LAST_MODIFIED) } returns formatCommCareDate(expectedLastModifiedTime)
+
+        // Mock data cursor for subjectActions
+        every { mockDataCursor.moveToNext() } returnsMany listOf(true, false)
+        every { mockDataCursor.getString(COLUMN_INDEX_DATUM_ID) } returns SIMPRINTS_COSYNC_SUBJECT_ACTIONS
+        every { mockDataCursor.getString(COLUMN_INDEX_VALUE) } returns SUBJECT_ACTIONS_EVENT_1
+
+        val result = dataSource.getEvents(queryWithExternalIds)
+        val events = result.eventFlow.toList()
+
+        assertEquals(1, result.totalCount)
+        assertEquals(1, events.size)
+
+        val event = events[0] as EnrolmentRecordCreationEvent
+        assertEquals(SUBJECT_ACTIONS_EVENT_1_SUBJECT_ID, event.payload.subjectId)
+
+        // Call onEventsProcessed to verify pendingSyncedCases was populated correctly
+        dataSource.onEventsProcessed(events)
+
+        // Verify that the case was added to cache with correct data
+        coVerify {
+            mockCommCareSyncCache.addSyncedCase(
+                match<SyncedCaseEntity> {
+                    it.caseId == caseId &&
+                        it.simprintsId == SUBJECT_ACTIONS_EVENT_1_SUBJECT_ID &&
+                        it.lastSyncedTimestamp == expectedLastModifiedTime
+                },
             )
         }
     }

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/down/tasks/CommCareEventSyncTaskTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/down/tasks/CommCareEventSyncTaskTest.kt
@@ -206,7 +206,7 @@ class CommCareEventSyncTaskTest {
 
     @Test
     fun downSync_shouldEmitAFailureIfDownloadFails() = runTest {
-        coEvery { commCareEventDataSource.getEvents() } throws Throwable("CommCare Exception")
+        coEvery { commCareEventDataSource.getEvents(any()) } throws Throwable("CommCare Exception")
 
         val progress = commCareEventSyncTask.downSync(this, projectOp, eventScope, project).toList()
 
@@ -216,21 +216,21 @@ class CommCareEventSyncTaskTest {
 
     @Test(expected = SecurityException::class)
     fun downSync_shouldThrowUpIfSecurityExceptionOccurs() = runTest {
-        coEvery { commCareEventDataSource.getEvents() } throws SecurityException("Security Exception")
+        coEvery { commCareEventDataSource.getEvents(any()) } throws SecurityException("Security Exception")
 
         commCareEventSyncTask.downSync(this, projectOp, eventScope, project).toList()
     }
 
     @Test(expected = IllegalStateException::class)
     fun downSync_shouldThrowUpIfIllegalStateExceptionOccurs() = runTest {
-        coEvery { commCareEventDataSource.getEvents() } throws IllegalStateException("Illegal State Exception")
+        coEvery { commCareEventDataSource.getEvents(any()) } throws IllegalStateException("Illegal State Exception")
 
         commCareEventSyncTask.downSync(this, projectOp, eventScope, project).toList()
     }
 
     @Test
     fun downSync_shouldAddEventWithErrorIfDownloadFails() = runTest {
-        coEvery { commCareEventDataSource.getEvents() } throws Throwable("CommCare Exception")
+        coEvery { commCareEventDataSource.getEvents(any()) } throws Throwable("CommCare Exception")
         commCareEventSyncTask.downSync(this, projectOp, eventScope, project).toList()
 
         coVerify(exactly = 1) {
@@ -277,7 +277,7 @@ class CommCareEventSyncTaskTest {
     @Test
     fun downSync_shouldAddEventWithExceptionClassSimpleNameIfDownloadFails() = runTest {
         val expectedException = Exception("Test")
-        coEvery { commCareEventDataSource.getEvents() } throws expectedException
+        coEvery { commCareEventDataSource.getEvents(any()) } throws expectedException
 
         commCareEventSyncTask.downSync(this, projectOp, eventScope, project).toList()
 
@@ -394,7 +394,7 @@ class CommCareEventSyncTaskTest {
     }
 
     private fun mockCommCareDataSource(events: List<EnrolmentRecordEvent>) {
-        coEvery { commCareEventDataSource.getEvents() } returns CommCareEventSyncResult(
+        coEvery { commCareEventDataSource.getEvents(any()) } returns CommCareEventSyncResult(
             totalCount = events.size,
             eventFlow = flowOf(*events.toTypedArray()),
         )


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1091)
Will be released in: **2025.3.0**

### Notable changes

* Adds the ability to sync specific caseIds from CommCare
* `EventSyncManagerImpl` makes use of this to downsync individual subjects "on-demand" (used during verification to guarantee that the biometrics of the subject we are matching against are present on the device)
* This is achieved by passing metadata (which should contain the caseId associated with the subject we want to verify) from `FetchSubject*` to `EventSyncManagerImpl` which tries to parse and extract the caseId
* Since the parsing and extracting bit (as small as it is) was shared with `CommCareIdentityDataSource` (used for the same use case but when just-in-time CommCare reading is configured) - it was extracted in a common use case in `core` module

### Testing guidance

* Pass metadata with the form `{"caseId": "123"}` in verification callout from CommCare and make sure the subject is synced if not present on the device

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
