### PR TITLE
Remove redundant config refresh

### DIFF
--- a/infra/config-sync/src/main/java/com/simprints/infra/config/sync/ConfigManager.kt
+++ b/infra/config-sync/src/main/java/com/simprints/infra/config/sync/ConfigManager.kt
@@ -8,7 +8,6 @@ import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.config.store.models.ProjectConfiguration
 import com.simprints.infra.config.store.models.ProjectWithConfig
 import com.simprints.infra.enrolment.records.repository.EnrolmentRecordRepository
-import com.simprints.infra.enrolment.records.repository.local.migration.RealmToRoomMigrationScheduler
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,7 +20,6 @@ class ConfigManager @Inject constructor(
     private val configRepository: ConfigRepository,
     private val enrolmentRecordRepository: EnrolmentRecordRepository,
     private val configSyncCache: ConfigSyncCache,
-    private val realmToRoomMigrationScheduler: RealmToRoomMigrationScheduler,
 ) {
     private val isProjectRefreshingFlow: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
@@ -31,7 +29,6 @@ class ConfigManager @Inject constructor(
             return configRepository.refreshProject(projectId).also {
                 enrolmentRecordRepository.tokenizeExistingRecords(it.project)
                 configSyncCache.saveUpdateTime()
-                realmToRoomMigrationScheduler.scheduleMigrationWorkerIfNeeded()
             }
         } finally {
             isProjectRefreshingFlow.tryEmit(false)

--- a/infra/config-sync/src/test/java/com/simprints/infra/config/sync/ConfigManagerTest.kt
+++ b/infra/config-sync/src/test/java/com/simprints/infra/config/sync/ConfigManagerTest.kt
@@ -7,7 +7,6 @@ import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.config.store.models.ProjectConfiguration
 import com.simprints.infra.config.store.models.ProjectWithConfig
 import com.simprints.infra.enrolment.records.repository.EnrolmentRecordRepository
-import com.simprints.infra.enrolment.records.repository.local.migration.RealmToRoomMigrationScheduler
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -48,9 +47,6 @@ class ConfigManagerTest {
     private lateinit var deviceConfiguration: DeviceConfiguration
 
     @MockK
-    private lateinit var realmToRoomMigrationScheduler: RealmToRoomMigrationScheduler
-
-    @MockK
     private lateinit var project: Project
 
     @Before
@@ -60,7 +56,6 @@ class ConfigManagerTest {
             configRepository = configRepository,
             enrolmentRecordRepository = enrolmentRecordRepository,
             configSyncCache = configSyncCache,
-            realmToRoomMigrationScheduler = realmToRoomMigrationScheduler,
         )
     }
 
@@ -72,7 +67,6 @@ class ConfigManagerTest {
         assertThat(refreshedProject).isEqualTo(projectWithConfig)
 
         coVerify { configSyncCache.saveUpdateTime() }
-        coVerify { realmToRoomMigrationScheduler.scheduleMigrationWorkerIfNeeded() }
     }
 
     @Test
@@ -228,7 +222,7 @@ class ConfigManagerTest {
         launch {
             try {
                 configManager.refreshProject(PROJECT_ID)
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Expected
             }
         }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
@@ -70,9 +70,8 @@ internal class EventUpSyncTask @Inject constructor(
             }
         }
 
-        val projectWithConfig = configManager.refreshProject(operation.projectId)
-        val project = projectWithConfig.project
-        val config = projectWithConfig.configuration
+        val project = configManager.getProject(operation.projectId)
+        val config = configManager.getProjectConfiguration()
         var lastOperation = operation.copy()
         var isUsefulUpload = false
 

--- a/infra/sync/src/test/java/com/simprints/infra/sync/config/worker/ProjectConfigDownSyncWorkerTest.kt
+++ b/infra/sync/src/test/java/com/simprints/infra/sync/config/worker/ProjectConfigDownSyncWorkerTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.simprints.infra.authstore.AuthStore
 import com.simprints.infra.config.store.models.ProjectWithConfig
 import com.simprints.infra.config.sync.ConfigManager
+import com.simprints.infra.enrolment.records.repository.local.migration.RealmToRoomMigrationScheduler
 import com.simprints.infra.sync.config.testtools.project
 import com.simprints.infra.sync.config.testtools.projectConfiguration
 import com.simprints.infra.sync.config.usecase.HandleProjectStateUseCase
@@ -42,6 +43,9 @@ class ProjectConfigDownSyncWorkerTest {
     @MockK
     private lateinit var resetLocalRecordsIfConfigChangedUseCase: ResetLocalRecordsIfConfigChangedUseCase
 
+    @MockK
+    private lateinit var realmToRoomMigrationScheduler: RealmToRoomMigrationScheduler
+
     private lateinit var projectConfigDownSyncWorker: ProjectConfigDownSyncWorker
 
     @Before
@@ -60,6 +64,7 @@ class ProjectConfigDownSyncWorkerTest {
             handleProjectState = handleProjectStateUseCase,
             rescheduleWorkersIfConfigChanged = rescheduleWorkersIfConfigChangedUseCase,
             resetLocalRecordsIfConfigChanged = resetLocalRecordsIfConfigChangedUseCase,
+            realmToRoomMigrationScheduler = realmToRoomMigrationScheduler,
             dispatcher = testCoroutineRule.testCoroutineDispatcher,
         )
     }
@@ -94,8 +99,9 @@ class ProjectConfigDownSyncWorkerTest {
 
         coVerify {
             handleProjectStateUseCase.invoke(any())
-            rescheduleWorkersIfConfigChangedUseCase.invoke(any(), any())
             resetLocalRecordsIfConfigChangedUseCase.invoke(any(), any())
+            realmToRoomMigrationScheduler.scheduleMigrationWorkerIfNeeded()
+            rescheduleWorkersIfConfigChangedUseCase.invoke(any(), any())
         }
     }
 


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2026.1.0**

### Notable changes

* Doesn't explicitly refresh configuration inside upsync task - it's scheduled to refresh in a worker first thing in each sync cycle
* Moves the DB migration scheduler out of ConfigManager and in the config worker - this way all post-config refresh tasks are in one place. Only tokenization is left inside ConfigManager as it was it's main purpose for existing
* Moves local records reset before rescheduling workers and DB migration

### Testing guidance

* Sync and enjoy less needless work and more logical post-config refresh order

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
