### PR TITLE
Prevent endless loop when initial sync is required

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
@@ -1,15 +1,12 @@
 package com.simprints.feature.dashboard.settings.syncinfo
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import com.simprints.core.DispatcherIO
-import com.simprints.core.livedata.LiveDataEventWithContent
-import com.simprints.core.livedata.send
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.feature.dashboard.logout.usecase.LogoutUseCase
 import com.simprints.feature.dashboard.settings.syncinfo.usecase.ObserveSyncInfoUseCase
@@ -138,12 +135,15 @@ internal class SyncInfoViewModel @Inject constructor(
             .asLiveData(viewModelScope.coroutineContext)
     }
 
-    fun forceEventSync() {
+    fun forceEventSync(canEmitSyncButtonClick: Boolean = true) {
         viewModelScope.launch {
-            val isEventSyncing = eventSyncStateFlow.firstOrNull()?.isSyncInProgress() == true
-            if (!isEventSyncing) {
-                eventSyncButtonClickFlow.emit(Unit)
+            if (canEmitSyncButtonClick) {
+                val isEventSyncing = eventSyncStateFlow.firstOrNull()?.isSyncInProgress() == true
+                if (!isEventSyncing) {
+                    eventSyncButtonClickFlow.emit(Unit)
+                }
             }
+
             syncOrchestrator.stopEventSync()
             val projectState = try {
                 configManager.getProject(authStore.signedInProjectId).state
@@ -207,7 +207,7 @@ internal class SyncInfoViewModel @Inject constructor(
                 else -> false
             }
             if (isForceEventSync) {
-                forceEventSync()
+                forceEventSync(canEmitSyncButtonClick = false)
             }
         }
     }


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0-dev**

* When the SyncInfoViewModel is started and an initial sync is required, it triggers an endless loop

### Notable changes

* Initial sync doesn't emit on `eventSyncButtonClickFlow` to prevent the loop

### Testing guidance

* Describe how the reviewers can verify that issue is fixed

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
