### PR TITLE
MS-1188 Short-term logout fix

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/base/BaseFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/base/BaseFragment.kt
@@ -18,7 +18,7 @@ internal class BaseFragment : Fragment(R.layout.fragment_base) {
         if (authStore.signedInProjectId.isNotEmpty()) {
             findNavController().navigateSafely(this, BaseFragmentDirections.actionBaseFragmentToMainFragment())
         } else {
-            findNavController().navigateSafely(this, BaseFragmentDirections.actionBaseFragmentToRequestLoginFragment())
+            findNavController().navigateSafely(this, BaseFragmentDirections.actionToRequestLoginFragment())
         }
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/LogoutSyncViewModel.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -52,9 +51,7 @@ internal class LogoutSyncViewModel @Inject constructor(
         }
 
     fun logout() {
-        viewModelScope.launch {
-            logoutUseCase()
-        }
+        logoutUseCase()
     }
 
     private companion object {

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/sync/LogoutSyncFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/sync/LogoutSyncFragment.kt
@@ -54,7 +54,7 @@ class LogoutSyncFragment : Fragment(R.layout.fragment_logout_sync) {
         viewModel.logoutEventLiveData.observe(viewLifecycleOwner) {
             findNavController().navigateSafely(
                 this@LogoutSyncFragment,
-                R.id.action_logoutSyncFragment_to_requestLoginFragment,
+                LogoutSyncFragmentDirections.actionToRequestLoginFragment(null),
             )
         }
     }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/sync/LogoutSyncFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/sync/LogoutSyncFragment.kt
@@ -51,11 +51,5 @@ class LogoutSyncFragment : Fragment(R.layout.fragment_logout_sync) {
                 }
             }
         }
-        viewModel.logoutEventLiveData.observe(viewLifecycleOwner) {
-            findNavController().navigateSafely(
-                this@LogoutSyncFragment,
-                LogoutSyncFragmentDirections.actionToRequestLoginFragment(null),
-            )
-        }
     }
 }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/syncdecline/LogoutSyncDeclineFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/syncdecline/LogoutSyncDeclineFragment.kt
@@ -74,7 +74,7 @@ class LogoutSyncDeclineFragment : Fragment(R.layout.fragment_logout_sync_decline
         viewModel.logoutEventLiveData.observe(viewLifecycleOwner) {
             findNavController().navigateSafely(
                 this@LogoutSyncDeclineFragment,
-                LogoutSyncDeclineFragmentDirections.actionLogoutSyncDeclineFragmentToRequestLoginFragment(),
+                LogoutSyncDeclineFragmentDirections.actionToRequestLoginFragment(null),
             )
         }
     }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCase.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCase.kt
@@ -6,7 +6,7 @@ import com.simprints.infra.enrolment.records.repository.EnrolmentRecordRepositor
 import com.simprints.infra.enrolment.records.repository.local.migration.RealmToRoomMigrationFlagsStore
 import com.simprints.infra.sync.SyncOrchestrator
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 internal class LogoutUseCase @Inject constructor(
@@ -16,7 +16,8 @@ internal class LogoutUseCase @Inject constructor(
     private val enrolmentRecordRepository: EnrolmentRecordRepository,
     @DispatcherIO private val ioDispatcher: CoroutineDispatcher,
 ) {
-    suspend operator fun invoke() = withContext(ioDispatcher) {
+    // To prevent a race between wiping data and navigation, this use case must block the executing thread
+    operator fun invoke() = runBlocking(ioDispatcher) {
         // Cancel all background sync
         syncOrchestrator.cancelBackgroundWork()
         syncOrchestrator.deleteEventSyncInfo()

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/about/AboutFragment.kt
@@ -19,9 +19,9 @@ import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentSettingsAboutBinding
 import com.simprints.feature.dashboard.settings.password.SettingsPasswordDialogFragment
 import com.simprints.infra.config.store.models.GeneralConfiguration.Modality.FINGERPRINT
-import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.system.Clipboard
+import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
@@ -96,7 +96,7 @@ internal class AboutFragment : PreferenceFragmentCompat() {
             LiveDataEventWithContentObserver {
                 val destination = when (it) {
                     LogoutDestination.LogoutDataSyncScreen -> AboutFragmentDirections.actionAboutFragmentToLogoutNavigation()
-                    LogoutDestination.LoginScreen -> AboutFragmentDirections.actionAboutFragmentToRequestLoginFragment()
+                    LogoutDestination.LoginScreen -> AboutFragmentDirections.actionToRequestLoginFragment()
                 }
                 findNavController().navigateSafely(this, destination)
             },

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
@@ -171,7 +171,7 @@ internal class SyncInfoViewModel @Inject constructor(
     }
 
     fun performLogout() {
-        viewModelScope.launch { logoutUseCase() }
+        logoutUseCase()
     }
 
     fun requestNavigationToLogin() {

--- a/feature/dashboard/src/main/res/navigation/graph_dashboard.xml
+++ b/feature/dashboard/src/main/res/navigation/graph_dashboard.xml
@@ -34,11 +34,6 @@
         android:label="BaseFragment"
         tools:layout="@layout/fragment_base">
         <action
-            android:id="@+id/action_baseFragment_to_requestLoginFragment"
-            app:destination="@id/requestLoginFragment"
-            app:popUpTo="@id/dashboard_navigation"
-            app:popUpToInclusive="true" />
-        <action
             android:id="@+id/action_baseFragment_to_mainFragment"
             app:destination="@id/mainFragment"
             app:popUpTo="@id/dashboard_navigation"
@@ -98,11 +93,6 @@
             android:id="@+id/action_aboutFragment_to_logout_navigation"
             app:destination="@id/logout_navigation" />
         <action
-            android:id="@+id/action_aboutFragment_to_requestLoginFragment"
-            app:destination="@id/requestLoginFragment"
-            app:popUpTo="@id/dashboard_navigation"
-            app:popUpToInclusive="true" />
-        <action
             android:id="@+id/action_aboutFragment_to_troubleshooting"
             app:destination="@id/graph_troubleshooting" />
     </fragment>
@@ -142,11 +132,6 @@
                 android:id="@+id/action_logoutSyncFragment_to_logoutSyncDeclineFragment"
                 app:destination="@id/logOutSyncDeclineFragment" />
             <action
-                android:id="@+id/action_logoutSyncFragment_to_requestLoginFragment"
-                app:destination="@id/requestLoginFragment"
-                app:popUpTo="@id/dashboard_navigation"
-                app:popUpToInclusive="true" />
-            <action
                 android:id="@+id/action_logoutSyncFragment_to_moduleSelectionFragment"
                 app:destination="@id/moduleSelectionFragment" />
             <action
@@ -157,13 +142,7 @@
             android:id="@+id/logOutSyncDeclineFragment"
             android:name="com.simprints.feature.dashboard.logout.syncdecline.LogoutSyncDeclineFragment"
             android:label="LogoutSyncDeclineFragment"
-            tools:layout="@layout/fragment_logout_sync_decline">
-            <action
-                android:id="@+id/action_logoutSyncDeclineFragment_to_requestLoginFragment"
-                app:destination="@id/requestLoginFragment"
-                app:popUpTo="@id/dashboard_navigation"
-                app:popUpToInclusive="true" />
-        </fragment>
+            tools:layout="@layout/fragment_logout_sync_decline" />
     </navigation>
 
     <action

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/sync/LogoutSyncFragmentTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/sync/LogoutSyncFragmentTest.kt
@@ -61,18 +61,4 @@ internal class LogoutSyncFragmentTest {
         onView(withId(R.id.logout_sync_info)).check(matches(not(isDisplayed())))
         onView(withId(R.id.logoutWithoutSyncButton)).check(matches(not(isDisplayed())))
     }
-
-    @Test
-    fun `should navigate to requestLoginFragment when logout event received`() {
-        every { logoutSyncViewModel.logoutEventLiveData } returns mockk {
-            every { observe(any(), any()) } answers {
-                secondArg<Observer<Unit>>().onChanged(Unit)
-            }
-        }
-        val navController = testNavController(R.navigation.graph_dashboard, R.id.logout_navigation)
-        launchFragmentInHiltContainer<LogoutSyncFragment>(navController = navController)
-
-        assertThat(navController.currentDestination?.id)
-            .isEqualTo(R.id.requestLoginFragment)
-    }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1188)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0**

* Compounded issue that leads to some racing:
  * In both cases, the logout use case is called in the view model-scoped coroutine. Navigation happens right after the start of the logout coroutine, which kills the VM scope and cancels the logout navigation (sometimes, this is the racing part).
  * Navigation to the root leads to checking for "logged in"  state (which succeeds if navigation happened faster than the data cleanup) and opens the dashboard instead of the "login request" placeholder.

### Notable changes

* Made logout use case blocking (while still executing on the IO dispatcher) to block navigation until the data cleanup is done.
* Minor cleanup of the navigation graph actions to make it consistent.

### Testing guidance

* Login, do biometric flow (so that event upload is forced), attempt to log out. Repeat multiple times.
* Should navigate to the login request screen every time.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
