### PR TITLE
MS-1179 Update auto-capture UI state on resume after settings

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -117,11 +117,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
                 vm.initCapture(mainVm.bioSDK, mainVm.samplesToCapture, mainVm.attemptNumber)
             }
         }
-        if (vm.isAutoCapture) {
-            // Await until capture button is pressed
-            vm.holdOffAutoCapture()
-            binding.captureFeedbackBtn.isClickable = true
-        }
+        enableCaptureButtonIfAutoCapture()
 
         binding.captureInstructionsBtn.setOnClickListener {
             findNavController().navigateSafely(
@@ -185,9 +181,12 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
 
     override fun onResume() {
         super.onResume()
-
         when {
-            requireActivity().hasPermission(Manifest.permission.CAMERA) -> setUpCamera()
+            requireActivity().hasPermission(Manifest.permission.CAMERA) -> {
+                setUpCamera()
+                enableCaptureButtonIfAutoCapture()
+            }
+
             mainVm.shouldCheckCameraPermissions.getAndSet(false) -> {
                 // Check permission in onResume() so that if user left the app to go to Settings
                 // and give the permission, it's reflected when they come back to SID
@@ -199,6 +198,14 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
             }
 
             else -> mainVm.shouldCheckCameraPermissions.set(true)
+        }
+    }
+
+    private fun enableCaptureButtonIfAutoCapture() {
+        if (vm.isAutoCapture) {
+            // Await until capture button is pressed
+            vm.holdOffAutoCapture()
+            binding.captureFeedbackBtn.isClickable = true
         }
     }
 


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1179)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0**

* When returning from the permission settings, the capture UI is not being reset.

### Notable changes

* Restart the UI state on return when auto-capture is enabled.

### Testing guidance

* Enable auto-capture, authorise to SID and remove the camera permission
* Start biometric flow
* Decline camera permission request
* Press the "grant permission" button and grant the camera permission in settings
* Return to the capture screen - it should resume as usual

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
