### PR TITLE
[MS-1151] Sync UI: Layout adjustment for big numbers on counters to fit

### DIFF
--- a/feature/dashboard/src/main/res/layout/fragment_sync_info.xml
+++ b/feature/dashboard/src/main/res/layout/fragment_sync_info.xml
@@ -143,209 +143,265 @@
                         android:textAllCaps="true"
                         android:textColor="@color/simprints_text_orange" />
 
-                    <LinearLayout
+                    <androidx.constraintlayout.widget.ConstraintLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
                         android:paddingVertical="8dp">
 
                         <ImageView
+                            android:id="@+id/iconRecordsOnDevice"
                             android:layout_width="32dp"
                             android:layout_height="32dp"
                             android:contentDescription="@string/sync_info_records_on_device"
                             android:padding="4dp"
                             android:src="@drawable/ic_records"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
                             app:tint="@color/simprints_text_grey" />
+
+                        <TextView
+                            android:id="@+id/totalRecordsCount"
+                            style="@style/Text.Body1.Secondary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="32dp"
+                            android:layout_marginEnd="7dp"
+                            android:gravity="end|center_vertical"
+                            android:textSize="16sp"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            tools:text="137" />
+
+                        <ProgressBar
+                            android:id="@+id/totalRecordsProgress"
+                            style="@style/Text.Body1.Secondary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="32dp"
+                            android:indeterminate="true"
+                            android:indeterminateTint="@color/simprints_grey_light"
+                            android:visibility="gone"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <androidx.constraintlayout.widget.Barrier
+                            android:id="@+id/barrier_records_on_device_end"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:barrierDirection="start"
+                            app:constraint_referenced_ids="totalRecordsCount,totalRecordsProgress" />
 
                         <TextView
                             style="@style/Text.Body1"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="start"
-                            android:layout_weight="0.85"
+                            android:ellipsize="end"
+                            android:lines="1"
                             android:padding="4dp"
-                            android:text="@string/sync_info_records_on_device" />
+                            android:text="@string/sync_info_records_on_device"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/barrier_records_on_device_end"
+                            app:layout_constraintStart_toEndOf="@id/iconRecordsOnDevice"
+                            app:layout_constraintTop_toTopOf="parent" />
 
-                        <TextView
-                            android:id="@+id/totalRecordsCount"
-                            style="@style/Text.Body1.Secondary"
-                            android:layout_width="0dp"
-                            android:layout_height="32dp"
-                            android:layout_gravity="center"
-                            android:layout_marginEnd="7dp"
-                            android:layout_weight="0.15"
-                            android:gravity="end|center_vertical"
-                            tools:text="137"
-                            android:textSize="16sp" />
+                    </androidx.constraintlayout.widget.ConstraintLayout>
 
-                        <ProgressBar
-                            android:id="@+id/totalRecordsProgress"
-                            style="@style/Text.Body1.Secondary"
-                            android:indeterminate="true"
-                            android:indeterminateTint="@color/simprints_grey_light"
-                            android:layout_width="0dp"
-                            android:layout_height="32dp"
-                            android:layout_gravity="center"
-                            android:layout_weight="0.15"
-                            android:visibility="gone"
-                            android:gravity="end|center_vertical" />
-
-                    </LinearLayout>
-
-                    <LinearLayout
+                    <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/layoutRecordsToUpload"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
                         android:paddingVertical="8dp">
 
                         <ImageView
+                            android:id="@+id/iconRecordsToUpload"
                             android:layout_width="32dp"
                             android:layout_height="32dp"
                             android:contentDescription="@string/sync_info_records_to_up_sync"
                             android:padding="4dp"
                             android:src="@drawable/ic_up_sync"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
                             app:tint="@color/simprints_text_grey" />
+
+                        <TextView
+                            android:id="@+id/recordsToUploadCount"
+                            style="@style/Text.Body1.Secondary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="32dp"
+                            android:layout_marginEnd="7dp"
+                            android:gravity="end|center_vertical"
+                            android:textSize="16sp"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            tools:text="41" />
+
+                        <ProgressBar
+                            android:id="@+id/recordsToUploadProgress"
+                            style="@style/Text.Body1.Secondary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="32dp"
+                            android:indeterminate="true"
+                            android:indeterminateTint="@color/simprints_grey_light"
+                            android:visibility="gone"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <androidx.constraintlayout.widget.Barrier
+                            android:id="@+id/barrier_records_upload_end"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:barrierDirection="start"
+                            app:constraint_referenced_ids="recordsToUploadCount,recordsToUploadProgress" />
 
                         <TextView
                             style="@style/Text.Body1"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="start"
-                            android:layout_weight="0.85"
+                            android:ellipsize="end"
+                            android:lines="1"
                             android:padding="4dp"
-                            android:text="@string/sync_info_records_to_up_sync" />
+                            android:text="@string/sync_info_records_to_up_sync"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/barrier_records_upload_end"
+                            app:layout_constraintStart_toEndOf="@id/iconRecordsToUpload"
+                            app:layout_constraintTop_toTopOf="parent" />
 
-                        <TextView
-                            android:id="@+id/recordsToUploadCount"
-                            style="@style/Text.Body1.Secondary"
-                            android:layout_width="0dp"
-                            android:layout_height="32dp"
-                            android:layout_gravity="center"
-                            android:layout_marginEnd="7dp"
-                            android:layout_weight="0.15"
-                            android:gravity="end|center_vertical"
-                            tools:text="41"
-                            android:textSize="16sp" />
+                    </androidx.constraintlayout.widget.ConstraintLayout>
 
-                        <ProgressBar
-                            android:id="@+id/recordsToUploadProgress"
-                            style="@style/Text.Body1.Secondary"
-                            android:indeterminate="true"
-                            android:indeterminateTint="@color/simprints_grey_light"
-                            android:layout_width="0dp"
-                            android:layout_height="32dp"
-                            android:layout_gravity="center"
-                            android:layout_weight="0.15"
-                            android:visibility="gone"
-                            android:gravity="end|center_vertical" />
-
-                    </LinearLayout>
-
-                    <LinearLayout
+                    <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/layoutRecordsToDownload"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
                         android:paddingVertical="8dp">
 
                         <ImageView
+                            android:id="@+id/iconRecordsToDownload"
                             android:layout_width="32dp"
                             android:layout_height="32dp"
                             android:contentDescription="@string/sync_info_records_to_down_sync"
                             android:padding="4dp"
                             android:src="@drawable/ic_down_sync"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
                             app:tint="@color/simprints_text_grey" />
+
+                        <TextView
+                            android:id="@+id/recordsToDownloadCount"
+                            style="@style/Text.Body1.Secondary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="32dp"
+                            android:layout_marginEnd="7dp"
+                            android:gravity="end|center_vertical"
+                            android:textSize="16sp"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            tools:text="16" />
+
+                        <ProgressBar
+                            android:id="@+id/recordsToDownloadProgress"
+                            style="@style/Text.Body1.Secondary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="32dp"
+                            android:indeterminate="true"
+                            android:indeterminateTint="@color/simprints_grey_light"
+                            android:visibility="gone"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <androidx.constraintlayout.widget.Barrier
+                            android:id="@+id/barrier_records_download_end"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:barrierDirection="start"
+                            app:constraint_referenced_ids="recordsToDownloadCount,recordsToDownloadProgress" />
 
                         <TextView
                             style="@style/Text.Body1"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="start"
-                            android:layout_weight="0.85"
+                            android:ellipsize="end"
+                            android:lines="1"
                             android:padding="4dp"
-                            android:text="@string/sync_info_records_to_down_sync" />
+                            android:text="@string/sync_info_records_to_down_sync"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/barrier_records_download_end"
+                            app:layout_constraintStart_toEndOf="@id/iconRecordsToDownload"
+                            app:layout_constraintTop_toTopOf="parent" />
 
-                        <TextView
-                            android:id="@+id/recordsToDownloadCount"
-                            style="@style/Text.Body1.Secondary"
-                            android:layout_width="0dp"
-                            android:layout_height="32dp"
-                            android:layout_gravity="center"
-                            android:layout_marginEnd="7dp"
-                            android:layout_weight="0.15"
-                            android:gravity="end|center_vertical"
-                            tools:text="16"
-                            android:textSize="16sp" />
+                    </androidx.constraintlayout.widget.ConstraintLayout>
 
-                        <ProgressBar
-                            android:id="@+id/recordsToDownloadProgress"
-                            style="@style/Text.Body1.Secondary"
-                            android:indeterminate="true"
-                            android:indeterminateTint="@color/simprints_grey_light"
-                            android:layout_width="0dp"
-                            android:layout_height="32dp"
-                            android:layout_gravity="center"
-                            android:layout_weight="0.15"
-                            android:visibility="gone"
-                            android:gravity="end|center_vertical" />
-
-                    </LinearLayout>
-
-                    <LinearLayout
+                    <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/layoutComboImageCounter"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:visibility="gone"
-                        android:paddingVertical="8dp">
+                        android:paddingVertical="8dp"
+                        android:visibility="gone">
 
                         <ImageView
+                            android:id="@+id/iconComboImagesToUpload"
                             android:layout_width="32dp"
                             android:layout_height="32dp"
                             android:contentDescription="@string/sync_info_images_to_up_sync"
                             android:padding="4dp"
                             android:src="@drawable/ic_images"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
                             app:tint="@color/simprints_text_grey" />
+
+                        <TextView
+                            android:id="@+id/comboImagesToUploadCount"
+                            style="@style/Text.Body1.Secondary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="32dp"
+                            android:layout_marginEnd="7dp"
+                            android:gravity="end|center_vertical"
+                            android:textSize="16sp"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            tools:text="30" />
+
+                        <ProgressBar
+                            android:id="@+id/comboImagesToUploadProgress"
+                            style="@style/Text.Body1.Secondary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="32dp"
+                            android:indeterminate="true"
+                            android:indeterminateTint="@color/simprints_grey_light"
+                            android:visibility="gone"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <androidx.constraintlayout.widget.Barrier
+                            android:id="@+id/barrier_combo_images_upload_end"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:barrierDirection="start"
+                            app:constraint_referenced_ids="comboImagesToUploadCount,comboImagesToUploadProgress" />
 
                         <TextView
                             style="@style/Text.Body1"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="start"
-                            android:layout_weight="0.85"
+                            android:ellipsize="end"
+                            android:lines="1"
                             android:padding="4dp"
-                            android:text="@string/sync_info_images_to_up_sync" />
+                            android:text="@string/sync_info_images_to_up_sync"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/barrier_combo_images_upload_end"
+                            app:layout_constraintStart_toEndOf="@id/iconComboImagesToUpload"
+                            app:layout_constraintTop_toTopOf="parent" />
 
-                        <TextView
-                            android:id="@+id/comboImagesToUploadCount"
-                            style="@style/Text.Body1.Secondary"
-                            android:layout_width="0dp"
-                            android:layout_height="32dp"
-                            android:layout_gravity="center"
-                            android:layout_marginEnd="7dp"
-                            android:layout_weight="0.15"
-                            android:gravity="end|center_vertical"
-                            tools:text="30"
-                            android:textSize="16sp" />
-
-                        <ProgressBar
-                            android:id="@+id/comboImagesToUploadProgress"
-                            style="@style/Text.Body1.Secondary"
-                            android:indeterminate="true"
-                            android:indeterminateTint="@color/simprints_grey_light"
-                            android:layout_width="0dp"
-                            android:layout_height="32dp"
-                            android:layout_gravity="center"
-                            android:layout_weight="0.15"
-                            android:visibility="gone"
-                            android:gravity="end|center_vertical" />
-                    </LinearLayout>
-
+                    </androidx.constraintlayout.widget.ConstraintLayout>
 
 
                     <LinearLayout
@@ -538,54 +594,69 @@
                         android:textAllCaps="true"
                         android:textColor="@color/simprints_text_orange" />
 
-                    <LinearLayout
+                    <androidx.constraintlayout.widget.ConstraintLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
                         android:paddingVertical="8dp">
 
                         <ImageView
+                            android:id="@+id/iconImagesToUpload"
                             android:layout_width="32dp"
                             android:layout_height="32dp"
                             android:contentDescription="@string/sync_info_images_to_up_sync"
                             android:padding="4dp"
                             android:src="@drawable/ic_images"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
                             app:tint="@color/simprints_text_grey" />
+
+                        <TextView
+                            android:id="@+id/imagesToUploadCount"
+                            style="@style/Text.Body1.Secondary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="32dp"
+                            android:layout_marginEnd="7dp"
+                            android:gravity="end|center_vertical"
+                            android:textSize="16sp"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            tools:text="30" />
+
+                        <ProgressBar
+                            android:id="@+id/imagesToUploadProgress"
+                            style="@style/Text.Body1.Secondary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="32dp"
+                            android:indeterminate="true"
+                            android:indeterminateTint="@color/simprints_grey_light"
+                            android:visibility="gone"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <androidx.constraintlayout.widget.Barrier
+                            android:id="@+id/barrier_images_upload_end"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:barrierDirection="start"
+                            app:constraint_referenced_ids="imagesToUploadCount,imagesToUploadProgress" />
 
                         <TextView
                             style="@style/Text.Body1"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="start"
-                            android:layout_weight="0.85"
+                            android:ellipsize="end"
+                            android:lines="1"
                             android:padding="4dp"
-                            android:text="@string/sync_info_images_to_up_sync" />
+                            android:text="@string/sync_info_images_to_up_sync"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/barrier_images_upload_end"
+                            app:layout_constraintStart_toEndOf="@id/iconImagesToUpload"
+                            app:layout_constraintTop_toTopOf="parent" />
 
-                        <TextView
-                            android:id="@+id/imagesToUploadCount"
-                            style="@style/Text.Body1.Secondary"
-                            android:layout_width="0dp"
-                            android:layout_height="32dp"
-                            android:layout_gravity="center"
-                            android:layout_marginEnd="7dp"
-                            android:layout_weight="0.15"
-                            android:gravity="end|center_vertical"
-                            tools:text="30"
-                            android:textSize="16sp" />
-
-                        <ProgressBar
-                            android:id="@+id/imagesToUploadProgress"
-                            style="@style/Text.Body1.Secondary"
-                            android:indeterminate="true"
-                            android:indeterminateTint="@color/simprints_grey_light"
-                            android:layout_width="0dp"
-                            android:layout_height="32dp"
-                            android:layout_gravity="center"
-                            android:layout_weight="0.15"
-                            android:visibility="gone"
-                            android:gravity="end|center_vertical" />
-                    </LinearLayout>
+                    </androidx.constraintlayout.widget.ConstraintLayout>
 
                     <FrameLayout
                         android:layout_width="match_parent"

--- a/feature/dashboard/src/main/res/layout/item_module_count.xml
+++ b/feature/dashboard/src/main/res/layout/item_module_count.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="horizontal"
     android:paddingVertical="8dp">
 
     <ImageView
@@ -14,29 +13,36 @@
         android:contentDescription="@string/sync_info_item_default"
         android:padding="4dp"
         android:src="@drawable/ic_module"
-        app:tint="@color/simprints_text_grey" />
+        app:tint="@color/simprints_text_grey"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+    <TextView
+        android:id="@+id/moduleCountText"
+        style="@style/Text.Body1.Secondary"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        android:layout_marginEnd="7dp"
+        android:gravity="end|center_vertical"
+        android:textSize="16sp"
+        tools:text="42"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <TextView
         android:id="@+id/moduleNameText"
         style="@style/Text.Body1"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:layout_weight="0.85"
         android:padding="4dp"
+        android:lines="1"
+        android:ellipsize="end"
+        app:layout_constraintStart_toEndOf="@id/moduleItemIcon"
+        app:layout_constraintEnd_toStartOf="@id/moduleCountText"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         tools:text="Module1" />
 
-    <TextView
-        android:id="@+id/moduleCountText"
-        style="@style/Text.Body1.Secondary"
-        android:layout_width="0dp"
-        android:layout_height="32dp"
-        android:layout_gravity="center"
-        android:layout_marginEnd="7dp"
-        android:layout_weight="0.15"
-        android:gravity="end|center_vertical"
-        tools:text="42"
-        android:textSize="16sp" />
-
-
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1151)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: 2025.2.0, dev-only

* Numbers of events or images had fixed width
* On sode devices big (5+ digits) numbers didn't fit in one line

### Notable changes

* Numbers of events or images fit in one line
* In the edge case when the text to the left of the number doesn't fit, that text gets ellipsized. _Example, exaggerated:_

<img width="300" src="https://github.com/user-attachments/assets/2f0e44a1-efe7-4ea4-9028-8e80ce91c729" />

### Testing guidance

* See sync info when there are many events, 10000+. The number should fit

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
