### PR TITLE
Log full filename instead of just last char

### DIFF
--- a/infra/images/src/main/java/com/simprints/infra/images/remote/firebase/FirebaseSampleUploader.kt
+++ b/infra/images/src/main/java/com/simprints/infra/images/remote/firebase/FirebaseSampleUploader.kt
@@ -17,7 +17,6 @@ import com.simprints.infra.images.model.SecuredImageRef
 import com.simprints.infra.images.remote.SampleUploader
 import com.simprints.infra.images.usecase.SamplePathConverter
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SAMPLE_UPLOAD
-import com.simprints.infra.logging.LoggingConstants.CrashReportTag.SYNC
 import com.simprints.infra.logging.Simber
 import kotlinx.coroutines.tasks.await
 import java.io.FileInputStream
@@ -103,7 +102,7 @@ internal class FirebaseSampleUploader @Inject constructor(
         val fileRef = imageRef.relativePath.parts
             .fold(rootRef) { ref, pathPart -> ref.child(pathPart) }
 
-        Simber.i("Uploading ${fileRef.path.last()}", tag = SAMPLE_UPLOAD)
+        Simber.i("Uploading ${imageRef.relativePath.parts.last()}", tag = SAMPLE_UPLOAD)
 
         return if (metadata.isEmpty()) {
             fileRef.putStream(imageStream).await()


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.3.0-dev**

* Currently logs only last character of filename

### Notable changes

* Logs full filename

### Testing guidance

* Describe how the reviewers can verify that issue is fixed

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
