### PR TITLE
Add showProgressNotification() to workers that don't have it

### DIFF
--- a/infra/sync/src/main/java/com/simprints/infra/sync/enrolments/EnrolmentRecordWorker.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/enrolments/EnrolmentRecordWorker.kt
@@ -24,6 +24,7 @@ class EnrolmentRecordWorker @AssistedInject constructor(
     override val tag: String = "EnrolmentRecordWorker"
 
     override suspend fun doWork(): Result = withContext(dispatcher) {
+        showProgressNotification()
         crashlyticsLog("Started")
         try {
             val instructionId =

--- a/infra/sync/src/main/java/com/simprints/infra/sync/files/FileUpSyncWorker.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/files/FileUpSyncWorker.kt
@@ -32,6 +32,7 @@ internal class FileUpSyncWorker @AssistedInject constructor(
     override val tag: String = "FileUpSyncWorker"
 
     override suspend fun doWork(): Result = withContext(dispatcher) {
+        showProgressNotification()
         crashlyticsLog("Started")
         try {
             when {

--- a/infra/sync/src/main/java/com/simprints/infra/sync/firmware/FirmwareFileUpdateWorker.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/firmware/FirmwareFileUpdateWorker.kt
@@ -28,6 +28,7 @@ class FirmwareFileUpdateWorker @AssistedInject constructor(
     override val tag: String = "FirmwareFileUpdateWorker"
 
     override suspend fun doWork(): Result = withContext(dispatcher) {
+        showProgressNotification()
         crashlyticsLog("Started")
         try {
             firmwareRepository.updateStoredFirmwareFilesWithLatest()


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **unknown**

* 3 workers (image sync being the most notable one) didn't have the `showProgressNotification()` call at all
* I suspect that image sync taking more than 5-10 seconds was what caused all/most crashes

### Notable changes

* Added `showProgressNotification()` first thing in these Workers' doWork()

### Testing guidance

* Open the Sync Info screen and start tapping the two sync buttons like crazy for a few minutes. If no crash - celebrate!

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
