### PR TITLE
[MS-1142] Refactor logout flow to run off main thread and prevent ANR

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModel.kt
@@ -50,7 +50,7 @@ internal class LogoutSyncViewModel @Inject constructor(
             emit(LiveDataEventWithContent(configManager.getProjectConfiguration().general.settingsPassword))
         }
 
-    fun logout() {
+    suspend fun logout() {
         logoutUseCase()
     }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/syncdecline/LogoutSyncDeclineFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/syncdecline/LogoutSyncDeclineFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.simprints.core.livedata.LiveDataEventWithContentObserver
@@ -15,6 +16,7 @@ import com.simprints.feature.dashboard.settings.password.SettingsPasswordDialogF
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import com.simprints.infra.resources.R as IDR
 
 @AndroidEntryPoint
@@ -74,10 +76,12 @@ class LogoutSyncDeclineFragment : Fragment(R.layout.fragment_logout_sync_decline
     }
 
     private fun processLogoutConfirmation() {
-        viewModel.logout()
-        findNavController().navigateSafely(
-            this,
-            LogoutSyncDeclineFragmentDirections.actionLogoutSyncDeclineFragmentToRequestLoginFragment(),
-        )
+        lifecycleScope.launch {
+            viewModel.logout()
+            findNavController().navigateSafely(
+                this@LogoutSyncDeclineFragment,
+                LogoutSyncDeclineFragmentDirections.actionLogoutSyncDeclineFragmentToRequestLoginFragment(),
+            )
+        }
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCase.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCase.kt
@@ -1,17 +1,20 @@
 package com.simprints.feature.dashboard.logout.usecase
 
+import com.simprints.core.DispatcherIO
 import com.simprints.infra.authlogic.AuthManager
 import com.simprints.infra.enrolment.records.repository.local.migration.RealmToRoomMigrationFlagsStore
 import com.simprints.infra.sync.SyncOrchestrator
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 internal class LogoutUseCase @Inject constructor(
     private val syncOrchestrator: SyncOrchestrator,
     private val authManager: AuthManager,
     private val flagsStore: RealmToRoomMigrationFlagsStore,
+    @DispatcherIO private val ioDispatcher: CoroutineDispatcher,
 ) {
-    operator fun invoke() = runBlocking {
+    suspend operator fun invoke() = withContext(ioDispatcher) {
         // Cancel all background sync
         syncOrchestrator.cancelBackgroundWork()
         syncOrchestrator.deleteEventSyncInfo()

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
@@ -19,7 +19,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.progressindicator.LinearProgressIndicator
-import com.simprints.core.livedata.LiveDataEventWithContentObserver
 import com.simprints.core.tools.utils.TimeUtils
 import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentSyncInfoBinding
@@ -102,7 +101,7 @@ internal class SyncInfoFragment : Fragment(R.layout.fragment_sync_info) {
             startActivity(
                 Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
                     data = Uri.fromParts("package", requireContext().packageName, null)
-                }
+                },
             )
         }
         binding.textEventSyncInstructionsOffline.setOnClickListener {
@@ -139,12 +138,9 @@ internal class SyncInfoFragment : Fragment(R.layout.fragment_sync_info) {
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                viewModel.logoutEventLiveData.observe(
-                    viewLifecycleOwner,
-                    LiveDataEventWithContentObserver {
-                        viewModel.performLogout()
-                    },
-                )
+                viewModel.logoutEventFlow.collect {
+                    viewModel.performLogout()
+                }
             }
         }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.simprints.core.DispatcherIO
 import com.simprints.core.livedata.LiveDataEventWithContent
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.feature.dashboard.logout.usecase.LogoutUseCase
@@ -20,11 +21,14 @@ import com.simprints.infra.eventsync.EventSyncManager
 import com.simprints.infra.recent.user.activity.RecentUserActivityManager
 import com.simprints.infra.sync.SyncOrchestrator
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
@@ -40,6 +44,7 @@ internal class SyncInfoViewModel @Inject constructor(
     private val timeHelper: TimeHelper,
     observeSyncInfo: ObserveSyncInfoUseCase,
     private val logoutUseCase: LogoutUseCase,
+    @DispatcherIO private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     var isPreLogoutUpSync = false
 
@@ -48,11 +53,14 @@ internal class SyncInfoViewModel @Inject constructor(
     private val _loginNavigationEventLiveData = MutableLiveData<LoginParams>()
 
     private val eventSyncStateFlow =
-        eventSyncManager.getLastSyncState(useDefaultValue = true /* otherwise value not guaranteed */).asFlow()
+        eventSyncManager
+            .getLastSyncState(
+                useDefaultValue = true, // otherwise value not guaranteed
+            ).asFlow()
     private val imageSyncStatusFlow =
         syncOrchestrator.observeImageSyncStatus()
 
-    val logoutEventLiveData: LiveData<LiveDataEventWithContent<Unit>> = combine(
+    val logoutEventFlow: Flow<LiveDataEventWithContent<Unit>> = combine(
         eventSyncStateFlow,
         imageSyncStatusFlow,
     ) { eventSyncState, imageSyncStatus ->
@@ -64,14 +72,15 @@ internal class SyncInfoViewModel @Inject constructor(
             isReadyToLogOut // only when ready
         }.map {
             LiveDataEventWithContent(Unit)
-        }.asLiveData(viewModelScope.coroutineContext)
+        }.flowOn(ioDispatcher)
 
     val syncInfoLiveData: LiveData<SyncInfo> by lazy {
         observeSyncInfo(isPreLogoutUpSync)
             .onStart {
                 startInitialSyncIfRequired()
                 syncImagesAfterEventsWhenRequired()
-            }.asLiveData(viewModelScope.coroutineContext)
+            }.flowOn(ioDispatcher)
+            .asLiveData(viewModelScope.coroutineContext)
     }
 
     fun forceEventSync() {
@@ -94,7 +103,7 @@ internal class SyncInfoViewModel @Inject constructor(
         }
     }
 
-    fun performLogout() {
+    suspend fun performLogout() {
         logoutUseCase()
     }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCase.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCase.kt
@@ -1,12 +1,14 @@
 package com.simprints.feature.dashboard.settings.syncinfo.usecase
 
 import androidx.lifecycle.asFlow
+import com.simprints.core.DispatcherIO
+import com.simprints.core.DispatcherMain
 import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.core.lifecycle.AppForegroundStateTracker
 import com.simprints.core.tools.extentions.combine9
 import com.simprints.core.tools.extentions.onChange
-import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Ticker
+import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.feature.dashboard.settings.syncinfo.SyncInfo
 import com.simprints.feature.dashboard.settings.syncinfo.SyncInfoError
@@ -34,10 +36,12 @@ import com.simprints.infra.eventsync.status.models.DownSyncCounts
 import com.simprints.infra.images.ImageRepository
 import com.simprints.infra.network.ConnectivityTracker
 import com.simprints.infra.sync.SyncOrchestrator
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
@@ -55,9 +59,14 @@ internal class ObserveSyncInfoUseCase @Inject constructor(
     private val timeHelper: TimeHelper,
     private val ticker: Ticker,
     private val appForegroundStateTracker: AppForegroundStateTracker,
+    @DispatcherMain private val mainDispatcher: CoroutineDispatcher,
+    @DispatcherIO private val ioDispatcher: CoroutineDispatcher,
 ) {
     private val eventSyncStateFlow =
-        eventSyncManager.getLastSyncState(useDefaultValue = true /* otherwise value not guaranteed */).asFlow()
+        eventSyncManager
+            .getLastSyncState(
+                useDefaultValue = true, // otherwise value not guaranteed
+            ).asFlow()
     private val imageSyncStatusFlow =
         syncOrchestrator.observeImageSyncStatus()
 
@@ -69,7 +78,11 @@ internal class ObserveSyncInfoUseCase @Inject constructor(
         imageSyncStatusFlow,
         configManager.observeProjectConfiguration(),
         configManager.observeDeviceConfiguration(),
-        appForegroundStateTracker.observeAppInForeground().filter { it }, // only when going to foreground
+        appForegroundStateTracker
+            .observeAppInForeground()
+            .filter {
+                it // only when going to foreground
+            }.flowOn(mainDispatcher), // runs in main thread by design
         ticker.observeTickOncePerMinute(),
     ) { isOnline, isLoggedIn, isRefreshing, eventSyncState, imageSyncStatus, projectConfig, deviceConfig, _, _ ->
         val currentEvents = eventSyncState.progress?.coerceAtLeast(0) ?: 0
@@ -297,7 +310,7 @@ internal class ObserveSyncInfoUseCase @Inject constructor(
         delay(timeMillis = SYNC_COMPLETION_HOLD_MILLIS)
     }.onImageSyncComplete {
         delay(timeMillis = SYNC_COMPLETION_HOLD_MILLIS)
-    }
+    }.flowOn(ioDispatcher) // upstream flows mostly do IO work
 
     // sync info change detection helpers
 
@@ -345,7 +358,7 @@ internal class ObserveSyncInfoUseCase @Inject constructor(
  * A representation of a non-overlapping, exhaustive "sync state" as shown in UI.
  * To be used in a temporary UI state calculation: good to be used with exhaustive pattern matching.
  * Not to be confused with the data layer-specific EventSyncState.
-  */
+ */
 private sealed class EventSyncVisibleState
 
 private object OnStandby : EventSyncVisibleState()

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModelTest.kt
@@ -17,13 +17,14 @@ import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import com.simprints.testtools.common.livedata.getOrAwaitValue
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -54,16 +55,16 @@ internal class LogoutSyncViewModelTest {
     fun setup() {
         MockKAnnotations.init(this, relaxed = true)
         // Setup default behavior for logoutUseCase
-        every { logoutUseCase() } returns Unit
+        coEvery { logoutUseCase() } returns Unit
     }
 
     @Test
-    fun `should logout correctly`() {
+    fun `should logout correctly`() = runTest {
         val viewModel = createViewModel()
 
         viewModel.logout()
 
-        verify(exactly = 1) { logoutUseCase() }
+        coVerify(exactly = 1) { logoutUseCase() }
     }
 
     @Test

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/syncdecline/LogoutSyncDeclineFragmentTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/syncdecline/LogoutSyncDeclineFragmentTest.kt
@@ -20,9 +20,9 @@ import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -51,7 +51,7 @@ internal class LogoutSyncDeclineFragmentTest {
             .inRoot(RootMatchers.isDialog())
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
             .perform(click())
-        verify(exactly = 1) { viewModel.logout() }
+        coVerify(exactly = 1) { viewModel.logout() }
     }
 
     @Test
@@ -66,7 +66,7 @@ internal class LogoutSyncDeclineFragmentTest {
             .inRoot(RootMatchers.isDialog())
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
             .perform(click())
-        verify(exactly = 0) { viewModel.logout() }
+        coVerify(exactly = 0) { viewModel.logout() }
     }
 
     @Test
@@ -82,7 +82,7 @@ internal class LogoutSyncDeclineFragmentTest {
             .inRoot(RootMatchers.isDialog())
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
             .perform(ViewActions.replaceText(password))
-        verify(exactly = 1) { viewModel.logout() }
+        coVerify(exactly = 1) { viewModel.logout() }
     }
 
     @Test
@@ -98,7 +98,7 @@ internal class LogoutSyncDeclineFragmentTest {
             .inRoot(RootMatchers.isDialog())
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
             .perform(click())
-        verify(exactly = 0) { viewModel.logout() }
+        coVerify(exactly = 0) { viewModel.logout() }
     }
 
     @Test

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCaseTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCaseTest.kt
@@ -39,6 +39,7 @@ class LogoutUseCaseTest {
             syncOrchestrator = syncOrchestrator,
             authManager = authManager,
             flagsStore = flagsStore,
+            ioDispatcher = testCoroutineRule.testCoroutineDispatcher,
         )
     }
 

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
@@ -2,11 +2,9 @@ package com.simprints.feature.dashboard.settings.syncinfo
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Observer
 import androidx.lifecycle.asFlow
-import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.*
 import com.simprints.core.domain.tokenization.TokenizableString
-import com.simprints.core.livedata.LiveDataEventWithContent
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.feature.dashboard.logout.usecase.LogoutUseCase
@@ -29,15 +27,9 @@ import com.simprints.infra.sync.ImageSyncStatus
 import com.simprints.infra.sync.SyncOrchestrator
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import com.simprints.testtools.common.livedata.getOrAwaitValue
-import io.mockk.MockKAnnotations
-import io.mockk.coEvery
-import io.mockk.coVerify
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.slot
-import io.mockk.verify
+import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceTimeBy
@@ -164,6 +156,7 @@ class SyncInfoViewModelTest {
             timeHelper = timeHelper,
             observeSyncInfo = observeSyncInfo,
             logoutUseCase = logoutUseCase,
+            ioDispatcher = testCoroutineRule.testCoroutineDispatcher,
         )
     }
 
@@ -241,17 +234,16 @@ class SyncInfoViewModelTest {
         every { syncOrchestrator.observeImageSyncStatus() } returns MutableStateFlow(mockNotSyncingImageStatus)
         createViewModel()
         viewModel.isPreLogoutUpSync = true
-        val observer = mockk<Observer<LiveDataEventWithContent<Unit>>>(relaxed = true)
-        val slot = slot<LiveDataEventWithContent<Unit>>()
-        val capturedValues = mutableListOf<LiveDataEventWithContent<Unit>>()
-        every { observer.onChanged(capture(slot)) } answers {
-            capturedValues.add(slot.captured)
+
+        var numberOfEmissions = 0
+        val flowCollector = async {
+            viewModel.logoutEventFlow.collect {
+                numberOfEmissions++
+            }
         }
-
-        viewModel.logoutEventLiveData.observeForever(observer)
         advanceTimeBy(3100L) // after the logout delay (3000ms)
-
-        assertThat(capturedValues.map { it.peekContent() }).contains(Unit)
+        assertThat(numberOfEmissions).isEqualTo(1)
+        flowCollector.cancel()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -269,22 +261,18 @@ class SyncInfoViewModelTest {
         every { syncOrchestrator.observeImageSyncStatus() } returns MutableStateFlow(mockNotSyncingImageStatus)
         createViewModel()
         viewModel.isPreLogoutUpSync = true
-        val observer = mockk<Observer<LiveDataEventWithContent<Unit>>>(relaxed = true)
-        val slot = slot<LiveDataEventWithContent<Unit>>()
-        val capturedValues = mutableListOf<LiveDataEventWithContent<Unit>>()
-        every { observer.onChanged(capture(slot)) } answers {
-            capturedValues.add(slot.captured)
+
+        var numberOfEmissions = 0
+        val flowCollector = async {
+            viewModel.logoutEventFlow.collect {
+                numberOfEmissions++
+            }
         }
-
-        viewModel.logoutEventLiveData.observeForever(observer)
         advanceTimeBy(2900L) // still during the debounce delay
-
-        assertThat(capturedValues).isEmpty() // no logout event yet
-
+        assertThat(numberOfEmissions).isEqualTo(0)
         advanceTimeBy(200L) // after the debounce delay (total 3100ms > 3000ms)
-
-        assertThat(capturedValues).hasSize(1)
-        assertThat(capturedValues[0].peekContent()).isEqualTo(Unit)
+        assertThat(numberOfEmissions).isEqualTo(1)
+        flowCollector.cancel()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -302,17 +290,15 @@ class SyncInfoViewModelTest {
         every { syncOrchestrator.observeImageSyncStatus() } returns MutableStateFlow(mockNotSyncingImageStatus)
         createViewModel()
         viewModel.isPreLogoutUpSync = false
-        val observer = mockk<Observer<LiveDataEventWithContent<Unit>>>(relaxed = true)
-        val slot = slot<LiveDataEventWithContent<Unit>>()
-        val capturedValues = mutableListOf<LiveDataEventWithContent<Unit>>()
-        every { observer.onChanged(capture(slot)) } answers {
-            capturedValues.add(slot.captured)
+
+        val flowCollector = async {
+            viewModel.logoutEventFlow.collect {
+                // fail if any logout event is emitted
+                assertThat(true).isFalse()
+            }
         }
-
-        viewModel.logoutEventLiveData.observeForever(observer)
         advanceTimeBy(3100L) // after the logout delay (3000ms)
-
-        assertThat(capturedValues).isEmpty()
+        flowCollector.cancel()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -331,17 +317,15 @@ class SyncInfoViewModelTest {
         every { syncOrchestrator.observeImageSyncStatus() } returns MutableStateFlow(mockNotSyncingImageStatus)
         createViewModel()
         viewModel.isPreLogoutUpSync = true
-        val observer = mockk<Observer<LiveDataEventWithContent<Unit>>>(relaxed = true)
-        val slot = slot<LiveDataEventWithContent<Unit>>()
-        val capturedValues = mutableListOf<LiveDataEventWithContent<Unit>>()
-        every { observer.onChanged(capture(slot)) } answers {
-            capturedValues.add(slot.captured)
+
+        val flowCollector = async {
+            viewModel.logoutEventFlow.collect {
+                // fail if any logout event is emitted
+                assertThat(true).isFalse()
+            }
         }
-
-        viewModel.logoutEventLiveData.observeForever(observer)
         advanceTimeBy(3100L) // after the logout delay (3000ms)
-
-        assertThat(capturedValues).isEmpty()
+        flowCollector.cancel()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -359,17 +343,15 @@ class SyncInfoViewModelTest {
         every { syncOrchestrator.observeImageSyncStatus() } returns MutableStateFlow(mockSyncingImageStatus)
         createViewModel()
         viewModel.isPreLogoutUpSync = true
-        val observer = mockk<Observer<LiveDataEventWithContent<Unit>>>(relaxed = true)
-        val slot = slot<LiveDataEventWithContent<Unit>>()
-        val capturedValues = mutableListOf<LiveDataEventWithContent<Unit>>()
-        every { observer.onChanged(capture(slot)) } answers {
-            capturedValues.add(slot.captured)
+
+        val flowCollector = async {
+            viewModel.logoutEventFlow.collect {
+                // fail test if any logout event is emitted
+                assertThat(true).isFalse()
+            }
         }
-
-        viewModel.logoutEventLiveData.observeForever(observer)
         advanceTimeBy(3100L) // after the logout delay (3000ms)
-
-        assertThat(capturedValues).isEmpty()
+        flowCollector.cancel()
     }
 
     // forceEventSync() tests
@@ -408,7 +390,7 @@ class SyncInfoViewModelTest {
         coVerify { syncOrchestrator.stopEventSync() }
         coVerify { syncOrchestrator.startEventSync(isDownSyncAllowed = false) }
     }
-    
+
     @Test
     fun `should start event sync with down sync disabled when project ending`() = runTest {
         val mockEndingProject = mockk<Project> {
@@ -468,7 +450,7 @@ class SyncInfoViewModelTest {
     fun `should call logout use case when logout invoked`() = runTest {
         viewModel.performLogout()
 
-        verify { logoutUseCase() }
+        coVerify { logoutUseCase() }
     }
 
     // requestNavigationToLogin() tests

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCaseTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCaseTest.kt
@@ -6,8 +6,8 @@ import androidx.lifecycle.asFlow
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.core.lifecycle.AppForegroundStateTracker
-import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Ticker
+import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.feature.dashboard.settings.syncinfo.SyncInfoModuleCount
 import com.simprints.infra.authstore.AuthStore
@@ -78,15 +78,13 @@ class ObserveSyncInfoUseCaseTest {
         const val TEST_MODULE_NAME = "test_module"
         val TEST_TIMESTAMP = Timestamp(1000L)
 
-        fun createMockSynchronizationConfiguration(): SynchronizationConfiguration {
-            return mockk<SynchronizationConfiguration>(relaxed = true) {
-                every { down } returns mockk<DownSynchronizationConfiguration>(relaxed = true) {
-                    every { commCare } returns null
-                }
-                every { up } returns mockk<UpSynchronizationConfiguration>(relaxed = true) {
-                    every { coSync } returns mockk<UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration>(relaxed = true) {
-                        every { kind } returns UpSynchronizationConfiguration.UpSynchronizationKind.NONE
-                    }
+        fun createMockSynchronizationConfiguration(): SynchronizationConfiguration = mockk<SynchronizationConfiguration>(relaxed = true) {
+            every { down } returns mockk<DownSynchronizationConfiguration>(relaxed = true) {
+                every { commCare } returns null
+            }
+            every { up } returns mockk<UpSynchronizationConfiguration>(relaxed = true) {
+                every { coSync } returns mockk<UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration>(relaxed = true) {
+                    every { kind } returns UpSynchronizationConfiguration.UpSynchronizationKind.NONE
                 }
             }
         }
@@ -195,6 +193,8 @@ class ObserveSyncInfoUseCaseTest {
             timeHelper = timeHelper,
             ticker = ticker,
             appForegroundStateTracker = appForegroundStateTracker,
+            ioDispatcher = testCoroutineRule.testCoroutineDispatcher,
+            mainDispatcher = testCoroutineRule.testCoroutineDispatcher,
         )
     }
 
@@ -944,9 +944,10 @@ class ObserveSyncInfoUseCaseTest {
                 }
                 every { synchronization } returns mockk<SynchronizationConfiguration>(relaxed = true) {
                     every { up } returns mockk<UpSynchronizationConfiguration>(relaxed = true) {
-                        every { coSync } returns mockk<UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration>(relaxed = true) {
-                            every { kind } returns UpSynchronizationConfiguration.UpSynchronizationKind.NONE
-                        }
+                        every { coSync } returns
+                            mockk<UpSynchronizationConfiguration.CoSyncUpSynchronizationConfiguration>(relaxed = true) {
+                                every { kind } returns UpSynchronizationConfiguration.UpSynchronizationKind.NONE
+                            }
                     }
                 }
             },

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/tools/di/FakeCoreModule.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/tools/di/FakeCoreModule.kt
@@ -8,13 +8,14 @@ import com.simprints.core.CoreModule
 import com.simprints.core.DeviceID
 import com.simprints.core.DispatcherBG
 import com.simprints.core.DispatcherIO
+import com.simprints.core.DispatcherMain
 import com.simprints.core.ExternalScope
 import com.simprints.core.NonCancellableIO
 import com.simprints.core.PackageVersionName
 import com.simprints.core.SessionCoroutineScope
 import com.simprints.core.tools.json.JsonHelper
-import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Ticker
+import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.utils.EncodingUtils
 import com.simprints.core.tools.utils.StringTokenizer
 import com.simprints.testtools.unit.EncodingUtilsImplForTests
@@ -72,6 +73,10 @@ object FakeCoreModule {
     @DispatcherBG
     @Provides
     fun provideCoroutineDispatcherBg(): CoroutineDispatcher = StandardTestDispatcher()
+
+    @DispatcherMain
+    @Provides
+    fun provideCoroutineDispatcherMain(): CoroutineDispatcher = StandardTestDispatcher()
 
     @NonCancellableIO
     @Provides

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/AuthStore.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/AuthStore.kt
@@ -5,7 +5,7 @@ import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.infra.authstore.domain.models.Token
 import com.simprints.infra.network.SimNetwork
 import com.simprints.infra.network.SimRemoteInterface
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlin.reflect.KClass
 
 interface AuthStore {
@@ -14,7 +14,7 @@ interface AuthStore {
 
     fun isProjectIdSignedIn(possibleProjectId: String): Boolean
 
-    fun observeSignedInProjectId(): StateFlow<String>
+    fun observeSignedInProjectId(): Flow<String>
 
     fun cleanCredentials()
 

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/AuthStoreImpl.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/AuthStoreImpl.kt
@@ -8,7 +8,7 @@ import com.simprints.infra.authstore.domain.models.Token
 import com.simprints.infra.authstore.network.SimApiClientFactory
 import com.simprints.infra.network.SimNetwork
 import com.simprints.infra.network.SimRemoteInterface
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import kotlin.reflect.KClass
 
@@ -29,7 +29,7 @@ internal class AuthStoreImpl @Inject constructor(
             loginInfoStore.signedInProjectId = value
         }
 
-    override fun observeSignedInProjectId(): StateFlow<String> = loginInfoStore.observeSignedInProjectId()
+    override fun observeSignedInProjectId(): Flow<String> = loginInfoStore.observeSignedInProjectId()
 
     override fun isProjectIdSignedIn(possibleProjectId: String): Boolean = loginInfoStore.isProjectIdSignedIn(possibleProjectId)
 

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
@@ -6,10 +6,8 @@ import androidx.core.content.edit
 import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.core.domain.tokenization.isTokenized
 import com.simprints.infra.security.SecurityManager
+import com.simprints.infra.security.keyprovider.keyFlow
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -41,6 +39,7 @@ internal class LoginInfoStore @Inject constructor(
      * Ensures that data has been migrated to secure prefs before accessing it.
      */
     private fun getSecurePrefs(): SharedPreferences {
+        @Suppress("DEPRECATION")
         if (prefs.contains(PROJECT_ID)) {
             securePrefs.edit(commit = true) {
                 putString(USER_ID_VALUE, prefs.getString(USER_ID_VALUE, ""))
@@ -78,19 +77,14 @@ internal class LoginInfoStore @Inject constructor(
             }
         }
 
-    private val signedInProjectIdFlow: MutableStateFlow<String> = MutableStateFlow(
-        getSecurePrefs().getString(PROJECT_ID, "").orEmpty(),
-    )
-
     var signedInProjectId: String = ""
         get() = getSecurePrefs().getString(PROJECT_ID, "").orEmpty()
         set(value) {
             field = value
             getSecurePrefs().edit { putString(PROJECT_ID, field) }
-            signedInProjectIdFlow.tryEmit(value)
         }
 
-    fun observeSignedInProjectId(): StateFlow<String> = signedInProjectIdFlow.asStateFlow()
+    fun observeSignedInProjectId() = getSecurePrefs().keyFlow(PROJECT_ID, "", true)
 
     // Core Firebase Project details. We store them to initialize the core Firebase project.
     var coreFirebaseProjectId: String = ""
@@ -128,7 +122,6 @@ internal class LoginInfoStore @Inject constructor(
     fun cleanCredentials() {
         securePrefs.clearValues()
         prefs.clearValues()
-        signedInProjectIdFlow.tryEmit("")
     }
 
     fun clearCachedTokenClaims() {

--- a/infra/security/src/main/java/com/simprints/infra/security/keyprovider/PrefFlow.kt
+++ b/infra/security/src/main/java/com/simprints/infra/security/keyprovider/PrefFlow.kt
@@ -1,0 +1,39 @@
+package com.simprints.infra.security.keyprovider
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.onStart
+
+/**
+ * Creates a Flow that emits the value of the given key in the SharedPreferences whenever it changes.
+ * Optionally, it can emit the current value immediately upon collection.
+ *
+ * @param key The key to observe in the SharedPreferences.
+ * @param default The default value to emit if the key is not present.
+ * @param emitInitial If true, the current value will be emitted immediately upon collection.
+ * @return A Flow emitting the value associated with the key, or the default value if not present.
+ */
+inline fun <reified T> SharedPreferences.keyFlow(
+    key: String,
+    default: T,
+    emitInitial: Boolean = true,
+): Flow<T> = callbackFlow {
+    val listener = SharedPreferences.OnSharedPreferenceChangeListener { prefs, changedKey ->
+        if (changedKey == key) {
+            val newValue = prefs.all[key] as? T ?: default
+            trySend(newValue)
+        }
+    }
+    registerOnSharedPreferenceChangeListener(listener)
+    awaitClose { unregisterOnSharedPreferenceChangeListener(listener) }
+}.let { base ->
+    val withInitial = if (emitInitial) {
+        base.onStart { emit(this@keyFlow.all[key] as? T ?: default) }
+    } else {
+        base
+    }
+    withInitial.distinctUntilChanged()
+}


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1142)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0**

* Check Jira ticket for reproduction steps and video recording


### Notable changes

* Moved project ID queries from the main thread to the IO thread using a SharedPreferences change listener.
* Shifted most flow checks away from the main dispatcher.


### Testing guidance

*  Test that this PR addresses and resolves the ANR occurring during the logout process.
 
### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
