### PR TITLE
[MS-1251] Make Simber.w throwable argument non-optional to avoid lumping all warnings together in Crashlytics

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/FallbackToCommCareDataSourceIfNeededUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/steps/FallbackToCommCareDataSourceIfNeededUseCase.kt
@@ -45,7 +45,11 @@ internal class FallbackToCommCareDataSourceIfNeededUseCase @Inject constructor(
             return false
         }
 
-        Simber.w("Falling back to CommCare data source because threshold is $thresholdMs and last sync was at $lastSyncTime", tag = SYNC)
+        Simber.w(
+            message = "Falling back to CommCare data source because threshold is $thresholdMs and last sync was at $lastSyncTime",
+            t = Exception("Fallback to CommCare just-in-time reading"),
+            tag = SYNC,
+        )
         return true
     }
 }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/commcare/CommCareEventDataSource.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/commcare/CommCareEventDataSource.kt
@@ -253,7 +253,11 @@ internal class CommCareEventDataSource @Inject constructor(
             }
         }
 
-        Simber.w("All date parsing attempts failed for: $dateString", tag = COMMCARE_SYNC)
+        Simber.w(
+            message = "All date parsing attempts failed for: $dateString",
+            t = IllegalArgumentException("Could not parse date string"),
+            tag = COMMCARE_SYNC,
+        )
         return 0L
     }
 

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/commcare/CommCareEventDataSourceTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/commcare/CommCareEventDataSourceTest.kt
@@ -570,7 +570,7 @@ class CommCareEventDataSourceTest {
         assertEquals(1, events.size) // Still processes because invalid date defaults to 0L
         // Should log error for each format attempt plus final failure warning
         verify(atLeast = 2) { Simber.e(any(), ofType<Exception>(), tag = LoggingConstants.CrashReportTag.COMMCARE_SYNC) }
-        verify { Simber.w(any(), tag = LoggingConstants.CrashReportTag.COMMCARE_SYNC) }
+        verify { Simber.w(any(), ofType<IllegalArgumentException>(), tag = LoggingConstants.CrashReportTag.COMMCARE_SYNC) }
     }
 
     @Test
@@ -976,7 +976,7 @@ class CommCareEventDataSourceTest {
 
         // Should log date parsing errors
         verify(atLeast = 2) { Simber.e(any(), ofType<Exception>(), tag = LoggingConstants.CrashReportTag.COMMCARE_SYNC) }
-        verify { Simber.w(any(), tag = LoggingConstants.CrashReportTag.COMMCARE_SYNC) }
+        verify { Simber.w(any(), ofType<IllegalArgumentException>(), tag = LoggingConstants.CrashReportTag.COMMCARE_SYNC) }
     }
 
     @Test

--- a/infra/logging/src/main/java/com/simprints/infra/logging/Simber.kt
+++ b/infra/logging/src/main/java/com/simprints/infra/logging/Simber.kt
@@ -72,19 +72,19 @@ object Simber {
      */
     fun w(
         message: String,
-        t: Throwable? = null,
+        t: Throwable,
         tag: CrashReportTag,
     ) = w(message, t, tag.name)
 
     fun w(
         message: String,
-        t: Throwable? = null,
+        t: Throwable,
         tag: String = DEFAULT_TAG,
     ) {
-        when {
-            t == null -> Logger.w(message, null, ensureCharactersAreValid(tag))
-            shouldSkipThrowableReporting(t) -> Logger.i(message, t, ensureCharactersAreValid(tag))
-            else -> Logger.w(message, t, ensureCharactersAreValid(tag))
+        if (shouldSkipThrowableReporting(t)) {
+            Logger.i(message, t, ensureCharactersAreValid(tag))
+        } else {
+            Logger.w(message, t, ensureCharactersAreValid(tag))
         }
     }
 
@@ -171,7 +171,7 @@ object Simber {
                 throw IllegalArgumentException("String must be less than $max characters.")
             }
 
-            return message.substring(0, max)
+            return message.take(max)
         }
         return message
     }

--- a/infra/logging/src/test/java/com/simprints/infra/logging/writers/CrashlyticsLogWriterTest.kt
+++ b/infra/logging/src/test/java/com/simprints/infra/logging/writers/CrashlyticsLogWriterTest.kt
@@ -57,21 +57,6 @@ class CrashlyticsLogWriterTest {
     }
 
     @Test
-    fun `should log and record error on WARN priority`() {
-        val crashMock = mockk<FirebaseCrashlytics>(relaxed = true)
-        val spyCrashReportingTree = spyk(CrashlyticsLogWriter(crashMock))
-
-        Logger.setLogWriters(spyCrashReportingTree)
-        Simber.w("Test Message", null)
-
-        verify {
-            crashMock.recordException(
-                match<Exception> { it.message?.contains("Test Message") == true }
-            )
-        }
-    }
-
-    @Test
     fun `with custom exception should log and record error on WARN priority`() {
         val crashMock = mockk<FirebaseCrashlytics>(relaxed = true)
         val spyCrashReportingTree = spyk(CrashlyticsLogWriter(crashMock))

--- a/infra/matching/src/main/java/com/simprints/infra/matching/usecase/FaceMatcherUseCase.kt
+++ b/infra/matching/src/main/java/com/simprints/infra/matching/usecase/FaceMatcherUseCase.kt
@@ -40,7 +40,11 @@ class FaceMatcherUseCase @Inject constructor(
     ): Flow<MatcherState> = channelFlow {
         Simber.i("Initialising matcher", tag = crashReportTag)
         if (matchParams.bioSdk !is FaceConfiguration.BioSdk) {
-            Simber.w("Face SDK was not provided", tag = crashReportTag)
+            Simber.w(
+                message = "Face SDK was not provided",
+                t = IllegalArgumentException("Face SDK was not provided"),
+                tag = crashReportTag,
+            )
             send(MatcherState.Success(emptyList(), emptyList(), 0, ""))
             return@channelFlow
         }

--- a/infra/matching/src/main/java/com/simprints/infra/matching/usecase/FingerprintMatcherUseCase.kt
+++ b/infra/matching/src/main/java/com/simprints/infra/matching/usecase/FingerprintMatcherUseCase.kt
@@ -42,7 +42,11 @@ class FingerprintMatcherUseCase @Inject constructor(
     ): Flow<MatcherState> = channelFlow {
         Simber.i("Initialising matcher", tag = crashReportTag)
         if (matchParams.bioSdk !is FingerprintConfiguration.BioSdk) {
-            Simber.w("Fingerprint SDK was not provided", tag = crashReportTag)
+            Simber.w(
+                message = "Fingerprint SDK was not provided",
+                t = IllegalArgumentException("Fingerprint SDK was not provided"),
+                tag = crashReportTag,
+            )
             send(MatcherState.Success(emptyList(), emptyList(), 0, ""))
             return@channelFlow
         }

--- a/infra/ui-base/src/main/java/com/simprints/infra/uibase/navigation/NavigationResultExt.kt
+++ b/infra/ui-base/src/main/java/com/simprints/infra/uibase/navigation/NavigationResultExt.kt
@@ -168,7 +168,7 @@ private fun NavController.navigateIfPossible(
     } else {
         val fragmentName = currentFragment.toString().takeWhile { it != ' ' }
         val target = (currentDestination as? FragmentNavigator.Destination)?.className
-        Simber.w("Cannot navigate from $fragmentName to $target")
+        Simber.w("Cannot navigate from $fragmentName to $target", t = IllegalStateException("Navigation not possible"))
     }
 }
 


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1251)
Will be released in: **2026.1.0**

### Root cause analysis (for bugfixes only)

First known affected version: **forever**

* Currently all Simber.w logs are wrapped in a generic Exception which in Crashlytics they are all lumped together into [this single issue](https://console.firebase.google.com/project/simprints-152315/crashlytics/app/android:com.simprints.id/issues/05ae5e1d98686e7494af8e5dd8342c03) with 10s of variants. This is very impractical for monitoring and risks hiding real issues among benign ones.

### Notable changes

* Makes the Throwable parameter in Simber.w() non-optional in order to force callers to pass a Throwable argument. This will group different call sites together
* All current Simber.w() calls were provided an appropriate exception

### Testing guidance

* I guess we'll have to either wait this to reach prod or create a staging build and force some warning scenarios to happen

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
