### PR TITLE
Merge data layer sync info along with buttons' in order to react to data layer updates

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
@@ -126,11 +126,10 @@ internal class SyncInfoViewModel @Inject constructor(
         }
 
         merge(
+            dataLayerDrivenSyncInfoFlow,
             eventSyncButtonResponsiveSyncInfo,
             imageSyncButtonResponsiveSyncInfo,
-        ).onStart {
-            emit(dataLayerDrivenSyncInfoFlow.firstOrNull() ?: SyncInfo())
-        }.distinctUntilChanged()
+        ).distinctUntilChanged()
             .flowOn(ioDispatcher)
             .asLiveData(viewModelScope.coroutineContext)
     }


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2025.3.0-dev**

### Root cause analysis (for bugfixes only)

First known affected version: **version**

* Sync Info card does not update if sync button is disabled
* More info in [this discussion](https://simprints.slack.com/archives/C04ERK7B93R/p1759929962298819)

### Notable changes

* Data layer flow is merged along with button flows in order to keep updating after onStart

### Testing guidance

* Describe how the reviewers can verify that issue is fixed

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
