### PR TITLE
MS-1181 Exit form handling on matcher screen

### DIFF
--- a/feature/matcher/build.gradle.kts
+++ b/feature/matcher/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":feature:exit-form"))
 
     implementation(project(":infra:orchestrator-data"))
     implementation(project(":infra:enrolment-records:repository"))

--- a/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchFragment.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchFragment.kt
@@ -3,6 +3,7 @@ package com.simprints.matcher.screen
 import android.animation.ObjectAnimator
 import android.os.Bundle
 import android.view.View
+import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -14,15 +15,21 @@ import com.simprints.core.livedata.LiveDataEventWithContentObserver
 import com.simprints.core.tools.extentions.applicationSettingsIntent
 import com.simprints.core.tools.extentions.hasPermission
 import com.simprints.core.tools.extentions.permissionFromResult
+import com.simprints.feature.exitform.ExitFormContract
+import com.simprints.feature.exitform.ExitFormResult
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.uibase.navigation.finishWithResult
+import com.simprints.infra.uibase.navigation.handleResult
+import com.simprints.infra.uibase.navigation.navigateSafely
 import com.simprints.infra.uibase.navigation.navigationParams
 import com.simprints.infra.uibase.view.applySystemBarInsets
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import com.simprints.matcher.MatchParams
 import com.simprints.matcher.R
 import com.simprints.matcher.databinding.FragmentMatcherBinding
+import com.simprints.matcher.screen.MatchFragment.Companion.LOADING_PROGRESS
+import com.simprints.matcher.screen.MatchFragment.Companion.MATCHING_PROGRESS
 import com.simprints.matcher.screen.MatchViewModel.MatchState
 import dagger.hilt.android.AndroidEntryPoint
 import com.simprints.infra.resources.R as IDR
@@ -56,7 +63,24 @@ internal class MatchFragment : Fragment(R.layout.fragment_matcher) {
         applySystemBarInsets(view)
         Simber.i("MatchFragment started (isFace=${params.isFaceMatch()})", tag = ORCHESTRATION)
 
+        findNavController().handleResult<ExitFormResult>(
+            this,
+            R.id.matcherFragment,
+            ExitFormContract.DESTINATION,
+        ) {
+            val option = it.submittedOption()
+            if (option != null) {
+                findNavController().finishWithResult(this, it)
+            }
+        }
+
         observeViewModel()
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            findNavController().navigateSafely(
+                this@MatchFragment,
+                MatchFragmentDirections.actionGlobalRefusalFragment(),
+            )
+        }
     }
 
     override fun onResume() {

--- a/feature/matcher/src/main/res/navigation/graph_matcher.xml
+++ b/feature/matcher/src/main/res/navigation/graph_matcher.xml
@@ -12,4 +12,9 @@
             android:name="params"
             app:argType="com.simprints.core.domain.step.StepParams" />
     </fragment>
+
+    <include app:graph="@navigation/graph_exit_form" />
+    <action
+        android:id="@+id/action_global_refusalFragment"
+        app:destination="@+id/graph_exit_form" />
 </navigation>


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1181)
Will be released in: **2025.3.0**

### Notable changes

* Since the user can now get stuck on the matching screen when there is no CommCare permission the back press should be handled in the same way it is handled on other screens.

### Testing guidance

* Make sure that SID does not have CommCare permission.
* Start the workflow, capture biometrics and move to the matching.
* When presented with permission requests - reject all and press (gesture) back from the matching screen.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
