### PR TITLE
Fix CommCare permission state not updated after coming back to the application

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/SettingsFragment.kt
@@ -21,8 +21,8 @@ import com.simprints.feature.dashboard.databinding.FragmentSettingsBinding
 import com.simprints.feature.dashboard.settings.password.SettingsPasswordDialogFragment
 import com.simprints.infra.config.store.models.GeneralConfiguration
 import com.simprints.infra.config.store.models.GeneralConfiguration.Modality.FINGERPRINT
-import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import com.simprints.infra.resources.R as IDR
@@ -82,7 +82,7 @@ internal class SettingsFragment : PreferenceFragmentCompat() {
         )
         viewModel.sinceConfigLastUpdated.observe(
             viewLifecycleOwner,
-            LiveDataEventWithContentObserver<String> { lastUpdated ->
+            LiveDataEventWithContentObserver { lastUpdated ->
                 getUpdateConfig()?.summary = getString(
                     IDR.string.dashboard_preference_summary_update_config_last_updated,
                     lastUpdated,

--- a/feature/setup/src/main/java/com/simprints/feature/setup/screen/SetupFragment.kt
+++ b/feature/setup/src/main/java/com/simprints/feature/setup/screen/SetupFragment.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.simprints.core.domain.permission.CommCarePermissions
 import com.simprints.core.tools.utils.TimeUtils
 import com.simprints.feature.alert.AlertContract
 import com.simprints.feature.alert.AlertResult
@@ -24,14 +25,14 @@ import com.simprints.infra.license.models.LicenseState.Started
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.LICENSE
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
-import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.finishWithResult
 import com.simprints.infra.uibase.navigation.handleResult
 import com.simprints.infra.uibase.navigation.navigateSafely
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
-import com.simprints.infra.resources.R as IDR
 import javax.inject.Inject
+import com.simprints.infra.resources.R as IDR
 
 @AndroidEntryPoint
 internal class SetupFragment : Fragment(R.layout.fragment_setup) {
@@ -78,7 +79,9 @@ internal class SetupFragment : Fragment(R.layout.fragment_setup) {
         }
         // Request CommCare permission
         viewModel.requestCommCarePermission.observe(viewLifecycleOwner) {
-            launchCommCarePermissionRequest.launch("${lastCallingPackageStore.lastCallingPackageName}.provider.cases.read")
+            launchCommCarePermissionRequest.launch(
+                CommCarePermissions.buildPermissionForPackage(lastCallingPackageStore.lastCallingPackageName ?: ""),
+            )
         }
         // Request notification permission
         viewModel.requestNotificationPermission.observe(viewLifecycleOwner) {
@@ -93,7 +96,6 @@ internal class SetupFragment : Fragment(R.layout.fragment_setup) {
         // Start the setup process
         viewModel.start()
     }
-
 
     private fun observeOverallSetupResult() = viewModel.overallSetupResult.observe(viewLifecycleOwner) {
         // if the overall setup result is success, finish the setup flow else an alert will be shown

--- a/infra/core/src/main/java/com/simprints/core/domain/permission/CommCarePermissions.kt
+++ b/infra/core/src/main/java/com/simprints/core/domain/permission/CommCarePermissions.kt
@@ -1,0 +1,15 @@
+package com.simprints.core.domain.permission
+
+/**
+ * Utility for CommCare permissions required to access CommCare content provider data.
+ */
+object CommCarePermissions {
+    /**
+     * Builds a dynamic CommCare permission string for a specific package.
+     * @param callerPackageName The package name to build the permission for
+     * @return The complete permission string in format "packageName.provider.cases.read"
+     */
+    fun buildPermissionForPackage(callerPackageName: String): String {
+        return "$callerPackageName.provider.cases.read"
+    }
+}

--- a/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/domain/models/BiometricDataSource.kt
+++ b/infra/enrolment-records/repository/src/main/java/com/simprints/infra/enrolment/records/repository/domain/models/BiometricDataSource.kt
@@ -1,6 +1,7 @@
 package com.simprints.infra.enrolment.records.repository.domain.models
 
 import androidx.annotation.Keep
+import com.simprints.core.domain.permission.CommCarePermissions
 import com.simprints.core.domain.step.StepParams
 
 @Keep
@@ -16,7 +17,7 @@ sealed class BiometricDataSource : StepParams {
     ) : BiometricDataSource() {
         override fun callerPackageName() = callerPackageName
 
-        override fun permissionName() = "$callerPackageName.provider.cases.read"
+        override fun permissionName() = CommCarePermissions.buildPermissionForPackage(callerPackageName)
     }
 
     companion object {

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/permission/CommCarePermissionChecker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/permission/CommCarePermissionChecker.kt
@@ -1,0 +1,30 @@
+package com.simprints.infra.eventsync.permission
+
+import android.content.Context
+import android.content.pm.PackageManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CommCarePermissionChecker @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+
+    /**
+     * Checks if the required CommCare permissions are granted.
+     * These permissions are needed to access CommCare content provider data.
+     *
+     * @return true if both CommCare permissions are granted, false otherwise
+     */
+    fun hasCommCarePermissions(): Boolean {
+        val permissions = listOf(
+            "org.commcare.dalvik.provider.cases.read",
+            "org.commcare.dalvik.debug.provider.cases.read"
+        )
+        
+        return permissions.any { permission ->
+            context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+}

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/permission/CommCarePermissionChecker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/permission/CommCarePermissionChecker.kt
@@ -2,6 +2,8 @@ package com.simprints.infra.eventsync.permission
 
 import android.content.Context
 import android.content.pm.PackageManager
+import com.simprints.core.domain.permission.CommCarePermissions
+import com.simprints.infra.config.store.LastCallingPackageStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -9,22 +11,17 @@ import javax.inject.Singleton
 @Singleton
 class CommCarePermissionChecker @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val lastCallingPackageStore: LastCallingPackageStore,
 ) {
-
     /**
-     * Checks if the required CommCare permissions are granted.
-     * These permissions are needed to access CommCare content provider data.
+     * Checks if the required CommCare permission is granted for the last calling package.
      *
-     * @return true if both CommCare permissions are granted, false otherwise
+     * @return true if the CommCare permission for the last calling package is granted, false otherwise
      */
     fun hasCommCarePermissions(): Boolean {
-        val permissions = listOf(
-            "org.commcare.dalvik.provider.cases.read",
-            "org.commcare.dalvik.debug.provider.cases.read"
+        val targetPermission = CommCarePermissions.buildPermissionForPackage(
+            lastCallingPackageStore.lastCallingPackageName ?: "",
         )
-        
-        return permissions.any { permission ->
-            context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
-        }
+        return context.checkSelfPermission(targetPermission) == PackageManager.PERMISSION_GRANTED
     }
 }

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/permission/CommCarePermissionCheckerTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/permission/CommCarePermissionCheckerTest.kt
@@ -1,0 +1,112 @@
+package com.simprints.infra.eventsync.permission
+
+import android.content.Context
+import android.content.pm.PackageManager
+import com.google.common.truth.Truth.assertThat
+import com.simprints.infra.config.store.LastCallingPackageStore
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class CommCarePermissionCheckerTest {
+    @MockK
+    private lateinit var context: Context
+
+    @MockK
+    private lateinit var lastCallingPackageStore: LastCallingPackageStore
+
+    private lateinit var commCarePermissionChecker: CommCarePermissionChecker
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        commCarePermissionChecker = CommCarePermissionChecker(context, lastCallingPackageStore)
+    }
+
+    @Test
+    fun `hasCommCarePermissions returns true when permission is granted`() {
+        // Given
+        val packageName = "com.example.commcare"
+        val expectedPermission = "$packageName.provider.cases.read"
+        every { lastCallingPackageStore.lastCallingPackageName } returns packageName
+        every { context.checkSelfPermission(expectedPermission) } returns PackageManager.PERMISSION_GRANTED
+
+        // When
+        val result = commCarePermissionChecker.hasCommCarePermissions()
+
+        // Then
+        assertThat(result).isTrue()
+        verify { lastCallingPackageStore.lastCallingPackageName }
+        verify { context.checkSelfPermission(expectedPermission) }
+    }
+
+    @Test
+    fun `hasCommCarePermissions returns false when permission is denied`() {
+        // Given
+        val packageName = "com.example.commcare"
+        val expectedPermission = "$packageName.provider.cases.read"
+        every { lastCallingPackageStore.lastCallingPackageName } returns packageName
+        every { context.checkSelfPermission(expectedPermission) } returns PackageManager.PERMISSION_DENIED
+
+        // When
+        val result = commCarePermissionChecker.hasCommCarePermissions()
+
+        // Then
+        assertThat(result).isFalse()
+        verify { lastCallingPackageStore.lastCallingPackageName }
+        verify { context.checkSelfPermission(expectedPermission) }
+    }
+
+    @Test
+    fun `hasCommCarePermissions handles null package name by using empty string`() {
+        // Given
+        val expectedPermission = ".provider.cases.read"
+        every { lastCallingPackageStore.lastCallingPackageName } returns null
+        every { context.checkSelfPermission(expectedPermission) } returns PackageManager.PERMISSION_DENIED
+
+        // When
+        val result = commCarePermissionChecker.hasCommCarePermissions()
+
+        // Then
+        assertThat(result).isFalse()
+        verify { lastCallingPackageStore.lastCallingPackageName }
+        verify { context.checkSelfPermission(expectedPermission) }
+    }
+
+    @Test
+    fun `hasCommCarePermissions handles empty package name`() {
+        // Given
+        val packageName = ""
+        val expectedPermission = ".provider.cases.read"
+        every { lastCallingPackageStore.lastCallingPackageName } returns packageName
+        every { context.checkSelfPermission(expectedPermission) } returns PackageManager.PERMISSION_GRANTED
+
+        // When
+        val result = commCarePermissionChecker.hasCommCarePermissions()
+
+        // Then
+        assertThat(result).isTrue()
+        verify { lastCallingPackageStore.lastCallingPackageName }
+        verify { context.checkSelfPermission(expectedPermission) }
+    }
+
+    @Test
+    fun `hasCommCarePermissions constructs correct permission string for different package names`() {
+        // Given
+        val packageName = "org.commcare.dalvik"
+        val expectedPermission = "$packageName.provider.cases.read"
+        every { lastCallingPackageStore.lastCallingPackageName } returns packageName
+        every { context.checkSelfPermission(expectedPermission) } returns PackageManager.PERMISSION_GRANTED
+
+        // When
+        val result = commCarePermissionChecker.hasCommCarePermissions()
+
+        // Then
+        assertThat(result).isTrue()
+        verify { lastCallingPackageStore.lastCallingPackageName }
+        verify { context.checkSelfPermission(expectedPermission) }
+    }
+}

--- a/infra/resources/src/main/res/values/strings.xml
+++ b/infra/resources/src/main/res/values/strings.xml
@@ -331,7 +331,7 @@
     <string name="sync_info_instruction_records">Manually synchronise records by pressing this button. <font fgcolor='#FF7C00'><u>More info</u></font></string>
     <string name="sync_info_instruction_images">Manually send images to the cloud by pressing this button. <font fgcolor='#FF7C00'><u>More info</u></font></string>
     <string name="sync_info_instruction_modules">Records from the selected modules will be synchronised. <font fgcolor='#FF7C00'><u>More info</u></font></string>
-    <string name="sync_info_instruction_comm_care_permission">Syncing from CommCare requires permission in <font fgcolor='#FF7C00'><u>Settings</u></font></string>
+    <string name="sync_info_instruction_comm_care_permission">Syncing from CommCare requires permission in <font fgcolor='#FF7C00'><u>System Settings</u></font></string>
     <string name="sync_info_instruction_error_offline">Sync needs an internet connection. <font fgcolor='#FF7C00'><u>Connection settings</u></font></string>
     <string name="sync_info_instruction_error_no_modules">Sync needs modules selected. <font fgcolor='#FF7C00'><u>Select modules</u></font></string>
     <string name="sync_info_instruction_error">Sync failed. <font fgcolor='#FF7C00'><u>More info</u></font></string>


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0-dev**

After the merging of CoDownSync changes with the Sync UI/UX update, the missing CommCare permission logic got broken:
- If permission is missing the sync card shows this with a button to lead the user to app's settings
- However, upon granting the permission and going back to the app, the UI does not reflect that the permission is now granted

### Notable changes

* Adds permission check to the sync state logic
* Extracts CommCare permission name to a central place to avoid duplicating it in numerous places
* Changes "button" name from "Settings" to "System Settings" to differentiate from SID's internal settings

### Testing guidance

- Setup CommCare sync
- Deny the permission
- Try to sync and get the missing permission error
- Tap the button, go to settings, grant the permission, come back
- Sync button should become enabled automatically

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
