### PR TITLE
MS-1158 Compromised logout fix

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfo.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfo.kt
@@ -84,3 +84,8 @@ data class SyncInfoModuleCount(
     val name: String,
     val count: String = "",
 )
+
+enum class LogoutActionReason {
+    USER_ACTION,
+    PROJECT_ENDING_OR_DEVICE_COMPROMISED,
+}

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
@@ -140,8 +140,16 @@ internal class SyncInfoViewModel @Inject constructor(
                 eventSyncButtonClickFlow.emit(Unit)
             }
             syncOrchestrator.stopEventSync()
-            val isDownSyncAllowed =
-                !isPreLogoutUpSync && configManager.getProject(authStore.signedInProjectId).state == ProjectState.RUNNING
+            val projectState = try {
+                configManager.getProject(authStore.signedInProjectId).state
+            } catch (_: Exception) {
+                // When the device is compromised the project data will be deleted and
+                // attempting to access project state with result in exception.
+                // For user it is essentially the same as project ending.
+                ProjectState.PROJECT_ENDED
+            }
+
+            val isDownSyncAllowed = !isPreLogoutUpSync && projectState == ProjectState.RUNNING
             syncOrchestrator.startEventSync(isDownSyncAllowed)
         }
     }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
@@ -148,9 +148,8 @@ internal class SyncInfoViewModel @Inject constructor(
             val projectState = try {
                 configManager.getProject(authStore.signedInProjectId).state
             } catch (_: Exception) {
-                // When the device is compromised the project data will be deleted and
-                // attempting to access project state with result in exception.
-                // For user it is essentially the same as project ending.
+                // If the device is compromised, project data is deleted. Access attempts will throw an exception,
+                // effectively appearing to the user as if the project has ended.
                 ProjectState.PROJECT_ENDED
             }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCase.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCase.kt
@@ -236,9 +236,8 @@ internal class ObserveSyncInfoUseCase @Inject constructor(
         val project = try {
             projectId.takeUnless { it.isBlank() }?.let { configManager.getProject(it) }
         } catch (_: Exception) {
-            // When the device is compromised the project data will be deleted and
-            // attempting to access project state with result in exception.
-            // For user it is essentially the same as project ending.
+            // If the device is compromised, project data is deleted. Access attempts will throw an exception,
+            // effectively appearing to the user as if the project has ended.
             null
         }
 

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCase.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCase.kt
@@ -234,12 +234,15 @@ internal class ObserveSyncInfoUseCase @Inject constructor(
         }
 
         val project = try {
-            configManager.getProject(projectId)
-        } catch (e: Exception) {
+            projectId.takeUnless { it.isBlank() }?.let { configManager.getProject(it) }
+        } catch (_: Exception) {
+            // When the device is compromised the project data will be deleted and
+            // attempting to access project state with result in exception.
+            // For user it is essentially the same as project ending.
             null
         }
-        val isProjectRunning =
-            project?.state == ProjectState.RUNNING
+
+        val isProjectRunning = project?.state == ProjectState.RUNNING
         val moduleCounts = if (project != null) {
             deviceConfig.selectedModules.map { moduleName ->
                 ModuleCount(

--- a/feature/dashboard/src/main/res/navigation/graph_dashboard.xml
+++ b/feature/dashboard/src/main/res/navigation/graph_dashboard.xml
@@ -62,11 +62,6 @@
             android:id="@+id/action_mainFragment_to_moduleSelectionFragment"
             app:destination="@id/moduleSelectionFragment" />
         <action
-            android:id="@+id/action_mainFragment_to_requestLoginFragment"
-            app:destination="@id/requestLoginFragment"
-            app:popUpTo="@id/dashboard_navigation"
-            app:popUpToInclusive="true" />
-        <action
             android:id="@+id/action_mainFragment_to_privacyNoticesFragment"
             app:destination="@id/graph_privacy" />
         <action
@@ -170,5 +165,11 @@
                 app:popUpToInclusive="true" />
         </fragment>
     </navigation>
+
+    <action
+        android:id="@+id/action_to_requestLoginFragment"
+        app:destination="@id/requestLoginFragment"
+        app:popUpTo="@id/dashboard_navigation"
+        app:popUpToInclusive="true" />
 
 </navigation>


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1158)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0**

* When the device is compromised, the user is logged out and local data is cleared. This causes a crash when any part of the UI attempts to request the project state.

### Notable changes

* Added handling for the exception that is thrown in the AuthManager when there is no Firebase token available. ([We should really look into how we are handling missing project info throughout the app](https://simprints.atlassian.net/browse/MS-1006?focusedCommentId=35165)) 
* Added explicit handling of forced logout in the sync screen similar to how it was before Sync refactor.

### Testing guidance

* Log into the project, do some workflows
* In Vulcan, mark the device as compromised
* In SID, navigate to settings and update the project configuration (or wait until the worker is executed in the background)
* Navigate back to the main dashboard screen - device should be logged out and an explanation given in a dialogue. 

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
