### PR TITLE
MS-1186 Sync "Try again" fix

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCase.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCase.kt
@@ -203,7 +203,7 @@ internal class ObserveSyncInfoUseCase @Inject constructor(
                         )
                 )
         val isSyncButtonEnabled =
-            (eventSyncVisibleState == OnStandby) &&
+            (eventSyncVisibleState == OnStandby || eventSyncVisibleState == Error) &&
                 ((!isPreLogoutUpSync && isDownSyncPossible) || isEventUpSyncPossible)
 
         val projectId = authStore.signedInProjectId

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCaseTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCaseTest.kt
@@ -1169,6 +1169,20 @@ class ObserveSyncInfoUseCaseTest {
     }
 
     @Test
+    fun `sync button should be enabled when sync has failed for non-CommCare and non-network reasons`() = runTest {
+        val mockCommCarePermissionErrorEventSyncState = mockk<EventSyncState>(relaxed = true) {
+            every { isSyncFailed() } returns true
+            every { isSyncFailedBecauseCommCarePermissionIsMissing() } returns false
+        }
+        every { eventSyncManager.getLastSyncState(any()) } returns MutableLiveData(mockCommCarePermissionErrorEventSyncState)
+
+        createUseCase()
+        val result = useCase().first()
+
+        assertThat(result.syncInfoSectionRecords.isSyncButtonEnabled).isTrue()
+    }
+
+    @Test
     fun `should calculate correct record last sync time when sync time available`() = runTest {
         val timestamp = Timestamp(0L)
         coEvery { eventSyncManager.getLastSyncTime() } returns timestamp


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1186)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0**

* Any kind of error in sync disabled the "sync now/try again" button.

### Notable changes

* Added a case for non-commcare, non-network errors to be allowed to retry the sync.
* NOTE: I was not able to reliably get sync errors, so this is mostly unit-test based solution.

### Testing guidance

* Somehow get sync to fail while being online. "Try again" button should be working.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
