### PR TITLE
MS-1137 Add device ID and SID versions to commcare responses

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/CommCareResponseMapper.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/CommCareResponseMapper.kt
@@ -2,6 +2,8 @@ package com.simprints.feature.clientapi.mappers.response
 
 import android.os.Bundle
 import androidx.core.os.bundleOf
+import com.simprints.core.DeviceID
+import com.simprints.core.PackageVersionName
 import com.simprints.feature.clientapi.models.CommCareConstants
 import com.simprints.infra.orchestration.data.ActionResponse
 import com.simprints.libsimprints.Constants
@@ -9,9 +11,14 @@ import javax.inject.Inject
 import com.simprints.libsimprints.Identification as LegacyIdentification
 import com.simprints.libsimprints.Tier as LegacyTier
 
-internal class CommCareResponseMapper @Inject constructor() {
+internal class CommCareResponseMapper @Inject constructor(
+    @DeviceID private val deviceId: String,
+    @PackageVersionName private val appVersionName: String,
+) {
     operator fun invoke(response: ActionResponse): Bundle = when (response) {
         is ActionResponse.EnrolActionResponse -> bundleOf(
+            CommCareConstants.COMMCARE_DEVICE_ID to deviceId,
+            CommCareConstants.COMMCARE_SID_VERSION to appVersionName,
             CommCareConstants.SIMPRINTS_SESSION_ID to response.sessionId,
             CommCareConstants.BIOMETRICS_COMPLETE_CHECK_KEY to "true",
             CommCareConstants.REGISTRATION_GUID_KEY to response.enrolledGuid,
@@ -23,6 +30,8 @@ internal class CommCareResponseMapper @Inject constructor() {
          * from others (not inside [CommCareConstants.COMMCARE_BUNDLE_KEY]).
          */
         is ActionResponse.IdentifyActionResponse -> bundleOf(
+            CommCareConstants.COMMCARE_DEVICE_ID to deviceId,
+            CommCareConstants.COMMCARE_SID_VERSION to appVersionName,
             Constants.SIMPRINTS_SESSION_ID to response.sessionId,
             Constants.SIMPRINTS_IDENTIFICATIONS to ArrayList<LegacyIdentification>(
                 response.identifications.map {
@@ -32,11 +41,15 @@ internal class CommCareResponseMapper @Inject constructor() {
         )
 
         is ActionResponse.ConfirmActionResponse -> bundleOf(
+            CommCareConstants.COMMCARE_DEVICE_ID to deviceId,
+            CommCareConstants.COMMCARE_SID_VERSION to appVersionName,
             CommCareConstants.SIMPRINTS_SESSION_ID to response.sessionId,
             CommCareConstants.BIOMETRICS_COMPLETE_CHECK_KEY to "true",
         ).toCommCareBundle()
 
         is ActionResponse.VerifyActionResponse -> bundleOf(
+            CommCareConstants.COMMCARE_DEVICE_ID to deviceId,
+            CommCareConstants.COMMCARE_SID_VERSION to appVersionName,
             CommCareConstants.SIMPRINTS_SESSION_ID to response.sessionId,
             CommCareConstants.BIOMETRICS_COMPLETE_CHECK_KEY to "true",
             CommCareConstants.VERIFICATION_GUID_KEY to response.matchResult.guid,
@@ -49,6 +62,8 @@ internal class CommCareResponseMapper @Inject constructor() {
         }.toCommCareBundle()
 
         is ActionResponse.ExitFormActionResponse -> bundleOf(
+            CommCareConstants.COMMCARE_DEVICE_ID to deviceId,
+            CommCareConstants.COMMCARE_SID_VERSION to appVersionName,
             CommCareConstants.SIMPRINTS_SESSION_ID to response.sessionId,
             CommCareConstants.BIOMETRICS_COMPLETE_CHECK_KEY to "true",
             CommCareConstants.EXIT_REASON to response.reason,
@@ -56,6 +71,8 @@ internal class CommCareResponseMapper @Inject constructor() {
         ).toCommCareBundle()
 
         is ActionResponse.ErrorActionResponse -> bundleOf(
+            CommCareConstants.COMMCARE_DEVICE_ID to deviceId,
+            CommCareConstants.COMMCARE_SID_VERSION to appVersionName,
             CommCareConstants.SIMPRINTS_SESSION_ID to response.sessionId,
             CommCareConstants.BIOMETRICS_COMPLETE_CHECK_KEY to response.flowCompleted.toString(),
         ).toCommCareBundle()

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/models/Constants.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/models/Constants.kt
@@ -64,6 +64,9 @@ internal object CommCareConstants {
 
     const val COMMCARE_BUNDLE_KEY = "odk_intent_bundle"
     const val COMMCARE_DATA_KEY = "odk_intent_data"
+
+    const val COMMCARE_DEVICE_ID = "deviceId"
+    const val COMMCARE_SID_VERSION = "appVersionName"
 }
 
 internal object LibSimprintsConstants {

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/CommCareResponseMapperTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/CommCareResponseMapperTest.kt
@@ -21,7 +21,7 @@ import com.simprints.libsimprints.Tier as LegacyTier
 
 @RunWith(AndroidJUnit4::class)
 class CommCareResponseMapperTest {
-    private val mapper = CommCareResponseMapper()
+    private val mapper = CommCareResponseMapper("deviceId", "appVersionName")
 
     @Test
     fun `correctly maps enrol response`() {
@@ -35,6 +35,8 @@ class CommCareResponseMapperTest {
         ).getBundle(CommCareConstants.COMMCARE_BUNDLE_KEY) ?: bundleOf()
 
         assertThat(extras.getString(CommCareConstants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_SID_VERSION)).isEqualTo("appVersionName")
         assertThat(extras.getString(CommCareConstants.REGISTRATION_GUID_KEY)).isEqualTo("guid")
         assertThat(extras.getString(CommCareConstants.BIOMETRICS_COMPLETE_CHECK_KEY)).isEqualTo("true")
     }
@@ -61,6 +63,8 @@ class CommCareResponseMapperTest {
         )
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_SID_VERSION)).isEqualTo("appVersionName")
         @Suppress("DEPRECATION")
         // Intentionally using deprecated getParcelableArrayList() as this is what CommCare uses
         assertThat(extras.getParcelableArrayList<LegacyIdentification>(Constants.SIMPRINTS_IDENTIFICATIONS))
@@ -85,6 +89,8 @@ class CommCareResponseMapperTest {
         ).getBundle(CommCareConstants.COMMCARE_BUNDLE_KEY) ?: bundleOf()
 
         assertThat(extras.getString(CommCareConstants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_SID_VERSION)).isEqualTo("appVersionName")
         assertThat(extras.getString(CommCareConstants.BIOMETRICS_COMPLETE_CHECK_KEY)).isEqualTo("true")
     }
 
@@ -104,6 +110,8 @@ class CommCareResponseMapperTest {
         ).getBundle(CommCareConstants.COMMCARE_BUNDLE_KEY) ?: bundleOf()
 
         assertThat(extras.getString(CommCareConstants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_SID_VERSION)).isEqualTo("appVersionName")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_GUID_KEY)).isEqualTo("guid")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_CONFIDENCE_KEY)).isEqualTo("50")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_TIER_KEY)).isEqualTo("TIER_1")
@@ -127,6 +135,8 @@ class CommCareResponseMapperTest {
         ).getBundle(CommCareConstants.COMMCARE_BUNDLE_KEY) ?: bundleOf()
 
         assertThat(extras.getString(CommCareConstants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_SID_VERSION)).isEqualTo("appVersionName")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_GUID_KEY)).isEqualTo("guid")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_CONFIDENCE_KEY)).isEqualTo("50")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_TIER_KEY)).isEqualTo("TIER_1")
@@ -150,6 +160,8 @@ class CommCareResponseMapperTest {
         ).getBundle(CommCareConstants.COMMCARE_BUNDLE_KEY) ?: bundleOf()
 
         assertThat(extras.getString(CommCareConstants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_SID_VERSION)).isEqualTo("appVersionName")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_GUID_KEY)).isEqualTo("guid")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_CONFIDENCE_KEY)).isEqualTo("50")
         assertThat(extras.getString(CommCareConstants.VERIFICATION_TIER_KEY)).isEqualTo("TIER_1")
@@ -186,6 +198,8 @@ class CommCareResponseMapperTest {
         ).getBundle(CommCareConstants.COMMCARE_BUNDLE_KEY) ?: bundleOf()
 
         assertThat(extras.getString(CommCareConstants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(CommCareConstants.COMMCARE_SID_VERSION)).isEqualTo("appVersionName")
         assertThat(extras.getString(CommCareConstants.BIOMETRICS_COMPLETE_CHECK_KEY)).isEqualTo("true")
     }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1137)
Will be released in: **2025.3.0**


### Notable changes

* Added device ID and app version to CommCare responses.
* Only adding to CommCare in this response to expedite the actually requested changes. I will add the same data to LibSimprints responses in a separate PR, as it requires changes in the library.

### Testing guidance

* Describe how the reviewers can verify that issue is fixed

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
