### PR TITLE
Refactor InvalidIntent and  SuspiciousIntent events payloads to use JsonElement for extras

### DIFF
--- a/.github/workflows/reusable-sonar-scan.yml
+++ b/.github/workflows/reusable-sonar-scan.yml
@@ -60,11 +60,11 @@ jobs:
                     for ARTEFACT_DIR in test-reports/*; do
                       echo "Copying the contents of ${ARTEFACT_DIR}"
                       
-                      [[ -d "ARTEFACT_DIR" ]] || continue
+                      [[ -d "$ARTEFACT_DIR" ]] || continue
                       ALL_SKIPPED=false
                     
                       # Copy the contents of each artefact folder into the workspace root
-                      rsync -arv "${ARTEFACT_DIR}" . || true
+                      rsync -arv "${ARTEFACT_DIR}"/* . || true
                     done
                     
                     if [[ "$ALL_SKIPPED" == "true" ]]; then

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/ClientApiViewModel.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/ClientApiViewModel.kt
@@ -10,6 +10,7 @@ import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.core.livedata.LiveDataEvent
 import com.simprints.core.livedata.LiveDataEventWithContent
 import com.simprints.core.livedata.send
+import com.simprints.core.tools.extentions.toJsonElementMap
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.feature.clientapi.exceptions.InvalidRequestException
 import com.simprints.feature.clientapi.extensions.toMap
@@ -86,7 +87,7 @@ class ClientApiViewModel @Inject internal constructor(
             intentMapper(action = action, extras = extrasMap, project = getProject())
         } catch (validationException: InvalidRequestException) {
             Simber.e("Cannot parse intent data", validationException, tag = ORCHESTRATION)
-            simpleEventReporter.addInvalidIntentEvent(action, extrasMap.mapValues { it.value.toString() })
+            simpleEventReporter.addInvalidIntentEvent(action, extrasMap.toJsonElementMap())
             _showAlert.send(validationException.error)
             null
         }

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/usecases/SimpleEventReporter.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/usecases/SimpleEventReporter.kt
@@ -7,6 +7,7 @@ import com.simprints.infra.events.event.domain.models.InvalidIntentEvent
 import com.simprints.infra.events.session.SessionEventRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonElement
 import javax.inject.Inject
 
 internal class SimpleEventReporter @Inject constructor(
@@ -16,7 +17,7 @@ internal class SimpleEventReporter @Inject constructor(
 ) {
     fun addInvalidIntentEvent(
         action: String,
-        extras: Map<String, String>,
+        extras: Map<String, JsonElement?>,
     ) {
         sessionCoroutineScope.launch {
             coreEventRepository.addOrUpdateEvent(InvalidIntentEvent(timeHelper.now(), action, extras))

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/ClientApiViewModelTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/ClientApiViewModelTest.kt
@@ -33,6 +33,7 @@ import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonElement
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -158,7 +159,7 @@ internal class ClientApiViewModelTest {
 
         viewModel.handleIntent("action", bundleOf("contractVersion" to 42))
 
-        verify { simpleEventReporter.addInvalidIntentEvent("action", any<Map<String, String>>()) }
+        verify { simpleEventReporter.addInvalidIntentEvent("action", any<Map<String, JsonElement>>()) }
         viewModel.showAlert.test().assertHasValue()
     }
 

--- a/feature/login-check/build.gradle.kts
+++ b/feature/login-check/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("simprints.feature")
+    id("simprints.library.kotlinSerialization")
 }
 
 android {

--- a/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/ReportActionRequestEventsUseCase.kt
+++ b/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/ReportActionRequestEventsUseCase.kt
@@ -1,6 +1,7 @@
 package com.simprints.feature.logincheck.usecases
 
 import com.simprints.core.SessionCoroutineScope
+import com.simprints.core.tools.extentions.toJsonElementMap
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.utils.SimNetworkUtils
 import com.simprints.infra.events.event.domain.models.BiometricDataSource
@@ -43,7 +44,7 @@ internal class ReportActionRequestEventsUseCase @Inject constructor(
                 sessionEventRepository.addOrUpdateEvent(
                     SuspiciousIntentEvent(
                         timeHelper.now(),
-                        actionRequest.unknownExtras.mapValues { it.value.toString() },
+                        actionRequest.unknownExtras.toJsonElementMap(),
                     ),
                 )
             }

--- a/infra/core/src/main/java/com/simprints/core/tools/extentions/Map.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extentions/Map.ext.kt
@@ -1,0 +1,22 @@
+package com.simprints.core.tools.extentions
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+
+fun Map<String, JsonElement?>.toStringMap(): Map<String, String> = mapValues { (_, jsonElement) ->
+    when (jsonElement) {
+        is JsonPrimitive -> jsonElement.content
+        null -> ""
+        else -> jsonElement.toString()
+    }
+}
+
+fun Map<String, Any?>.toJsonElementMap(): Map<String, JsonElement?> = mapValues { (_, value) ->
+    when (value) {
+        is String -> JsonPrimitive(value)
+        is Boolean -> JsonPrimitive(value)
+        is Number -> JsonPrimitive(value)
+        null -> JsonPrimitive("")
+        else -> JsonPrimitive(value.toString())
+    }
+}

--- a/infra/core/src/test/java/com/simprints/core/tools/utils/MapUtilKtTest.kt
+++ b/infra/core/src/test/java/com/simprints/core/tools/utils/MapUtilKtTest.kt
@@ -1,0 +1,133 @@
+package com.simprints.core.tools.utils
+
+import com.simprints.core.tools.extentions.toJsonElementMap
+import com.simprints.core.tools.extentions.toStringMap
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MapUtilKtTest {
+    @Test
+    fun `toStringMap JsonPrimitive string is returned as content`() {
+        val input = mapOf(
+            "key" to JsonPrimitive("value"),
+        )
+
+        val result = input.toStringMap()
+
+        assertEquals(mapOf("key" to "value"), result)
+    }
+
+    @Test
+    fun `toStringMap JsonPrimitive number is returned as string`() {
+        val input = mapOf(
+            "key" to JsonPrimitive(42),
+        )
+
+        val result = input.toStringMap()
+
+        assertEquals(mapOf("key" to "42"), result)
+    }
+
+    @Test
+    fun `toStringMap JsonObject is converted using toString`() {
+        val jsonObject = buildJsonObject {
+            put("a", 1)
+        }
+        val input = mapOf(
+            "key" to jsonObject,
+        )
+
+        val result = input.toStringMap()
+
+        assertEquals(mapOf("key" to jsonObject.toString()), result)
+    }
+
+    @Test
+    fun `toStringMap JsonArray is converted using toString`() {
+        val jsonArray = buildJsonArray {
+            add(1)
+            add(2)
+        }
+        val input = mapOf(
+            "key" to jsonArray,
+        )
+
+        val result = input.toStringMap()
+
+        assertEquals(mapOf("key" to jsonArray.toString()), result)
+    }
+
+    @Test
+    fun `toStringMap null JsonElement is converted to string null`() {
+        val input = mapOf(
+            "key" to null,
+        )
+
+        val result = input.toStringMap()
+
+        assertEquals(mapOf("key" to ""), result)
+    }
+
+    @Test
+    fun `toJsonElementMap String is converted to JsonPrimitive string`() {
+        val input = mapOf(
+            "key" to "value",
+        )
+
+        val result = input.toJsonElementMap()
+
+        assertEquals(JsonPrimitive("value"), result["key"])
+    }
+
+    @Test
+    fun `toJsonElementMap Boolean is converted to JsonPrimitive boolean`() {
+        val input = mapOf(
+            "key" to true,
+        )
+
+        val result = input.toJsonElementMap()
+
+        assertEquals(JsonPrimitive(true), result["key"])
+    }
+
+    @Test
+    fun `toJsonElementMap Number is converted to JsonPrimitive number`() {
+        val input = mapOf(
+            "key" to 123,
+        )
+
+        val result = input.toJsonElementMap()
+
+        assertEquals(JsonPrimitive(123), result["key"])
+    }
+
+    @Test
+    fun `toJsonElementMap Unknown object is converted using toString`() {
+        val value = object {
+            override fun toString() = "custom-object"
+        }
+        val input = mapOf(
+            "key" to value,
+        )
+
+        val result = input.toJsonElementMap()
+
+        assertEquals(JsonPrimitive("custom-object"), result["key"])
+    }
+
+    @Test
+    fun `toJsonElementMap null value is converted to JsonPrimitive string null`() {
+        val input = mapOf(
+            "key" to null,
+        )
+
+        val result = input.toJsonElementMap()
+
+        assertEquals(JsonPrimitive(""), result["key"])
+    }
+}

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiInvalidIntentPayload.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiInvalidIntentPayload.kt
@@ -1,6 +1,7 @@
 package com.simprints.infra.eventsync.event.remote.models
 
 import androidx.annotation.Keep
+import com.simprints.core.tools.extentions.toStringMap
 import com.simprints.infra.config.store.models.TokenKeyType
 import com.simprints.infra.events.event.domain.models.InvalidIntentEvent.InvalidIntentPayload
 import kotlinx.serialization.Serializable
@@ -15,7 +16,7 @@ internal data class ApiInvalidIntentPayload(
     constructor(domainPayload: InvalidIntentPayload) : this(
         domainPayload.createdAt.fromDomainToApi(),
         domainPayload.action,
-        domainPayload.extras,
+        domainPayload.extras.toStringMap(),
     )
 
     override fun getTokenizedFieldJsonPath(tokenKeyType: TokenKeyType): String? = null // this payload doesn't have tokenizable fields

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiSuspiciousIntentPayload.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiSuspiciousIntentPayload.kt
@@ -1,6 +1,7 @@
 package com.simprints.infra.eventsync.event.remote.models
 
 import androidx.annotation.Keep
+import com.simprints.core.tools.extentions.toStringMap
 import com.simprints.infra.config.store.models.TokenKeyType
 import com.simprints.infra.events.event.domain.models.SuspiciousIntentEvent.SuspiciousIntentPayload
 import kotlinx.serialization.Serializable
@@ -13,7 +14,7 @@ internal data class ApiSuspiciousIntentPayload(
 ) : ApiEventPayload() {
     constructor(domainPayload: SuspiciousIntentPayload) : this(
         domainPayload.createdAt.fromDomainToApi(),
-        domainPayload.unexpectedExtras,
+        domainPayload.unexpectedExtras.toStringMap(),
     )
 
     override fun getTokenizedFieldJsonPath(tokenKeyType: TokenKeyType): String? = null // this payload doesn't have tokenizable fields

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/ApiInvalidIntentPayloadTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/ApiInvalidIntentPayloadTest.kt
@@ -1,8 +1,11 @@
 package com.simprints.infra.eventsync.event.remote.models
 
 import com.google.common.truth.Truth.assertThat
+import com.simprints.core.tools.time.Timestamp
 import com.simprints.infra.config.store.models.TokenKeyType
+import com.simprints.infra.events.event.domain.models.InvalidIntentEvent
 import io.mockk.mockk
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Test
 
 class ApiInvalidIntentPayloadTest {
@@ -12,5 +15,17 @@ class ApiInvalidIntentPayloadTest {
         TokenKeyType.values().forEach {
             assertThat(payload.getTokenizedFieldJsonPath(it)).isNull()
         }
+    }
+
+    @Test
+    fun `converts extras jsonElements to string`() {
+        val domainPayload = InvalidIntentEvent.InvalidIntentPayload(
+            createdAt = Timestamp(123L),
+            eventVersion = 1,
+            action = "Enrol",
+            extras = mapOf("key" to JsonPrimitive("value"), "key2" to JsonPrimitive(123)),
+        )
+        val apiInvalidIntentPayload = ApiInvalidIntentPayload(domainPayload = domainPayload)
+        assertThat(apiInvalidIntentPayload.extras).isEqualTo(mapOf("key" to "value", "key2" to "123"))
     }
 }

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/ApiSuspiciousIntentPayloadTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/ApiSuspiciousIntentPayloadTest.kt
@@ -1,16 +1,30 @@
 package com.simprints.infra.eventsync.event.remote.models
 
-import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.*
+import com.simprints.core.tools.time.Timestamp
 import com.simprints.infra.config.store.models.TokenKeyType
-import io.mockk.mockk
+import com.simprints.infra.events.event.domain.models.SuspiciousIntentEvent
+import io.mockk.*
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Test
 
 class ApiSuspiciousIntentPayloadTest {
     @Test
     fun `when getTokenizedFieldJsonPath is invoked, null is returned`() {
         val payload = ApiSuspiciousIntentPayload(domainPayload = mockk(relaxed = true))
-        TokenKeyType.values().forEach {
+        TokenKeyType.entries.forEach {
             assertThat(payload.getTokenizedFieldJsonPath(it)).isNull()
         }
+    }
+
+    @Test
+    fun `converts extras jsonElements to string`() {
+        val domainPayload = SuspiciousIntentEvent.SuspiciousIntentPayload(
+            createdAt = Timestamp(123L),
+            eventVersion = 1,
+            unexpectedExtras = mapOf("key" to JsonPrimitive("value"), "key2" to JsonPrimitive(123)),
+        )
+        val apiSuspiciousIntentPayload = ApiSuspiciousIntentPayload(domainPayload = domainPayload)
+        assertThat(apiSuspiciousIntentPayload.unexpectedExtras).isEqualTo(mapOf("key" to "value", "key2" to "123"))
     }
 }

--- a/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
+++ b/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
@@ -104,6 +104,7 @@ import com.simprints.infra.events.sampledata.SampleDefaults.ENDED_AT
 import com.simprints.infra.events.sampledata.SampleDefaults.EXTERNAL_CREDENTIAL
 import com.simprints.infra.events.sampledata.SampleDefaults.GUID1
 import com.simprints.infra.events.sampledata.SampleDefaults.GUID2
+import kotlinx.serialization.json.JsonPrimitive
 
 fun createSessionScope(
     id: String = GUID1,
@@ -422,7 +423,7 @@ fun createIntentParsingEvent() = IntentParsingEvent(CREATED_AT, COMMCARE)
 fun createInvalidIntentEvent() = InvalidIntentEvent(
     CREATED_AT,
     "action",
-    mapOf("extra_key" to "extra_value"),
+    mapOf("extra_key" to JsonPrimitive("extra_value")),
 )
 
 fun createOneToManyMatchEvent() = OneToManyMatchEvent(
@@ -474,7 +475,7 @@ fun createScannerFirmwareUpdateEvent() = ScannerFirmwareUpdateEvent(
 
 fun createSuspiciousIntentEvent() = SuspiciousIntentEvent(
     CREATED_AT,
-    mapOf("extra_key" to "extra_value"),
+    mapOf("extra_key" to JsonPrimitive("extra_value")),
 )
 
 fun createVero2InfoSnapshotEvent() = Vero2InfoSnapshotEvent(

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/InvalidIntentEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/InvalidIntentEvent.kt
@@ -8,6 +8,7 @@ import com.simprints.infra.events.event.domain.models.EventType.Companion.INVALI
 import com.simprints.infra.events.event.domain.models.EventType.INVALID_INTENT
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import java.util.UUID
 
 @Keep
@@ -23,7 +24,7 @@ data class InvalidIntentEvent(
     constructor(
         creationTime: Timestamp,
         action: String,
-        extras: Map<String, String?>,
+        extras: Map<String, JsonElement?>,
     ) : this(
         UUID.randomUUID().toString(),
         InvalidIntentPayload(creationTime, EVENT_VERSION, action, extras),
@@ -40,7 +41,7 @@ data class InvalidIntentEvent(
         override val createdAt: Timestamp,
         override val eventVersion: Int,
         val action: String,
-        val extras: Map<String, String?>,
+        val extras: Map<String, JsonElement?>,
         override val endedAt: Timestamp? = null,
         override val type: EventType = INVALID_INTENT,
     ) : EventPayload() {

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/SuspiciousIntentEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/SuspiciousIntentEvent.kt
@@ -8,6 +8,7 @@ import com.simprints.infra.events.event.domain.models.EventType.Companion.SUSPIC
 import com.simprints.infra.events.event.domain.models.EventType.SUSPICIOUS_INTENT
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import java.util.UUID
 
 @Keep
@@ -22,7 +23,7 @@ data class SuspiciousIntentEvent(
 ) : Event() {
     constructor(
         createdAt: Timestamp,
-        unexpectedExtras: Map<String, String?>,
+        unexpectedExtras: Map<String, JsonElement?>,
     ) : this(
         UUID.randomUUID().toString(),
         SuspiciousIntentPayload(createdAt, EVENT_VERSION, unexpectedExtras),
@@ -38,7 +39,7 @@ data class SuspiciousIntentEvent(
     data class SuspiciousIntentPayload(
         override val createdAt: Timestamp,
         override val eventVersion: Int,
-        val unexpectedExtras: Map<String, String?>,
+        val unexpectedExtras: Map<String, JsonElement?>,
         override val endedAt: Timestamp? = null,
         override val type: EventType = SUSPICIOUS_INTENT,
     ) : EventPayload() {

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/EventPayloadTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/EventPayloadTest.kt
@@ -32,6 +32,7 @@ import com.simprints.infra.events.sampledata.SampleDefaults.DEFAULT_USER_ID
 import com.simprints.infra.events.sampledata.SampleDefaults.ENDED_AT
 import com.simprints.infra.events.sampledata.SampleDefaults.GUID1
 import com.simprints.infra.events.sampledata.SampleDefaults.GUID2
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Test
 import com.simprints.infra.events.event.domain.models.AuthenticationEvent.AuthenticationPayload.UserInfo as AuthenticationUserInfo
 import com.simprints.infra.events.event.domain.models.AuthorizationEvent.AuthorizationPayload.UserInfo as AuthorizationUserInfo
@@ -202,7 +203,7 @@ class EventPayloadTest {
         ),
         GuidSelectionEvent(CREATED_AT, GUID1),
         IntentParsingEvent(CREATED_AT, COMMCARE),
-        InvalidIntentEvent(CREATED_AT, "REGISTER", mapOf("extra_key" to "value")),
+        InvalidIntentEvent(CREATED_AT, "REGISTER", extras = mapOf("extra_key" to JsonPrimitive("value"))),
         OneToManyMatchEvent(
             createdAt = CREATED_AT,
             endTime = ENDED_AT,
@@ -238,6 +239,6 @@ class EventPayloadTest {
             ),
         ),
         ScannerFirmwareUpdateEvent(CREATED_AT, ENDED_AT, "chip", "v1", "error"),
-        SuspiciousIntentEvent(CREATED_AT, mapOf("extra_key" to "value")),
+        SuspiciousIntentEvent(CREATED_AT, mapOf("extra_key" to JsonPrimitive("value"))),
     )
 }

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/InvalidIntentEventTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/InvalidIntentEventTest.kt
@@ -4,12 +4,13 @@ import com.google.common.truth.Truth.assertThat
 import com.simprints.infra.events.event.domain.models.EventType.INVALID_INTENT
 import com.simprints.infra.events.event.domain.models.InvalidIntentEvent.Companion.EVENT_VERSION
 import com.simprints.infra.events.sampledata.SampleDefaults.CREATED_AT
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Test
 
 class InvalidIntentEventTest {
     @Test
     fun create_InvalidIntentEvent() {
-        val extras = mapOf("extra_key" to "value")
+        val extras = mapOf("extra_key" to JsonPrimitive("value"), "extra_key2" to JsonPrimitive(123))
         val event = InvalidIntentEvent(CREATED_AT, "REGISTER", extras)
 
         assertThat(event.id).isNotNull()

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/SuspiciousIntentEventTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/SuspiciousIntentEventTest.kt
@@ -1,15 +1,17 @@
 package com.simprints.infra.events.event.domain.models
 
-import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.*
+import com.simprints.core.tools.json.JsonHelper
 import com.simprints.infra.events.event.domain.models.EventType.SUSPICIOUS_INTENT
 import com.simprints.infra.events.event.domain.models.SuspiciousIntentEvent.Companion.EVENT_VERSION
 import com.simprints.infra.events.sampledata.SampleDefaults.CREATED_AT
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Test
 
 class SuspiciousIntentEventTest {
     @Test
     fun create_SuspiciousIntentEvent() {
-        val extrasArg = mapOf("extra_key" to "value")
+        val extrasArg = mapOf("extra_key" to JsonPrimitive("value"), "extra_key2" to JsonPrimitive(123))
         val event = SuspiciousIntentEvent(CREATED_AT, extrasArg)
 
         assertThat(event.id).isNotNull()
@@ -20,5 +22,32 @@ class SuspiciousIntentEventTest {
             assertThat(type).isEqualTo(SUSPICIOUS_INTENT)
             assertThat(unexpectedExtras).isEqualTo(extrasArg)
         }
+    }
+
+    @Test
+    fun `parse json with permissive extras`() {
+        val json = """
+            {
+                "id": "123",
+                "type": "SUSPICIOUS_INTENT",
+                "payload": {
+                    "createdAt": {"ms": 1234},
+                    "eventVersion": 2,
+                    "unexpectedExtras": {
+                        "extra_key": "value",
+                        "extra_key2": 123,
+                        "extra_key3": true                    
+                    }
+              }
+            }
+            """
+        val event = JsonHelper.json.decodeFromString<SuspiciousIntentEvent>(json)
+        assertThat(event.payload.unexpectedExtras).isEqualTo(
+            mapOf(
+                "extra_key" to JsonPrimitive("value"),
+                "extra_key2" to JsonPrimitive(123),
+                "extra_key3" to JsonPrimitive(true),
+            ),
+        )
     }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1304)
Will be released in: **2026.1.0**

### Notable changes
In a recent refactor, the extras map was changed from Map<String, Any> to Map<String, String>. While this change works correctly for new data, it causes the app to crash when reading old database records containing mixed-type values (e.g., integers, booleans).

To maintain backward compatibility, this PR updates the deserialization logic to safely convert all values in the extras map to strings when loading from the database. For example, JSON entries like:
```
"unexpectedExtras": {
    "extra_key": "value",
    "extra_key2": 123,
    "extra_key3": true                    
}
```
will now be correctly read and uploaded as:
````
"unexpectedExtras": {
    "extra_key": "value",
    "extra_key2": "123",
    "extra_key3": "true"                    
}
```
### Testing guidance

* In any older versions of SID create SuspiciousIntent and InvalidIntent events. don't sync the data and install the latest version of SID. The app should sync the data successfully 
* 
### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
