### PR TITLE
Do not require context on fragment creation since it is not attached

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -66,8 +66,10 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
 
     private var cameraControl: CameraControl? = null
 
-    private val validCaptureProgressColor = ContextCompat.getColor(requireContext(), IDR.color.simprints_green_light)
-    private val defaultCaptureProgressColor = ContextCompat.getColor(requireContext(), IDR.color.simprints_blue_grey_light)
+    private val validCaptureProgressColor: Int
+        get() = ContextCompat.getColor(requireContext(), IDR.color.simprints_green_light)
+    private val defaultCaptureProgressColor: Int
+        get() = ContextCompat.getColor(requireContext(), IDR.color.simprints_blue_grey_light)
 
     private val launchPermissionRequest = registerForActivityResult(
         ActivityResultContracts.RequestPermission(),


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0**

* When a live-feedback fragment is created, it does not have access to the context; therefore, `requireContext()` fails.

### Notable changes

* Ensured that `requireContext` is not called in the fragment construction

### Testing guidance

* Do some face captures

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
