### PR TITLE
[MS-1156] Change TokenizableString from Parcelable to Serializable

### DIFF
--- a/infra/core/src/main/java/com/simprints/core/domain/tokenization/TokenizableString.kt
+++ b/infra/core/src/main/java/com/simprints/core/domain/tokenization/TokenizableString.kt
@@ -1,10 +1,9 @@
 package com.simprints.core.domain.tokenization
 
-import android.os.Parcelable
 import androidx.annotation.Keep
 import com.simprints.core.domain.tokenization.TokenizableString.Raw
 import com.simprints.core.domain.tokenization.TokenizableString.Tokenized
-import kotlinx.parcelize.Parcelize
+import java.io.Serializable
 
 /**
  * Sealed class for values that might be tokenized (symmetrically encrypted). Use this wrapping
@@ -15,10 +14,9 @@ import kotlinx.parcelize.Parcelize
  */
 
 @Keep
-sealed class TokenizableString : Parcelable {
+sealed class TokenizableString : Serializable {
     abstract val value: String
 
-    @Parcelize
     data class Tokenized(
         override val value: String,
     ) : TokenizableString() {
@@ -29,7 +27,6 @@ sealed class TokenizableString : Parcelable {
         override fun toString() = super.toString()
     }
 
-    @Parcelize
     data class Raw(
         override val value: String,
     ) : TokenizableString() {


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1156)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0**

* Check the jira ticket for more info on how to get this issue.

### Notable changes

* This PR fixes a crash that occurs when the app is moved to the background during the login flow. The crash is caused by a NotSerializableException for TokenizableString.Raw because LoginParams implements StepParams (which is Serializable) but TokenizableString and its subclasses were not serializable.
* Reason for not using Parcelable:
The StepParams interface is used widely across the app and is already Serializable. Converting everything to Parcelable would require refactoring all existing StepParams implementations,

### Testing guidance

* Login and move the app to background and restore it should be OK

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
