### PR TITLE
[MS-1159] Sync (and adjacent) screens UI init speedup

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.asFlow
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
+import com.simprints.core.DispatcherMain
 import com.simprints.core.livedata.LiveDataEventWithContent
 import com.simprints.feature.dashboard.logout.usecase.LogoutUseCase
 import com.simprints.infra.authstore.AuthStore
@@ -13,25 +14,31 @@ import com.simprints.infra.config.store.models.SettingsPasswordConfig
 import com.simprints.infra.config.sync.ConfigManager
 import com.simprints.infra.eventsync.EventSyncManager
 import com.simprints.infra.sync.SyncOrchestrator
+import dagger.Lazy
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 internal class LogoutSyncViewModel @Inject constructor(
-    private val configManager: ConfigManager,
-    eventSyncManager: EventSyncManager,
-    syncOrchestrator: SyncOrchestrator,
-    authStore: AuthStore,
-    private val logoutUseCase: LogoutUseCase,
+    private val configManager: Lazy<ConfigManager>,
+    eventSyncManager: Lazy<EventSyncManager>,
+    syncOrchestrator: Lazy<SyncOrchestrator>,
+    authStore: Lazy<AuthStore>,
+    private val logoutUseCase: Lazy<LogoutUseCase>,
+    @DispatcherMain private val mainDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     val logoutEventLiveData: LiveData<Unit> =
-        authStore
+        authStore.get()
             .observeSignedInProjectId()
             .filter { projectId ->
                 projectId.isEmpty()
@@ -39,21 +46,25 @@ internal class LogoutSyncViewModel @Inject constructor(
             .map { /* Unit on every "true" */ }
             .asLiveData(viewModelScope.coroutineContext)
 
-    val isLogoutWithoutSyncVisibleLiveData: LiveData<Boolean> = combine(
-        eventSyncManager.getLastSyncState(useDefaultValue = true).asFlow(),
-        syncOrchestrator.observeImageSyncStatus(),
-    ) { eventSyncState, imageSyncStatus ->
-        !eventSyncState.isSyncCompleted() || imageSyncStatus.isSyncing
-    }.debounce(timeoutMillis = ANTI_JITTER_DELAY_MILLIS).asLiveData(viewModelScope.coroutineContext)
+    val isLogoutWithoutSyncVisibleLiveData: LiveData<Boolean> = flow {
+        emitAll(
+            combine(
+                eventSyncManager.get().getLastSyncState(useDefaultValue = true).asFlow(),
+                syncOrchestrator.get().observeImageSyncStatus(),
+            ) { eventSyncState, imageSyncStatus ->
+                !eventSyncState.isSyncCompleted() || imageSyncStatus.isSyncing
+            }.debounce(timeoutMillis = ANTI_JITTER_DELAY_MILLIS)
+        )
+    }.flowOn(mainDispatcher).asLiveData(viewModelScope.coroutineContext)
 
     val settingsLocked: LiveData<LiveDataEventWithContent<SettingsPasswordConfig>>
         get() = liveData(context = viewModelScope.coroutineContext) {
-            emit(LiveDataEventWithContent(configManager.getProjectConfiguration().general.settingsPassword))
+            emit(LiveDataEventWithContent(configManager.get().getProjectConfiguration().general.settingsPassword))
         }
 
     fun logout() {
         viewModelScope.launch {
-            logoutUseCase()
+            logoutUseCase.get().invoke()
         }
     }
 

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModelTest.kt
@@ -161,10 +161,11 @@ internal class LogoutSyncViewModelTest {
     }
 
     private fun createViewModel() = LogoutSyncViewModel(
-        configManager = configManager,
-        eventSyncManager = eventSyncManager,
-        syncOrchestrator = syncOrchestrator,
-        authStore = authStore,
-        logoutUseCase = logoutUseCase,
+        configManager = ::configManager,
+        eventSyncManager = ::eventSyncManager,
+        syncOrchestrator = ::syncOrchestrator,
+        authStore = ::authStore,
+        logoutUseCase = ::logoutUseCase,
+        mainDispatcher = testCoroutineRule.testCoroutineDispatcher,
     )
 }

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/about/AboutViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/about/AboutViewModelTest.kt
@@ -64,10 +64,10 @@ class AboutViewModelTest {
     @Test
     fun `should initialize the live data correctly`() {
         val viewModel = AboutViewModel(
-            configManager = configManager,
-            eventSyncManager = eventSyncManager,
-            recentUserActivityManager = recentUserActivityManager,
-            logoutUseCase = logoutUseCase,
+            configManager = ::configManager,
+            eventSyncManager = ::eventSyncManager,
+            recentUserActivityManager = ::recentUserActivityManager,
+            logoutUseCase = ::logoutUseCase,
         )
 
         assertThat(viewModel.modalities.value).isEqualTo(MODALITIES)
@@ -202,10 +202,10 @@ class AboutViewModelTest {
             upSyncKind,
         )
         return AboutViewModel(
-            configManager = configManager,
-            eventSyncManager = eventSyncManager,
-            recentUserActivityManager = recentUserActivityManager,
-            logoutUseCase = logoutUseCase,
+            configManager = ::configManager,
+            eventSyncManager = ::eventSyncManager,
+            recentUserActivityManager = ::recentUserActivityManager,
+            logoutUseCase = ::logoutUseCase,
         )
     }
 }

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
@@ -150,14 +150,14 @@ class SyncInfoViewModelTest {
 
     private fun createViewModel() {
         viewModel = SyncInfoViewModel(
-            configManager = configManager,
-            authStore = authStore,
-            eventSyncManager = eventSyncManager,
-            syncOrchestrator = syncOrchestrator,
-            recentUserActivityManager = recentUserActivityManager,
-            timeHelper = timeHelper,
-            observeSyncInfo = observeSyncInfo,
-            logoutUseCase = logoutUseCase,
+            configManager = ::configManager,
+            authStore = ::authStore,
+            eventSyncManager = ::eventSyncManager,
+            syncOrchestrator = ::syncOrchestrator,
+            recentUserActivityManager = ::recentUserActivityManager,
+            timeHelper = ::timeHelper,
+            observeSyncInfo = ::observeSyncInfo,
+            logoutUseCase = ::logoutUseCase,
             ioDispatcher = testCoroutineRule.testCoroutineDispatcher,
         )
     }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1159)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: 2025.3.0 (dev only)

* Sync Information, About and Logout screen ViewModels accumulated a lot of heavy dependencies over time, and especially during the sync UI rewrite. Also some flows were delaying the ViewModel initialization while waiting for the first emitted value. So, where it affected performance, these things were adjusted to be "lazy". That removes the UI freeze before these screens open.

### Notable changes & testing guidance

* UI responsiveness when opening Sync Information, About or Logout screen, before: 🐢
* UI responsiveness when opening Sync Information, About or Logout screen, after: 🚀

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
