### PR TITLE
[MS-1053] Fallback to reading from CommCare just-in-time when no successful sync within threshold

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/FallbackToCommCareDataSourceIfNeededUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/FallbackToCommCareDataSourceIfNeededUseCase.kt
@@ -1,0 +1,51 @@
+package com.simprints.feature.orchestrator.usecases.steps
+
+import com.simprints.core.tools.time.TimeHelper
+import com.simprints.infra.config.store.models.ProjectConfiguration
+import com.simprints.infra.config.store.models.experimental
+import com.simprints.infra.enrolment.records.repository.domain.models.BiometricDataSource
+import com.simprints.infra.eventsync.sync.common.EventSyncCache
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SYNC
+import com.simprints.infra.logging.Simber
+import com.simprints.infra.orchestration.data.ActionRequest
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+internal class FallbackToCommCareDataSourceIfNeededUseCase @Inject constructor(
+    private val eventSyncCache: EventSyncCache,
+    private val timeHelper: TimeHelper,
+) {
+    suspend operator fun invoke(
+        action: ActionRequest.EnrolActionRequest,
+        projectConfiguration: ProjectConfiguration,
+    ): ActionRequest.EnrolActionRequest =
+        action.takeUnless { shouldFallbackToCommCareDataSource(it.biometricDataSource, projectConfiguration) }
+            ?: action.copy(biometricDataSource = BiometricDataSource.COMMCARE)
+
+    suspend operator fun invoke(
+        action: ActionRequest.IdentifyActionRequest,
+        projectConfiguration: ProjectConfiguration,
+    ): ActionRequest.IdentifyActionRequest =
+        action.takeUnless { shouldFallbackToCommCareDataSource(it.biometricDataSource, projectConfiguration) }
+            ?: action.copy(biometricDataSource = BiometricDataSource.COMMCARE)
+
+    private suspend fun shouldFallbackToCommCareDataSource(
+        biometricDataSource: String,
+        projectConfiguration: ProjectConfiguration,
+    ): Boolean {
+        // Only fallback if the current data source is not CommCare
+        if (biometricDataSource == BiometricDataSource.COMMCARE) return false
+        // Only fallback if CommCare sync is configured
+        if (projectConfiguration.synchronization.down.commCare == null) return false
+
+        val lastSyncTime = eventSyncCache.readLastSuccessfulSyncTime()
+        val thresholdMs = TimeUnit.DAYS.toMillis(projectConfiguration.experimental().fallbackToCommCareThresholdDays)
+        // If there has been a successful sync within the threshold, don't fallback
+        if (lastSyncTime != null && timeHelper.msBetweenNowAndTime(lastSyncTime) < thresholdMs) {
+            return false
+        }
+
+        Simber.w("Falling back to CommCare data source because threshold is $thresholdMs and last sync was at $lastSyncTime", tag = SYNC)
+        return true
+    }
+}

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/OrchestratorViewModelTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/OrchestratorViewModelTest.kt
@@ -112,7 +112,7 @@ internal class OrchestratorViewModelTest {
 
     @Test
     fun `Starts executing steps when action when received`() = runTest {
-        every { stepsBuilder.build(any(), any()) } returns listOf(
+        coEvery { stepsBuilder.build(any(), any()) } returns listOf(
             createMockStep(StepId.SETUP),
         )
 
@@ -125,7 +125,7 @@ internal class OrchestratorViewModelTest {
 
     @Test
     fun `Executes next steps after step result`() = runTest {
-        every { stepsBuilder.build(any(), any()) } returns listOf(
+        coEvery { stepsBuilder.build(any(), any()) } returns listOf(
             createMockStep(StepId.SETUP),
             createMockStep(StepId.CONSENT),
         )
@@ -142,7 +142,7 @@ internal class OrchestratorViewModelTest {
 
     @Test
     fun `Returns response when all steps executed`() = runTest {
-        every { stepsBuilder.build(any(), any()) } returns listOf(
+        coEvery { stepsBuilder.build(any(), any()) } returns listOf(
             createMockStep(StepId.SETUP),
             createMockStep(StepId.CONSENT),
         )
@@ -160,7 +160,7 @@ internal class OrchestratorViewModelTest {
 
     @Test
     fun `Returns response when error result received`() = runTest {
-        every { stepsBuilder.build(any(), any()) } returns listOf(
+        coEvery { stepsBuilder.build(any(), any()) } returns listOf(
             createMockStep(StepId.SETUP),
             createMockStep(StepId.CONSENT),
         )
@@ -174,7 +174,7 @@ internal class OrchestratorViewModelTest {
 
     @Test
     fun `Returns AGE_GROUP_NOT_SUPPORTED response when step builder throws SubjectAgeNotSupportedException`() = runTest {
-        every { stepsBuilder.build(any(), any()) } throws SubjectAgeNotSupportedException()
+        coEvery { stepsBuilder.build(any(), any()) } throws SubjectAgeNotSupportedException()
 
         viewModel.handleAction(mockk())
 
@@ -187,7 +187,7 @@ internal class OrchestratorViewModelTest {
 
     @Test
     fun `Appends capture and match steps upon receiving SelectSubjectAgeGroupResult`() = runTest {
-        every { stepsBuilder.build(any(), any()) } returns listOf(
+        coEvery { stepsBuilder.build(any(), any()) } returns listOf(
             createMockStep(StepId.SELECT_SUBJECT_AGE),
         )
         coEvery { mapRefusalOrErrorResult(any(), any()) } returns null
@@ -202,12 +202,12 @@ internal class OrchestratorViewModelTest {
                 ),
             ),
         )
-        every { stepsBuilder.buildCaptureAndMatchStepsForAgeGroup(any(), any(), any()) } returns captureAndMatchSteps
+        coEvery { stepsBuilder.buildCaptureAndMatchStepsForAgeGroup(any(), any(), any()) } returns captureAndMatchSteps
 
         viewModel.handleAction(mockk())
         viewModel.handleResult(SelectSubjectAgeGroupResult(AgeGroup(0, 1)))
 
-        verify { stepsBuilder.buildCaptureAndMatchStepsForAgeGroup(any(), any(), any()) }
+        coVerify { stepsBuilder.buildCaptureAndMatchStepsForAgeGroup(any(), any(), any()) }
         viewModel.currentStep.test().value().peekContent()?.let { step ->
             assertThat(step.id).isEqualTo(StepId.FACE_CAPTURE)
         }
@@ -215,7 +215,7 @@ internal class OrchestratorViewModelTest {
 
     @Test
     fun `Updates face matcher step payload when receiving face capture`() = runTest {
-        every { stepsBuilder.build(any(), any()) } returns listOf(
+        coEvery { stepsBuilder.build(any(), any()) } returns listOf(
             createMockStep(StepId.FACE_CAPTURE),
             createMockStep(
                 StepId.FACE_MATCHER,
@@ -238,7 +238,7 @@ internal class OrchestratorViewModelTest {
 
     @Test
     fun `Updates fingerprint matcher step payload when receiving fingerprint capture`() = runTest {
-        every { stepsBuilder.build(any(), any()) } returns listOf(
+        coEvery { stepsBuilder.build(any(), any()) } returns listOf(
             createMockStep(StepId.FINGERPRINT_CAPTURE),
             createMockStep(
                 StepId.FINGERPRINT_MATCHER,
@@ -261,7 +261,7 @@ internal class OrchestratorViewModelTest {
 
     @Test
     fun `Updates the correct fingerprint match step when multiple fingerprint SDKs are used`() = runTest {
-        every { stepsBuilder.build(any(), any()) } returns listOf(
+        coEvery { stepsBuilder.build(any(), any()) } returns listOf(
             createMockStep(
                 StepId.FINGERPRINT_CAPTURE,
                 FingerprintCaptureContract.getParams(
@@ -350,7 +350,7 @@ internal class OrchestratorViewModelTest {
         val originalSteps = listOf(
             createMockStep(StepId.FINGERPRINT_CAPTURE),
         )
-        every { stepsBuilder.build(any(), any()) } returns originalSteps
+        coEvery { stepsBuilder.build(any(), any()) } returns originalSteps
         val savedSteps = listOf(
             createMockStep(StepId.SETUP),
             createMockStep(StepId.CONSENT),
@@ -414,7 +414,7 @@ internal class OrchestratorViewModelTest {
             TokenizableString.Tokenized("moduleId"),
             listOf(mockk<EnrolLastBiometricStepResult>()),
         )
-        every { stepsBuilder.build(any(), any()) } returns listOf(
+        coEvery { stepsBuilder.build(any(), any()) } returns listOf(
             captureStep,
             enrolLastStep,
         )

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/steps/FallbackToCommCareDataSourceIfNeededUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/steps/FallbackToCommCareDataSourceIfNeededUseCaseTest.kt
@@ -1,0 +1,307 @@
+package com.simprints.feature.orchestrator.usecases.steps
+
+import com.simprints.core.tools.time.TimeHelper
+import com.simprints.core.tools.time.Timestamp
+import com.simprints.infra.config.store.models.DownSynchronizationConfiguration
+import com.simprints.infra.config.store.models.ProjectConfiguration
+import com.simprints.infra.config.store.models.SynchronizationConfiguration
+import com.simprints.infra.enrolment.records.repository.domain.models.BiometricDataSource
+import com.simprints.infra.eventsync.sync.common.EventSyncCache
+import com.simprints.infra.orchestration.data.ActionRequest
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class FallbackToCommCareDataSourceIfNeededUseCaseTest {
+    @RelaxedMockK
+    private lateinit var eventSyncCache: EventSyncCache
+
+    @RelaxedMockK
+    private lateinit var timeHelper: TimeHelper
+
+    private lateinit var useCase: FallbackToCommCareDataSourceIfNeededUseCase
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        useCase = FallbackToCommCareDataSourceIfNeededUseCase(eventSyncCache, timeHelper)
+    }
+
+    private fun createProjectConfigurationWithCommCare(thresholdDays: Int = 3): ProjectConfiguration {
+        val syncConfig = mockk<SynchronizationConfiguration>(relaxed = true)
+        val downSyncConfig = mockk<DownSynchronizationConfiguration>(relaxed = true)
+        val commCareConfig = DownSynchronizationConfiguration.CommCareDownSynchronizationConfiguration
+
+        every { downSyncConfig.commCare } returns commCareConfig
+        every { syncConfig.down } returns downSyncConfig
+
+        return mockk<ProjectConfiguration>(relaxed = true) {
+            every { synchronization } returns syncConfig
+            every { custom } returns mapOf("fallbackToCommCareThresholdDays" to thresholdDays)
+        }
+    }
+
+    private fun createProjectConfigurationWithoutCommCare(): ProjectConfiguration {
+        val syncConfig = mockk<SynchronizationConfiguration>(relaxed = true)
+        val downSyncConfig = mockk<DownSynchronizationConfiguration>(relaxed = true)
+
+        every { downSyncConfig.commCare } returns null
+        every { syncConfig.down } returns downSyncConfig
+
+        return mockk<ProjectConfiguration>(relaxed = true) {
+            every { synchronization } returns syncConfig
+        }
+    }
+
+    @Test
+    fun `invoke EnrolActionRequest - CommCare data source - returns original action`() = runTest {
+        val projectConfig = createProjectConfigurationWithCommCare()
+        val action = mockk<ActionRequest.EnrolActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns BiometricDataSource.COMMCARE
+        }
+
+        val result = useCase(action, projectConfig)
+
+        assertEquals(action, result)
+    }
+
+    @Test
+    fun `invoke EnrolActionRequest - no CommCare config - returns original action`() = runTest {
+        val projectConfig = createProjectConfigurationWithoutCommCare()
+        val action = mockk<ActionRequest.EnrolActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns "OTHER_SOURCE"
+        }
+
+        val result = useCase(action, projectConfig)
+
+        assertEquals(action, result)
+    }
+
+    @Test
+    fun `invoke EnrolActionRequest - recent successful sync - returns original action`() = runTest {
+        val projectConfig = createProjectConfigurationWithCommCare()
+        val action = mockk<ActionRequest.EnrolActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns "OTHER_SOURCE"
+        }
+        val recentSyncTime = Timestamp(System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(1)) // 1 second ago
+
+        coEvery { eventSyncCache.readLastSuccessfulSyncTime() } returns recentSyncTime
+        every { timeHelper.msBetweenNowAndTime(recentSyncTime) } returns TimeUnit.SECONDS.toMillis(1) // 1 second
+
+        val result = useCase(action, projectConfig)
+
+        assertEquals(action, result)
+    }
+
+    @Test
+    fun `invoke EnrolActionRequest - old sync time - falls back to CommCare`() = runTest {
+        val projectConfig = createProjectConfigurationWithCommCare()
+        val originalAction = mockk<ActionRequest.EnrolActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns "OTHER_SOURCE"
+            every { copy(biometricDataSource = BiometricDataSource.COMMCARE) } returns mockk {
+                every { biometricDataSource } returns BiometricDataSource.COMMCARE
+            }
+        }
+        val oldSyncTime = Timestamp(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(4)) // 4 days ago
+
+        coEvery { eventSyncCache.readLastSuccessfulSyncTime() } returns oldSyncTime
+        every { timeHelper.msBetweenNowAndTime(oldSyncTime) } returns TimeUnit.DAYS.toMillis(4) // 4 days
+
+        val result = useCase(originalAction, projectConfig)
+
+        assertEquals(BiometricDataSource.COMMCARE, result.biometricDataSource)
+    }
+
+    @Test
+    fun `invoke EnrolActionRequest - no sync time - falls back to CommCare`() = runTest {
+        val projectConfig = createProjectConfigurationWithCommCare()
+        val originalAction = mockk<ActionRequest.EnrolActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns "OTHER_SOURCE"
+            every { copy(biometricDataSource = BiometricDataSource.COMMCARE) } returns mockk {
+                every { biometricDataSource } returns BiometricDataSource.COMMCARE
+            }
+        }
+
+        coEvery { eventSyncCache.readLastSuccessfulSyncTime() } returns null
+
+        val result = useCase(originalAction, projectConfig)
+
+        assertEquals(BiometricDataSource.COMMCARE, result.biometricDataSource)
+    }
+
+    @Test
+    fun `invoke EnrolActionRequest - sync time exactly at threshold - falls back to CommCare`() = runTest {
+        val projectConfig = createProjectConfigurationWithCommCare()
+        val originalAction = mockk<ActionRequest.EnrolActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns "OTHER_SOURCE"
+            every { copy(biometricDataSource = BiometricDataSource.COMMCARE) } returns mockk {
+                every { biometricDataSource } returns BiometricDataSource.COMMCARE
+            }
+        }
+        val thresholdSyncTime = Timestamp(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(3)) // Exactly 3 days ago
+
+        coEvery { eventSyncCache.readLastSuccessfulSyncTime() } returns thresholdSyncTime
+        every { timeHelper.msBetweenNowAndTime(thresholdSyncTime) } returns TimeUnit.DAYS.toMillis(3) // Exactly 3 days
+
+        val result = useCase(originalAction, projectConfig)
+
+        assertEquals(BiometricDataSource.COMMCARE, result.biometricDataSource)
+    }
+
+    @Test
+    fun `invoke IdentifyActionRequest - CommCare data source - returns original action`() = runTest {
+        val projectConfig = createProjectConfigurationWithCommCare()
+        val action = mockk<ActionRequest.IdentifyActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns BiometricDataSource.COMMCARE
+        }
+
+        val result = useCase(action, projectConfig)
+
+        assertEquals(action, result)
+    }
+
+    @Test
+    fun `invoke IdentifyActionRequest - no CommCare config - returns original action`() = runTest {
+        val projectConfig = createProjectConfigurationWithoutCommCare()
+        val action = mockk<ActionRequest.IdentifyActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns "OTHER_SOURCE"
+        }
+
+        val result = useCase(action, projectConfig)
+
+        assertEquals(action, result)
+    }
+
+    @Test
+    fun `invoke IdentifyActionRequest - recent successful sync - returns original action`() = runTest {
+        val projectConfig = createProjectConfigurationWithCommCare()
+        val action = mockk<ActionRequest.IdentifyActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns "OTHER_SOURCE"
+        }
+        val recentSyncTime = Timestamp(System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(1)) // 1 second ago
+
+        coEvery { eventSyncCache.readLastSuccessfulSyncTime() } returns recentSyncTime
+        every { timeHelper.msBetweenNowAndTime(recentSyncTime) } returns TimeUnit.SECONDS.toMillis(1) // 1 second
+
+        val result = useCase(action, projectConfig)
+
+        assertEquals(action, result)
+    }
+
+    @Test
+    fun `invoke IdentifyActionRequest - old sync time - falls back to CommCare`() = runTest {
+        val projectConfig = createProjectConfigurationWithCommCare()
+        val originalAction = mockk<ActionRequest.IdentifyActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns "OTHER_SOURCE"
+            every { copy(biometricDataSource = BiometricDataSource.COMMCARE) } returns mockk {
+                every { biometricDataSource } returns BiometricDataSource.COMMCARE
+            }
+        }
+        val oldSyncTime = Timestamp(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(4)) // 4 days ago
+
+        coEvery { eventSyncCache.readLastSuccessfulSyncTime() } returns oldSyncTime
+        every { timeHelper.msBetweenNowAndTime(oldSyncTime) } returns TimeUnit.DAYS.toMillis(4) // 4 days
+
+        val result = useCase(originalAction, projectConfig)
+
+        assertEquals(BiometricDataSource.COMMCARE, result.biometricDataSource)
+    }
+
+    @Test
+    fun `invoke IdentifyActionRequest - no sync time - falls back to CommCare`() = runTest {
+        val projectConfig = createProjectConfigurationWithCommCare()
+        val originalAction = mockk<ActionRequest.IdentifyActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns "OTHER_SOURCE"
+            every { copy(biometricDataSource = BiometricDataSource.COMMCARE) } returns mockk {
+                every { biometricDataSource } returns BiometricDataSource.COMMCARE
+            }
+        }
+
+        coEvery { eventSyncCache.readLastSuccessfulSyncTime() } returns null
+
+        val result = useCase(originalAction, projectConfig)
+
+        assertEquals(BiometricDataSource.COMMCARE, result.biometricDataSource)
+    }
+
+    @Test
+    fun `invoke IdentifyActionRequest - sync time exactly at threshold - falls back to CommCare`() = runTest {
+        val projectConfig = createProjectConfigurationWithCommCare()
+        val originalAction = mockk<ActionRequest.IdentifyActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns "OTHER_SOURCE"
+            every { copy(biometricDataSource = BiometricDataSource.COMMCARE) } returns mockk {
+                every { biometricDataSource } returns BiometricDataSource.COMMCARE
+            }
+        }
+        val thresholdSyncTime = Timestamp(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(3)) // Exactly 3 days ago
+
+        coEvery { eventSyncCache.readLastSuccessfulSyncTime() } returns thresholdSyncTime
+        every { timeHelper.msBetweenNowAndTime(thresholdSyncTime) } returns TimeUnit.DAYS.toMillis(3) // Exactly 3 days
+
+        val result = useCase(originalAction, projectConfig)
+
+        assertEquals(BiometricDataSource.COMMCARE, result.biometricDataSource)
+    }
+
+    @Test
+    fun `invoke IdentifyActionRequest - sync time just under threshold - returns original action`() = runTest {
+        val projectConfig = createProjectConfigurationWithCommCare()
+        val action = mockk<ActionRequest.IdentifyActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns "OTHER_SOURCE"
+        }
+        val justUnderThresholdSyncTime = Timestamp(System.currentTimeMillis() - (TimeUnit.DAYS.toMillis(3) - 1L)) // Just under 3 days ago
+
+        coEvery { eventSyncCache.readLastSuccessfulSyncTime() } returns justUnderThresholdSyncTime
+        every { timeHelper.msBetweenNowAndTime(justUnderThresholdSyncTime) } returns TimeUnit.DAYS.toMillis(3) - 1L // Just under 3 days
+
+        val result = useCase(action, projectConfig)
+
+        assertEquals(action, result)
+    }
+
+    @Test
+    fun `invoke IdentifyActionRequest - sync time just over threshold - falls back to CommCare`() = runTest {
+        val projectConfig = createProjectConfigurationWithCommCare()
+        val originalAction = mockk<ActionRequest.IdentifyActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns "OTHER_SOURCE"
+            every { copy(biometricDataSource = BiometricDataSource.COMMCARE) } returns mockk {
+                every { biometricDataSource } returns BiometricDataSource.COMMCARE
+            }
+        }
+        val overThresholdSyncTime = Timestamp(System.currentTimeMillis() - (TimeUnit.DAYS.toMillis(3) + 1L)) // Just over 3 days ago
+
+        coEvery { eventSyncCache.readLastSuccessfulSyncTime() } returns overThresholdSyncTime
+        every { timeHelper.msBetweenNowAndTime(overThresholdSyncTime) } returns TimeUnit.DAYS.toMillis(3) + 1L
+
+        val result = useCase(originalAction, projectConfig)
+
+        assertEquals(BiometricDataSource.COMMCARE, result.biometricDataSource)
+    }
+
+    @Test
+    fun `invoke EnrolActionRequest - custom threshold configuration - respects configured threshold`() = runTest {
+        val customThresholdDays = 1
+        val projectConfig = createProjectConfigurationWithCommCare(customThresholdDays)
+        val originalAction = mockk<ActionRequest.EnrolActionRequest>(relaxed = true) {
+            every { biometricDataSource } returns "OTHER_SOURCE"
+            every { copy(biometricDataSource = BiometricDataSource.COMMCARE) } returns mockk {
+                every { biometricDataSource } returns BiometricDataSource.COMMCARE
+            }
+        }
+        val syncTime = Timestamp(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(25)) // 25 hours ago
+
+        coEvery { eventSyncCache.readLastSuccessfulSyncTime() } returns syncTime
+        every { timeHelper.msBetweenNowAndTime(syncTime) } returns TimeUnit.HOURS.toMillis(25) // 25 hours
+
+        val result = useCase(originalAction, projectConfig)
+
+        assertEquals(BiometricDataSource.COMMCARE, result.biometricDataSource)
+    }
+}

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
@@ -56,6 +56,13 @@ data class ExperimentalProjectConfiguration(
             ?.let { it as? Boolean }
             .let { it == true }
 
+    val fallbackToCommCareThresholdDays: Long
+        get() = customConfig
+            ?.get(FALLBACK_TO_COMMCARE_THRESHOLD_DAYS)
+            ?.let { it as? Int }
+            ?.toLong()
+            ?: FALLBACK_TO_COMMCARE_THRESHOLD_DAYS_DEFAULT
+
     companion object {
         internal const val ENABLE_ID_POOL_VALIDATION = "validateIdentificationPool"
         internal const val SINGLE_GOOD_QUALITY_FALLBACK_REQUIRED = "singleQualityFallbackRequired"
@@ -72,5 +79,8 @@ data class ExperimentalProjectConfiguration(
         internal const val SAMPLE_UPLOAD_WITH_URL_ENABLED = "sampleUploadWithSignedUrl"
 
         internal const val CAMERA_FLASH_CONTROLS_ENABLED = "displayCameraFlashToggle"
+
+        internal const val FALLBACK_TO_COMMCARE_THRESHOLD_DAYS = "fallbackToCommCareThresholdDays"
+        internal const val FALLBACK_TO_COMMCARE_THRESHOLD_DAYS_DEFAULT = 5L
     }
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
@@ -8,6 +8,8 @@ import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.FACE_AUTO_CAPTURE_IMAGING_DURATION_MILLIS_DEFAULT
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.FACE_AUTO_CAPTURE_IMAGING_DURATION_MILLIS_MAX
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.FACE_AUTO_CAPTURE_IMAGING_DURATION_MILLIS_MIN
+import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.FALLBACK_TO_COMMCARE_THRESHOLD_DAYS
+import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.FALLBACK_TO_COMMCARE_THRESHOLD_DAYS_DEFAULT
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.RECORDS_DB_MIGRATION_FROM_REALM_TO_ROOM_DEFAULT_MAX_RETRIES
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.RECORDS_DB_MIGRATION_FROM_REALM_TO_ROOM_ENABLED
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.RECORDS_DB_MIGRATION_FROM_REALM_TO_ROOM_MAX_RETRIES
@@ -142,6 +144,23 @@ internal class ExperimentalProjectConfigurationTest {
             mapOf(CAMERA_FLASH_CONTROLS_ENABLED to true) to true,
         ).forEach { (config, result) ->
             assertThat(ExperimentalProjectConfiguration(config).displayCameraFlashToggle).isEqualTo(result)
+        }
+    }
+
+    @Test
+    fun `check fallback to CommCare threshold days correctly`() {
+        mapOf(
+            // Value not present
+            emptyMap<String, Any>() to FALLBACK_TO_COMMCARE_THRESHOLD_DAYS_DEFAULT,
+            // Value not int
+            mapOf(FALLBACK_TO_COMMCARE_THRESHOLD_DAYS to true) to FALLBACK_TO_COMMCARE_THRESHOLD_DAYS_DEFAULT,
+            mapOf(FALLBACK_TO_COMMCARE_THRESHOLD_DAYS to 0) to 0L,
+            mapOf(FALLBACK_TO_COMMCARE_THRESHOLD_DAYS to 1) to 1L,
+            mapOf(FALLBACK_TO_COMMCARE_THRESHOLD_DAYS to 5) to 5L,
+            // Value present and exactly at default
+            mapOf(FALLBACK_TO_COMMCARE_THRESHOLD_DAYS to 3) to 3L,
+        ).forEach { (config, result) ->
+            assertThat(ExperimentalProjectConfiguration(config).fallbackToCommCareThresholdDays).isEqualTo(result)
         }
     }
 }

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/domain/models/BiometricDataSource.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/domain/models/BiometricDataSource.kt
@@ -20,11 +20,13 @@ sealed class BiometricDataSource : StepParams {
     }
 
     companion object {
+        const val COMMCARE = "COMMCARE"
+
         fun fromString(
             value: String,
             callerPackageName: String,
         ) = when (value.uppercase()) {
-            "COMMCARE" -> CommCare(callerPackageName)
+            COMMCARE -> CommCare(callerPackageName)
             else -> Simprints
         }
     }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/common/EventSyncCache.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/common/EventSyncCache.kt
@@ -15,7 +15,7 @@ import javax.inject.Singleton
 
 @SuppressLint("ApplySharedPref")
 @Singleton
-internal class EventSyncCache @Inject constructor(
+class EventSyncCache @Inject constructor(
     securityManager: SecurityManager,
     @DispatcherIO private val dispatcher: CoroutineDispatcher,
 ) {


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1053)
Will be released in: **2025.3.0**

### Notable changes

* We are worried that when syncing from CommCare is configured there might be an unforeseen issue that prevents syncing from happening in the field. To avoid this we are adding a fallback mechanism where if:
1. We receive an Identify or Enrol+ Intent (the ones that do 1:N and therefore depend on synced local records)
2. Biometric data source of the Intent is Simprints (i.e. read from local records)
3. Configuration is to downsync form CommCare
4. A successful sync hasn't happened in X days (X being configurable through custom config)
we change the biometric data source to CommCare (i.e. don't use local records and read them from CommCare just-in-time). A Simber warning is logged to track if/how often this happens.

### Testing guidance

1. Configure a project to downsync from CommCare
2. Don't sync for X days (or hack it to think so)
3. Send an Identify Intent with Simprints (default) biometric data source
4. Make sure that SID reads records from CommCare just-in-time

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
