### PR TITLE
Bump simmatcher version to 1.3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,7 @@ kermit_version = "2.0.6"
 zip4j_version = "2.11.5"
 
 libsimprints_version = "2025.2.1"
-simmatcher_version = "1.2.0"
+simmatcher_version = "1.3.0"
 roc_wrapper_version = "1.23.0"
 roc_wrapper-v3_version = "3.1.0"
 nec_version = "1.5.0"


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1191)
Will be released in: **2025.4.0**

### Notable changes

*Simmatcher lib v1.3.0 supports 16k page size

### Testing guidance

* Testing Simmacher identification and verfication 

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
