### PR TITLE
MS-1137 Add device ID and app version to LibSimprints responses

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapper.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapper.kt
@@ -2,7 +2,10 @@ package com.simprints.feature.clientapi.mappers.response
 
 import android.os.Bundle
 import androidx.core.os.bundleOf
+import com.simprints.core.DeviceID
+import com.simprints.core.PackageVersionName
 import com.simprints.core.domain.response.AppErrorReason
+import com.simprints.infra.events.event.domain.models.scope.Device
 import com.simprints.infra.orchestration.data.ActionResponse
 import com.simprints.libsimprints.Constants
 import com.simprints.libsimprints.contracts.VersionsList
@@ -19,10 +22,15 @@ import com.simprints.libsimprints.Registration as LegacyEnrolment
 import com.simprints.libsimprints.Tier as LegacyTier
 import com.simprints.libsimprints.Verification as LegacyVerification
 
-internal class LibSimprintsResponseMapper @Inject constructor() {
+internal class LibSimprintsResponseMapper @Inject constructor(
+    @DeviceID private val deviceId: String,
+    @PackageVersionName private val appVersionName: String,
+) {
     operator fun invoke(response: ActionResponse): Bundle = when (response) {
         is ActionResponse.EnrolActionResponse -> bundleOf(
             Constants.SIMPRINTS_SESSION_ID to response.sessionId,
+            Constants.SIMPRINTS_DEVICE_ID to deviceId,
+            Constants.SIMPRINTS_APP_VERSION_NAME to appVersionName,
             Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK to true,
         ).appendDataPerContractVersion(response) { version ->
             when {
@@ -30,12 +38,15 @@ internal class LibSimprintsResponseMapper @Inject constructor() {
                     Constants.SIMPRINTS_REGISTRATION,
                     LegacyEnrolment(response.enrolledGuid),
                 )
+
                 else -> putString(Constants.SIMPRINTS_ENROLMENT, Enrolment(response.enrolledGuid).toJson())
             }
         }.appendCoSyncData(response.subjectActions)
 
         is ActionResponse.IdentifyActionResponse -> bundleOf(
             Constants.SIMPRINTS_SESSION_ID to response.sessionId,
+            Constants.SIMPRINTS_DEVICE_ID to deviceId,
+            Constants.SIMPRINTS_APP_VERSION_NAME to appVersionName,
             Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK to true,
         ).appendDataPerContractVersion(response) { version ->
             when {
@@ -57,11 +68,15 @@ internal class LibSimprintsResponseMapper @Inject constructor() {
 
         is ActionResponse.ConfirmActionResponse -> bundleOf(
             Constants.SIMPRINTS_SESSION_ID to response.sessionId,
+            Constants.SIMPRINTS_DEVICE_ID to deviceId,
+            Constants.SIMPRINTS_APP_VERSION_NAME to appVersionName,
             Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK to true,
         )
 
         is ActionResponse.VerifyActionResponse -> bundleOf(
             Constants.SIMPRINTS_SESSION_ID to response.sessionId,
+            Constants.SIMPRINTS_DEVICE_ID to deviceId,
+            Constants.SIMPRINTS_APP_VERSION_NAME to appVersionName,
             Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK to true,
         ).appendDataPerContractVersion(response) { version ->
             when {
@@ -92,6 +107,8 @@ internal class LibSimprintsResponseMapper @Inject constructor() {
 
         is ActionResponse.ExitFormActionResponse -> bundleOf(
             Constants.SIMPRINTS_SESSION_ID to response.sessionId,
+            Constants.SIMPRINTS_DEVICE_ID to deviceId,
+            Constants.SIMPRINTS_APP_VERSION_NAME to appVersionName,
             Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK to true,
         ).appendDataPerContractVersion(response) { version ->
             when {
@@ -109,6 +126,8 @@ internal class LibSimprintsResponseMapper @Inject constructor() {
 
         is ActionResponse.ErrorActionResponse -> bundleOf(
             Constants.SIMPRINTS_SESSION_ID to response.sessionId,
+            Constants.SIMPRINTS_DEVICE_ID to deviceId,
+            Constants.SIMPRINTS_APP_VERSION_NAME to appVersionName,
             Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK to response.flowCompleted,
             RESULT_CODE_OVERRIDE to response.reason.libSimprintsResultCode(),
         )

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapperTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapperTest.kt
@@ -1,7 +1,7 @@
 package com.simprints.feature.clientapi.mappers.response
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.common.truth.Truth.assertThat
+import androidx.test.ext.junit.runners.*
+import com.google.common.truth.Truth.*
 import com.simprints.core.domain.response.AppErrorReason
 import com.simprints.core.domain.response.AppMatchConfidence
 import com.simprints.feature.clientapi.mappers.request.requestFactories.ConfirmIdentityActionFactory
@@ -23,7 +23,7 @@ import com.simprints.libsimprints.Verification as LegacyVerification
 
 @RunWith(AndroidJUnit4::class)
 class LibSimprintsResponseMapperTest {
-    private val mapper = LibSimprintsResponseMapper()
+    private val mapper = LibSimprintsResponseMapper("deviceId", "appVersionName")
 
     @Test
     fun `correctly maps enrol response`() {
@@ -37,6 +37,8 @@ class LibSimprintsResponseMapperTest {
         )
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extras.getParcelable<LegacyEnrolment>(Constants.SIMPRINTS_REGISTRATION)).isEqualTo(
             LegacyEnrolment("guid"),
         )
@@ -57,6 +59,8 @@ class LibSimprintsResponseMapperTest {
         )
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extras.getString(Constants.SIMPRINTS_ENROLMENT)).isEqualTo("""{"guid":"guid"}""")
         assertThat(extras.getBoolean(Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK)).isTrue()
     }
@@ -83,6 +87,8 @@ class LibSimprintsResponseMapperTest {
         )
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extras.getParcelableArrayList<LegacyIdentification>(Constants.SIMPRINTS_IDENTIFICATIONS)).containsExactly(
             LegacyIdentification("guid-1", 100, LegacyTier.TIER_2),
             LegacyIdentification("guid-2", 75, LegacyTier.TIER_3),
@@ -108,6 +114,8 @@ class LibSimprintsResponseMapperTest {
         )
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extras.getString(Constants.SIMPRINTS_IDENTIFICATIONS)).isEqualTo(
             """
             [{"guid":"guid-1","confidenceBand":"MEDIUM","confidence":100}]
@@ -127,6 +135,8 @@ class LibSimprintsResponseMapperTest {
         )
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extras.getBoolean(Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK)).isTrue()
     }
 
@@ -149,6 +159,8 @@ class LibSimprintsResponseMapperTest {
         val extraVerification = extras.getParcelable<LegacyVerification>(Constants.SIMPRINTS_VERIFICATION)
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extraVerification?.guid).isEqualTo("guid")
         assertThat(extraVerification?.tier).isEqualTo(LegacyTier.TIER_1)
         assertThat(extraVerification?.getConfidence()).isEqualTo(50)
@@ -175,6 +187,8 @@ class LibSimprintsResponseMapperTest {
         val extraVerification = extras.getParcelable<LegacyVerification>(Constants.SIMPRINTS_VERIFICATION)
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extraVerification?.guid).isEqualTo("guid")
         assertThat(extraVerification?.tier).isEqualTo(LegacyTier.TIER_1)
         assertThat(extraVerification?.getConfidence()).isEqualTo(50)
@@ -202,6 +216,8 @@ class LibSimprintsResponseMapperTest {
         val extraVerification = extras.getParcelable<LegacyVerification>(Constants.SIMPRINTS_VERIFICATION)
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extraVerification?.guid).isEqualTo("guid")
         assertThat(extraVerification?.tier).isEqualTo(LegacyTier.TIER_1)
         assertThat(extraVerification?.getConfidence()).isEqualTo(50)
@@ -227,6 +243,8 @@ class LibSimprintsResponseMapperTest {
         )
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extras.getString(Constants.SIMPRINTS_VERIFICATION)).isEqualTo(
             """
             {"guid":"guid","confidenceBand":"HIGH","confidence":50,"isSuccess":true}
@@ -253,6 +271,8 @@ class LibSimprintsResponseMapperTest {
         )
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extras.getString(Constants.SIMPRINTS_VERIFICATION)).isEqualTo(
             """
             {"guid":"guid","confidenceBand":"HIGH","confidence":50}
@@ -273,6 +293,8 @@ class LibSimprintsResponseMapperTest {
         )
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extras.getParcelable<LegacyRefusalForm>(Constants.SIMPRINTS_REFUSAL_FORM)).isEqualTo(
             LegacyRefusalForm("reason", "extra"),
         )
@@ -293,6 +315,8 @@ class LibSimprintsResponseMapperTest {
         )
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extras.getString(Constants.SIMPRINTS_REFUSAL_FORM)).isEqualTo(
             """
             {"reason":"reason","extra":"extra"}
@@ -313,6 +337,8 @@ class LibSimprintsResponseMapperTest {
         )
 
         assertThat(extras.getString(Constants.SIMPRINTS_SESSION_ID)).isEqualTo("sessionId")
+        assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
+        assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extras.getBoolean(Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK)).isTrue()
         assertThat(extras.getInt(LibSimprintsResponseMapper.RESULT_CODE_OVERRIDE)).isEqualTo(
             Constants.SIMPRINTS_UNEXPECTED_ERROR,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,7 +62,7 @@ circleImageView_version = "3.1.0"
 kermit_version = "2.0.6"
 zip4j_version = "2.11.5"
 
-libsimprints_version = "2025.1.3"
+libsimprints_version = "2025.2.1"
 simmatcher_version = "1.2.0"
 roc_wrapper_version = "1.23.0"
 roc_wrapper-v3_version = "3.1.0"


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1137)
Will be released in: **2025.3.0**

### Notable changes

* Adds deviceId and appVersionName to LibSimprints responses in the same way as it is done for CommCare responses

### Testing guidance

* Do some calls with the updated version of intents launcher

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
