### PR TITLE
MS-1157 Material library version rollback

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ androidx_viewpager_version = "1.1.0"
 androidx_security_version = "1.1.0"
 androidx_annotation_version = "1.9.1"
 androidx_arch_core_version = "2.2.0"
-matertial_version = "1.13.0"
+material_version = "1.12.0"
 
 hilt_version = "2.56.2"
 hilt_androidx_version = "1.2.0"
@@ -133,7 +133,7 @@ androidX-navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", ver
 androidX-annotation-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx_annotation_version" }
 
 #Support
-support-material = { module = "com.google.android.material:material", version.ref = "matertial_version" }
+support-material = { module = "com.google.android.material:material", version.ref = "material_version" }
 
 #WorkManager
 workManager-work = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx_work_version" }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1157)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0**

* Progress indicators are messed up in the new version

### Notable changes

* Reverts the material library to the last known good version

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
