### PR TITLE
MS-1158 Compromised logout handling

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfo.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfo.kt
@@ -84,3 +84,8 @@ data class SyncInfoModuleCount(
     val name: String,
     val count: String = "",
 )
+
+enum class LogoutActionReason {
+    USER_ACTION,
+    PROJECT_ENDING,
+}

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
@@ -19,14 +19,18 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.progressindicator.LinearProgressIndicator
+import com.simprints.core.livedata.LiveDataEventWithContentObserver
 import com.simprints.core.tools.utils.TimeUtils
 import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentSyncInfoBinding
+import com.simprints.feature.dashboard.requestlogin.LogoutReason
+import com.simprints.feature.dashboard.requestlogin.RequestLoginFragmentArgs
 import com.simprints.feature.dashboard.settings.syncinfo.modulecount.ModuleCount
 import com.simprints.feature.dashboard.settings.syncinfo.modulecount.ModuleCountAdapter
 import com.simprints.feature.dashboard.view.ConfigurableSyncInfoFragmentContainer
 import com.simprints.feature.login.LoginContract
 import com.simprints.infra.uibase.navigation.handleResult
+import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.navigation.toBundle
 import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.view.setPulseAnimation
@@ -139,7 +143,7 @@ internal class SyncInfoFragment : Fragment(R.layout.fragment_sync_info) {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 viewModel.logoutEventFlow.collect {
-                    viewModel.performLogout()
+                    viewModel.performLogout(it)
                 }
             }
         }
@@ -147,6 +151,23 @@ internal class SyncInfoFragment : Fragment(R.layout.fragment_sync_info) {
         viewModel.loginNavigationEventLiveData.observe(viewLifecycleOwner) { loginParams ->
             findNavController().navigate(com.simprints.feature.login.R.id.graph_login, loginParams.toBundle())
         }
+        viewModel.signOutNavigationLiveData.observe(
+            viewLifecycleOwner,
+            LiveDataEventWithContentObserver { reason ->
+                val logoutReason = reason?.takeIf { it == LogoutActionReason.PROJECT_ENDING }?.let {
+                    LogoutReason(
+                        title = getString(IDR.string.dashboard_sync_project_ending_alert_title),
+                        body = getString(IDR.string.dashboard_sync_project_ending_message),
+                    )
+                }
+
+                findNavController().navigateSafely(
+                    parentFragment,
+                    R.id.action_to_requestLoginFragment,
+                    RequestLoginFragmentArgs(logoutReason = logoutReason).toBundle(),
+                )
+            },
+        )
     }
 
     private fun renderSyncInfo(

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCase.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCase.kt
@@ -234,12 +234,15 @@ internal class ObserveSyncInfoUseCase @Inject constructor(
         }
 
         val project = try {
-            configManager.getProject(projectId)
-        } catch (e: Exception) {
+            projectId.takeUnless { it.isBlank() }?.let { configManager.getProject(it) }
+        } catch (_: Exception) {
+            // When the device is compromised the project data will be deleted and
+            // attempting to access project state with result in exception.
+            // For user it is essentially the same as project ending.
             null
         }
-        val isProjectRunning =
-            project?.state == ProjectState.RUNNING
+
+        val isProjectRunning = project?.state == ProjectState.RUNNING
         val moduleCounts = if (project != null) {
             deviceConfig.selectedModules.map { moduleName ->
                 ModuleCount(

--- a/feature/dashboard/src/main/res/navigation/graph_dashboard.xml
+++ b/feature/dashboard/src/main/res/navigation/graph_dashboard.xml
@@ -62,11 +62,6 @@
             android:id="@+id/action_mainFragment_to_moduleSelectionFragment"
             app:destination="@id/moduleSelectionFragment" />
         <action
-            android:id="@+id/action_mainFragment_to_requestLoginFragment"
-            app:destination="@id/requestLoginFragment"
-            app:popUpTo="@id/dashboard_navigation"
-            app:popUpToInclusive="true" />
-        <action
             android:id="@+id/action_mainFragment_to_privacyNoticesFragment"
             app:destination="@id/graph_privacy" />
         <action
@@ -170,5 +165,11 @@
                 app:popUpToInclusive="true" />
         </fragment>
     </navigation>
+
+    <action
+        android:id="@+id/action_to_requestLoginFragment"
+        app:destination="@id/requestLoginFragment"
+        app:popUpTo="@id/dashboard_navigation"
+        app:popUpToInclusive="true" />
 
 </navigation>

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
@@ -34,12 +34,14 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.fail
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class SyncInfoViewModelTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
@@ -221,7 +223,6 @@ class SyncInfoViewModelTest {
 
     // LiveData logoutEventLiveData tests
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `should trigger logout when pre-logout sync completes successfully`() = runTest {
         val mockCompletedEventSyncState = mockk<EventSyncState>(relaxed = true) {
@@ -248,7 +249,6 @@ class SyncInfoViewModelTest {
         flowCollector.cancel()
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `should emit a logout event after the intended delay since ready to logout`() = runTest {
         val mockCompletedEventSyncState = mockk<EventSyncState>(relaxed = true) {
@@ -277,7 +277,25 @@ class SyncInfoViewModelTest {
         flowCollector.cancel()
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `should emit a logout event when auth store is cleared`() = runTest {
+        val projectIdFlow = MutableStateFlow(TEST_PROJECT_ID)
+        every { authStore.observeSignedInProjectId() } returns projectIdFlow
+        createViewModel()
+
+        var numberOfEmissions = 0
+        val flowCollector = async {
+            viewModel.logoutEventFlow.collect {
+                numberOfEmissions++
+            }
+        }
+        projectIdFlow.value = ""
+        advanceUntilIdle()
+
+        assertThat(numberOfEmissions).isEqualTo(1)
+        flowCollector.cancel()
+    }
+
     @Test
     fun `should not trigger logout when not in pre-logout mode`() = runTest {
         val mockCompletedEventSyncState = mockk<EventSyncState>(relaxed = true) {
@@ -303,7 +321,6 @@ class SyncInfoViewModelTest {
         flowCollector.cancel()
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `should not trigger logout when records still syncing`() = runTest {
         val mockInProgressEventSyncState = mockk<EventSyncState>(relaxed = true) {
@@ -330,7 +347,6 @@ class SyncInfoViewModelTest {
         flowCollector.cancel()
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `should not trigger logout when images still syncing`() = runTest {
         val mockCompletedEventSyncState = mockk<EventSyncState>(relaxed = true) {
@@ -450,7 +466,7 @@ class SyncInfoViewModelTest {
 
     @Test
     fun `should call logout use case when logout invoked`() = runTest {
-        viewModel.performLogout()
+        viewModel.performLogout(null)
 
         coVerify { logoutUseCase() }
     }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1158)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0**

* There are 2 compounding issues happening when the user is being logged out of the compromised device (i.e. the auth data is wiped).
  * Requests for `getProject()` throw exceptions since there is no valid way to get the project, and attempting to "refresh" the project data causes a crash.
  * The handling for the compromised device log-out got lost in the refactoring.

### Notable changes

* Restored the logout navigation if the project ID is missing in the auth store.
* Gracefully handling the exception when attempting to access a missing project config.

### Testing guidance

* Log into SID.
* Mark the device as compromised in Vulcan.
* Update the local configuration.
* Navigate to the main dashboard screen.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
