### PR TITLE
[MS-1194] Add support for simFace allowed age range in ProjectConfiguration

### DIFF
--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/steps/BuildStepsUseCaseTest.kt
@@ -52,7 +52,7 @@ class BuildStepsUseCaseTest {
     fun setup() {
         MockKAnnotations.init(this)
         useCase = BuildStepsUseCase(buildMatcherSubjectQuery, cache, mapStepsForLastBiometrics, fallbackToCommCareDataSourceIfNeeded)
-        
+
         // Setup fallback use case to return the input actions unchanged by default
         coEvery { fallbackToCommCareDataSourceIfNeeded(any<ActionRequest.EnrolActionRequest>(), any()) } answers { firstArg() }
         coEvery { fallbackToCommCareDataSourceIfNeeded(any<ActionRequest.IdentifyActionRequest>(), any()) } answers { firstArg() }
@@ -87,6 +87,7 @@ class BuildStepsUseCaseTest {
         every { projectConfiguration.face?.allowedSDKs } returns listOf(FaceConfiguration.BioSdk.RANK_ONE)
         every { projectConfiguration.face?.rankOne?.nbOfImagesToCapture } returns 3
         every { projectConfiguration.face?.rankOne?.allowedAgeRange } returns null
+        every { projectConfiguration.face?.simFace?.allowedAgeRange } returns null
 
         return projectConfiguration
     }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ProjectConfiguration.kt
@@ -37,8 +37,7 @@ fun ProjectConfiguration.canSyncBiometricDataToSimprints(): Boolean =
 fun ProjectConfiguration.canSyncAnalyticsDataToSimprints(): Boolean =
     synchronization.up.simprints.kind == UpSynchronizationConfiguration.UpSynchronizationKind.ONLY_ANALYTICS
 
-fun ProjectConfiguration.isSimprintsEventDownSyncAllowed(): Boolean =
-    synchronization.down.simprints != null &&
+fun ProjectConfiguration.isSimprintsEventDownSyncAllowed(): Boolean = synchronization.down.simprints != null &&
     synchronization.down.simprints.frequency != Frequency.ONLY_PERIODICALLY_UP_SYNC
 
 fun ProjectConfiguration.isCommCareEventDownSyncAllowed(): Boolean = synchronization.down.commCare != null
@@ -47,6 +46,7 @@ fun ProjectConfiguration.imagesUploadRequiresUnmeteredConnection(): Boolean = sy
 
 fun ProjectConfiguration.allowedAgeRanges(): List<AgeGroup> = listOfNotNull(
     face?.rankOne?.allowedAgeRange,
+    face?.simFace?.allowedAgeRange,
     fingerprint?.secugenSimMatcher?.allowedAgeRange,
     fingerprint?.nec?.allowedAgeRange,
 )

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ProjectConfigurationTest.kt
@@ -232,7 +232,7 @@ class ProjectConfigurationTest {
         val config = projectConfiguration.copy(
             synchronization = synchronizationConfiguration.copy(
                 down = synchronizationConfiguration.down.copy(
-                    simprints = null
+                    simprints = null,
                 ),
             ),
         )
@@ -245,7 +245,7 @@ class ProjectConfigurationTest {
         val config = projectConfiguration.copy(
             synchronization = synchronizationConfiguration.copy(
                 down = synchronizationConfiguration.down.copy(
-                    commCare = DownSynchronizationConfiguration.CommCareDownSynchronizationConfiguration
+                    commCare = DownSynchronizationConfiguration.CommCareDownSynchronizationConfiguration,
                 ),
             ),
         )
@@ -258,7 +258,7 @@ class ProjectConfigurationTest {
         val config = projectConfiguration.copy(
             synchronization = synchronizationConfiguration.copy(
                 down = synchronizationConfiguration.down.copy(
-                    commCare = null
+                    commCare = null,
                 ),
             ),
         )
@@ -294,6 +294,7 @@ class ProjectConfigurationTest {
                 rankOne = faceConfiguration.rankOne?.copy(
                     allowedAgeRange = faceAgeRange,
                 ),
+                simFace = null,
             ),
             fingerprint = fingerprintConfiguration.copy(
                 secugenSimMatcher = fingerprintConfiguration.secugenSimMatcher?.copy(
@@ -428,7 +429,7 @@ class ProjectConfigurationTest {
             AgeGroup(faceAgeRange.startInclusive, secugenSimMatcherAgeRange.startInclusive),
             AgeGroup(secugenSimMatcherAgeRange.startInclusive, faceAgeRange.endExclusive),
             AgeGroup(faceAgeRange.endExclusive!!, secugenSimMatcherAgeRange.endExclusive!!),
-            AgeGroup(secugenSimMatcherAgeRange.endExclusive!!, null),
+            AgeGroup(secugenSimMatcherAgeRange.endExclusive, null),
         )
 
         assertThat(result).isEqualTo(expected)


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1194)
Will be released in: **2025.4.0**

### Root cause analysis (for bugfixes only)

* When testing the SimFace integration, I noticed that the age group configurations were being ignored.

### Notable changes

* Now the allowed age groups are enabled for the SimFace SDK
### Testing guidance

* change the age limits for SimFace SDk then the age group selection screen will appear 

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
