### PR TITLE
[MS-1061] Fix relogin issue

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCase.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCase.kt
@@ -1,6 +1,7 @@
 package com.simprints.feature.dashboard.logout.usecase
 
 import com.simprints.infra.authlogic.AuthManager
+import com.simprints.infra.enrolment.records.repository.EnrolmentRecordRepository
 import com.simprints.infra.enrolment.records.repository.local.migration.RealmToRoomMigrationFlagsStore
 import com.simprints.infra.sync.SyncOrchestrator
 import kotlinx.coroutines.runBlocking
@@ -10,14 +11,15 @@ internal class LogoutUseCase @Inject constructor(
     private val syncOrchestrator: SyncOrchestrator,
     private val authManager: AuthManager,
     private val flagsStore: RealmToRoomMigrationFlagsStore,
+    private val enrolmentRecordRepository: EnrolmentRecordRepository,
 ) {
     operator fun invoke() = runBlocking {
-        // Cancel all background sync
         syncOrchestrator.cancelBackgroundWork()
         syncOrchestrator.deleteEventSyncInfo()
         // sign out the user
         authManager.signOut()
         // Reset migration flags
         flagsStore.clearMigrationFlags()
+        enrolmentRecordRepository.closeOpenDbConnection()
     }
 }

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCaseTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.simprints.feature.dashboard.logout.usecase
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.simprints.infra.authlogic.AuthManager
+import com.simprints.infra.enrolment.records.repository.EnrolmentRecordRepository
 import com.simprints.infra.enrolment.records.repository.local.migration.RealmToRoomMigrationFlagsStore
 import com.simprints.infra.sync.SyncOrchestrator
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
@@ -29,6 +30,8 @@ class LogoutUseCaseTest {
     @MockK
     private lateinit var flagsStore: RealmToRoomMigrationFlagsStore
 
+    @MockK lateinit var enrolmentRecordRepository: EnrolmentRecordRepository
+
     private lateinit var useCase: LogoutUseCase
 
     @Before
@@ -39,6 +42,7 @@ class LogoutUseCaseTest {
             syncOrchestrator = syncOrchestrator,
             authManager = authManager,
             flagsStore = flagsStore,
+            enrolmentRecordRepository = enrolmentRecordRepository,
         )
     }
 
@@ -51,6 +55,7 @@ class LogoutUseCaseTest {
             syncOrchestrator.deleteEventSyncInfo()
             authManager.signOut()
             flagsStore.clearMigrationFlags()
+            enrolmentRecordRepository.closeOpenDbConnection()
         }
     }
 }

--- a/infra/enrolment-records/realm-store/src/main/java/com/simprints/infra/enrolment/records/realm/store/RealmWrapper.kt
+++ b/infra/enrolment-records/realm-store/src/main/java/com/simprints/infra/enrolment/records/realm/store/RealmWrapper.kt
@@ -14,4 +14,9 @@ interface RealmWrapper {
      * that modifications are handled in a transaction.
      */
     suspend fun <R> writeRealm(block: (MutableRealm) -> R)
+
+    /**
+     *  close the Realm instance.
+     */
+    suspend fun close()
 }

--- a/infra/enrolment-records/realm-store/src/test/java/com/simprints/infra/enrolment/records/realm/store/RealmWrapperImplTest.kt
+++ b/infra/enrolment-records/realm-store/src/test/java/com/simprints/infra/enrolment/records/realm/store/RealmWrapperImplTest.kt
@@ -117,4 +117,41 @@ class RealmWrapperImplTest {
         }
         verify(exactly = 2) { Realm.open(configuration) }
     }
+
+    // test close realm instance
+    @Test
+    fun `test close realm instance`(): Unit = runTest {
+        // Given
+        realmWrapper.writeRealm { }
+        // When
+        realmWrapper.close()
+        // Then
+        verify { realm.close() }
+    }
+
+    @Test
+    fun `test close realm instance when already closed`(): Unit = runTest {
+        // Given
+        realmWrapper.writeRealm { }
+        every { realm.isClosed() } returns true
+        // When
+        realmWrapper.close()
+        // Then
+        verify(exactly = 0) { realm.close() }
+    }
+
+    // test useing a closed realm instance recreates it
+    @Test
+    fun `test using closed realm instance recreates it`(): Unit = runTest {
+        // Given
+        realmWrapper.writeRealm { } // initializes the realm instance
+        every { realm.isClosed() } returns true
+
+        // When
+        realmWrapper.writeRealm { }
+
+        // Then
+        verify { realm.isClosed() }
+        verify(exactly = 2) { Realm.open(configuration) }
+    }
 }

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/EnrolmentRecordRepositoryImpl.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/EnrolmentRecordRepositoryImpl.kt
@@ -158,4 +158,6 @@ internal class EnrolmentRecordRepositoryImpl @Inject constructor(
         insertRecordsInRoomDuringMigration(actions, project)
         selectEnrolmentRecordLocalDataSource().performActions(actions, project)
     }
+
+    override suspend fun closeOpenDbConnection() = selectEnrolmentRecordLocalDataSource().closeOpenDbConnection()
 }

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/EnrolmentRecordLocalDataSource.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/EnrolmentRecordLocalDataSource.kt
@@ -21,4 +21,6 @@ interface EnrolmentRecordLocalDataSource : IdentityDataSource {
     suspend fun getLocalDBInfo(): String
 
     suspend fun getAllSubjectIds(): List<String>
+
+    suspend fun closeOpenDbConnection()
 }

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/RealmEnrolmentRecordLocalDataSource.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/RealmEnrolmentRecordLocalDataSource.kt
@@ -365,4 +365,6 @@ internal class RealmEnrolmentRecordLocalDataSource @Inject constructor(
             .find()
             .map { it.subjectId.toString() }
     }
+
+    override suspend fun closeOpenDbConnection() = realmWrapper.close()
 }

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSource.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSource.kt
@@ -338,4 +338,8 @@ internal class RoomEnrolmentRecordLocalDataSource @Inject constructor(
     override suspend fun getAllSubjectIds(): List<String> = withContext(dispatcherIO) {
         subjectDao.getAllSubjectIds()
     }
+
+    override suspend fun closeOpenDbConnection() = withContext(dispatcherIO) {
+        subjectsDatabaseFactory.get().close()
+    }
 }

--- a/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSourceTest.kt
+++ b/infra/enrolment-records/repository/src/test/java/com/simprints/infra/enrolment/records/repository/local/RoomEnrolmentRecordLocalDataSourceTest.kt
@@ -13,6 +13,7 @@ import com.simprints.infra.enrolment.records.repository.domain.models.BiometricD
 import com.simprints.infra.enrolment.records.repository.domain.models.Subject
 import com.simprints.infra.enrolment.records.repository.domain.models.SubjectAction
 import com.simprints.infra.enrolment.records.repository.domain.models.SubjectQuery
+import com.simprints.infra.enrolment.records.room.store.SubjectsDatabase
 import com.simprints.infra.enrolment.records.room.store.SubjectsDatabaseFactory
 import com.simprints.infra.security.keyprovider.LocalDbKey
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
@@ -1582,5 +1583,28 @@ class RoomEnrolmentRecordLocalDataSourceTest {
         val finalCount = dataSource.count()
         assertThat(finalCount).isEqualTo(0)
         assertThat(initialCount).isGreaterThan(0)
+    }
+
+    @Test
+    fun `closeOpenDbConnection should close the database `() = runTest {
+        // Given
+        val mockedDb = mockk<SubjectsDatabase>(relaxed = true)
+        val mockedDbFactory = mockk<SubjectsDatabaseFactory> {
+            every { get() } returns mockedDb
+        }
+
+        dataSource = RoomEnrolmentRecordLocalDataSource(
+            timeHelper,
+            mockedDbFactory,
+            mockk(),
+            queryBuilder = RoomEnrolmentRecordQueryBuilder(),
+            dispatcherIO = testCoroutineRule.testCoroutineDispatcher,
+        )
+
+        // When
+        dataSource.closeOpenDbConnection()
+
+        // Then
+        verify { mockedDb.close() }
     }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1061)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **It’s been a long time since we started using Realm DB**

* Check the Jira ticket regarding the issue where, after a user logs out from one project and logs into another, Realm reuses the same db file, causing the user to lose some of the previously synced records.

### Notable changes

* Now, when logging out, SID closes the active DB connection, forces the creation of a new Realm file when relogin, and resolves the problem. As shown in this screenshot, two DB files are created—one for the old project and another for the new one—so there’s no need to delete the old file.
<img width="421" height="558" alt="two db files" src="https://github.com/user-attachments/assets/4705ab47-313e-4b29-b48e-c2324f24d5f4" />


### Testing guidance

* Follow the steps n the jira ticket to make sure that the issue is resolved. 

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
