### PR TITLE
[MS-1300] Sync architecture revamp, part 3

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/debug/DebugFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/debug/DebugFragment.kt
@@ -88,15 +88,15 @@ internal class DebugFragment : Fragment(R.layout.fragment_debug) {
         }
 
         binding.syncStart.setOnClickListener {
-            syncOrchestrator.executeOneTime(OneTime.Events.start())
+            syncOrchestrator.execute(OneTime.Events.start())
         }
 
         binding.syncStop.setOnClickListener {
-            syncOrchestrator.executeOneTime(OneTime.Events.stop())
+            syncOrchestrator.execute(OneTime.Events.stop())
         }
 
         binding.syncSchedule.setOnClickListener {
-            syncOrchestrator.executeSchedulingCommand(ScheduleCommand.Events.reschedule())
+            syncOrchestrator.execute(ScheduleCommand.Events.reschedule())
         }
 
         binding.clearFirebaseToken.setOnClickListener {
@@ -121,8 +121,8 @@ internal class DebugFragment : Fragment(R.layout.fragment_debug) {
 
         binding.cleanAll.setOnClickListener {
             lifecycleScope.launch(dispatcher) {
-                syncOrchestrator.executeOneTime(OneTime.Events.stop())
-                syncOrchestrator.executeSchedulingCommand(ScheduleCommand.Events.unschedule())
+                syncOrchestrator.execute(OneTime.Events.stop())
+                syncOrchestrator.execute(ScheduleCommand.Events.unschedule())
 
                 eventRepository.deleteAll()
                 eventSyncManager.resetDownSyncInfo()

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/debug/DebugFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/debug/DebugFragment.kt
@@ -85,7 +85,7 @@ internal class DebugFragment : Fragment(R.layout.fragment_debug) {
                 )
 
                 binding.logs.append(ssb)
-        }
+            }
 
         binding.syncStart.setOnClickListener {
             syncOrchestrator.execute(OneTime.Events.start())

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCase.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCase.kt
@@ -20,7 +20,7 @@ internal class LogoutUseCase @Inject constructor(
     // To prevent a race between wiping data and navigation, this use case must block the executing thread
     operator fun invoke() = runBlocking(ioDispatcher) {
         // Cancel all background sync
-        syncOrchestrator.executeSchedulingCommand(ScheduleCommand.Everything.unschedule())
+        syncOrchestrator.execute(ScheduleCommand.Everything.unschedule())
         syncOrchestrator.deleteEventSyncInfo()
         // sign out the user
         authManager.signOut()

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModel.kt
@@ -145,7 +145,7 @@ internal class SyncInfoViewModel @Inject constructor(
             }
 
             val isDownSyncAllowed = !isPreLogoutUpSync && configRepository.getProject()?.state == ProjectState.RUNNING
-            syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed))
+            syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed))
         }
     }
 
@@ -153,10 +153,10 @@ internal class SyncInfoViewModel @Inject constructor(
         viewModelScope.launch {
             val isImageSyncing = imageSyncStatusFlow.firstOrNull()?.isSyncing == true
             if (isImageSyncing) {
-                syncOrchestrator.executeOneTime(OneTime.Images.stop())
+                syncOrchestrator.execute(OneTime.Images.stop())
             } else {
                 imageSyncButtonClickFlow.emit(Unit)
-                syncOrchestrator.executeOneTime(OneTime.Images.start())
+                syncOrchestrator.execute(OneTime.Images.start())
             }
         }
     }
@@ -214,7 +214,7 @@ internal class SyncInfoViewModel @Inject constructor(
                     .distinctUntilChanged()
                     .collect { isEventSyncCompleted ->
                         if (isEventSyncCompleted) {
-                            syncOrchestrator.executeOneTime(OneTime.Images.start())
+                            syncOrchestrator.execute(OneTime.Images.start())
                         }
                     }
             }

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/ModuleSelectionViewModel.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/ModuleSelectionViewModel.kt
@@ -115,7 +115,7 @@ internal class ModuleSelectionViewModel @Inject constructor(
                 module.copy(name = encryptedName)
             }
             moduleRepository.saveModules(modules)
-            syncOrchestrator.executeOneTime(OneTime.Events.restart())
+            syncOrchestrator.execute(OneTime.Events.restart())
         }
     }
 

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCaseTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/logout/usecase/LogoutUseCaseTest.kt
@@ -41,7 +41,7 @@ class LogoutUseCaseTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-        every { syncOrchestrator.executeSchedulingCommand(any()) } returns Job().apply { complete() }
+        every { syncOrchestrator.execute(any<ScheduleCommand>()) } returns Job().apply { complete() }
 
         useCase = LogoutUseCase(
             syncOrchestrator = syncOrchestrator,
@@ -56,7 +56,7 @@ class LogoutUseCaseTest {
     fun `Fully logs out when called`() = runTest {
         useCase.invoke()
 
-        verify { syncOrchestrator.executeSchedulingCommand(ScheduleCommand.Everything.unschedule()) }
+        verify { syncOrchestrator.execute(ScheduleCommand.Everything.unschedule()) }
         coVerify {
             syncOrchestrator.deleteEventSyncInfo()
             authManager.signOut()

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
@@ -146,7 +146,7 @@ class SyncInfoViewModelTest {
             SyncStatus(eventSyncState = mockEventSyncState, imageSyncStatus = mockImageSyncStatus),
         )
         every { syncOrchestrator.observeSyncState() } returns syncStatusFlow
-        every { syncOrchestrator.executeOneTime(any()) } returns Job().apply { complete() }
+        every { syncOrchestrator.execute(any<OneTime>()) } returns Job().apply { complete() }
 
         every { timeHelper.now() } returns TEST_TIMESTAMP
         every { timeHelper.msBetweenNowAndTime(any()) } returns 0L
@@ -385,7 +385,7 @@ class SyncInfoViewModelTest {
 
         viewModel.forceEventSync()
 
-        verify { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = true)) }
+        verify { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = true)) }
     }
 
     @Test
@@ -394,7 +394,7 @@ class SyncInfoViewModelTest {
 
         viewModel.forceEventSync()
 
-        verify { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = false)) }
+        verify { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = false)) }
     }
 
     @Test
@@ -408,7 +408,7 @@ class SyncInfoViewModelTest {
 
         viewModel.forceEventSync()
 
-        verify { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = false)) }
+        verify { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = false)) }
     }
 
     @Test
@@ -422,7 +422,7 @@ class SyncInfoViewModelTest {
 
         viewModel.forceEventSync()
 
-        verify { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = false)) }
+        verify { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = false)) }
     }
 
     @Test
@@ -433,14 +433,14 @@ class SyncInfoViewModelTest {
 
         viewModel.forceEventSync()
 
-        verify { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = false)) }
+        verify { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = false)) }
     }
 
     @Test
     fun `should stop current event sync before starting new one`() = runTest {
         viewModel.forceEventSync()
 
-        verify { syncOrchestrator.executeOneTime(OneTime.Events.restart()) }
+        verify { syncOrchestrator.execute(OneTime.Events.restart()) }
     }
 
     // toggleImageSync() tests
@@ -455,8 +455,8 @@ class SyncInfoViewModelTest {
 
         viewModel.toggleImageSync()
 
-        verify { syncOrchestrator.executeOneTime(OneTime.Images.start()) }
-        verify(exactly = 0) { syncOrchestrator.executeOneTime(OneTime.Images.stop()) }
+        verify { syncOrchestrator.execute(OneTime.Images.start()) }
+        verify(exactly = 0) { syncOrchestrator.execute(OneTime.Images.stop()) }
     }
 
     @Test
@@ -469,8 +469,8 @@ class SyncInfoViewModelTest {
 
         viewModel.toggleImageSync()
 
-        verify { syncOrchestrator.executeOneTime(OneTime.Images.stop()) }
-        verify(exactly = 0) { syncOrchestrator.executeOneTime(OneTime.Images.start()) }
+        verify { syncOrchestrator.execute(OneTime.Images.stop()) }
+        verify(exactly = 0) { syncOrchestrator.execute(OneTime.Images.start()) }
     }
 
     // logout() tests
@@ -524,7 +524,7 @@ class SyncInfoViewModelTest {
 
         viewModel.handleLoginResult(successResult)
 
-        verify { syncOrchestrator.executeOneTime(OneTime.Events.restart()) }
+        verify { syncOrchestrator.execute(OneTime.Events.restart()) }
     }
 
     @Test
@@ -535,8 +535,8 @@ class SyncInfoViewModelTest {
 
         viewModel.handleLoginResult(failureResult)
 
-        verify(exactly = 0) { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = true)) }
-        verify(exactly = 0) { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = false)) }
+        verify(exactly = 0) { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = true)) }
+        verify(exactly = 0) { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = false)) }
     }
 
     // Sync button responsiveness optimization
@@ -672,7 +672,7 @@ class SyncInfoViewModelTest {
 
         viewModel.syncInfoLiveData.getOrAwaitValue()
 
-        verify { syncOrchestrator.executeOneTime(OneTime.Events.restart()) }
+        verify { syncOrchestrator.execute(OneTime.Events.restart()) }
     }
 
     @Test
@@ -688,7 +688,7 @@ class SyncInfoViewModelTest {
 
         viewModel.syncInfoLiveData.getOrAwaitValue()
 
-        verify { syncOrchestrator.executeOneTime(OneTime.Events.restart()) }
+        verify { syncOrchestrator.execute(OneTime.Events.restart()) }
     }
 
     @Test
@@ -704,8 +704,8 @@ class SyncInfoViewModelTest {
 
         viewModel.syncInfoLiveData.getOrAwaitValue()
 
-        verify(exactly = 0) { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = true)) }
-        verify(exactly = 0) { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = false)) }
+        verify(exactly = 0) { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = true)) }
+        verify(exactly = 0) { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = false)) }
     }
 
     @Test
@@ -719,8 +719,8 @@ class SyncInfoViewModelTest {
 
         viewModel.syncInfoLiveData.getOrAwaitValue()
 
-        verify(exactly = 0) { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = true)) }
-        verify(exactly = 0) { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = false)) }
+        verify(exactly = 0) { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = true)) }
+        verify(exactly = 0) { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = false)) }
     }
 
     @Test
@@ -737,7 +737,7 @@ class SyncInfoViewModelTest {
 
         viewModel.syncInfoLiveData.getOrAwaitValue()
 
-        verify { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = false)) }
+        verify { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = false)) }
     }
 
     @Test
@@ -758,7 +758,7 @@ class SyncInfoViewModelTest {
 
         viewModel.syncInfoLiveData.getOrAwaitValue()
 
-        verify(exactly = 1) { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = false)) }
+        verify(exactly = 1) { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = false)) }
     }
 
     @Test
@@ -779,8 +779,8 @@ class SyncInfoViewModelTest {
 
         viewModel.syncInfoLiveData.getOrAwaitValue()
 
-        verify(exactly = 0) { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = true)) }
-        verify(exactly = 0) { syncOrchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = false)) }
+        verify(exactly = 0) { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = true)) }
+        verify(exactly = 0) { syncOrchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = false)) }
     }
 
     private companion object {

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
@@ -24,8 +24,8 @@ import com.simprints.infra.eventsync.status.models.EventSyncState
 import com.simprints.infra.recent.user.activity.RecentUserActivityManager
 import com.simprints.infra.sync.ImageSyncStatus
 import com.simprints.infra.sync.OneTime
-import com.simprints.infra.sync.SyncStatus
 import com.simprints.infra.sync.SyncOrchestrator
+import com.simprints.infra.sync.SyncStatus
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import com.simprints.testtools.common.livedata.getOrAwaitValue
 import com.simprints.testtools.common.livedata.getOrAwaitValues

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/ModuleSelectionViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/ModuleSelectionViewModelTest.kt
@@ -57,7 +57,7 @@ class ModuleSelectionViewModelTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-        every { syncOrchestrator.executeOneTime(any()) } returns Job().apply { complete() }
+        every { syncOrchestrator.execute(any<OneTime>()) } returns Job().apply { complete() }
 
         val modulesDefault = listOf(
             Module("a".asTokenizableEncrypted(), false),
@@ -176,7 +176,7 @@ class ModuleSelectionViewModelTest {
         viewModel.saveModules()
 
         coVerify(exactly = 1) { repository.saveModules(updatedModules) }
-        verify(exactly = 1) { syncOrchestrator.executeOneTime(OneTime.Events.restart()) }
+        verify(exactly = 1) { syncOrchestrator.execute(OneTime.Events.restart()) }
     }
 
     @Test

--- a/feature/login-check/src/main/java/com/simprints/feature/logincheck/LoginCheckViewModel.kt
+++ b/feature/login-check/src/main/java/com/simprints/feature/logincheck/LoginCheckViewModel.kt
@@ -106,7 +106,7 @@ class LoginCheckViewModel @Inject internal constructor(
         cachedRequest = actionRequest
         loginAlreadyTried.set(true)
 
-        syncOrchestrator.executeSchedulingCommand(ScheduleCommand.Everything.unschedule())
+        syncOrchestrator.execute(ScheduleCommand.Everything.unschedule())
 
         _showLoginFlow.send(actionRequest)
     }

--- a/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/StartBackgroundSyncUseCase.kt
+++ b/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/StartBackgroundSyncUseCase.kt
@@ -18,6 +18,6 @@ internal class StartBackgroundSyncUseCase @Inject constructor(
             ?.frequency
 
         val withDelay = frequency != Frequency.PERIODICALLY_AND_ON_SESSION_START
-        syncOrchestrator.executeSchedulingCommand(ScheduleCommand.Everything.reschedule(withDelay)).await()
+        syncOrchestrator.execute(ScheduleCommand.Everything.reschedule(withDelay)).await()
     }
 }

--- a/feature/login-check/src/test/java/com/simprints/feature/logincheck/LoginCheckViewModelTest.kt
+++ b/feature/login-check/src/test/java/com/simprints/feature/logincheck/LoginCheckViewModelTest.kt
@@ -86,7 +86,7 @@ internal class LoginCheckViewModelTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-        every { syncOrchestrator.executeSchedulingCommand(any()) } returns Job().apply { complete() }
+        every { syncOrchestrator.execute(any<ScheduleCommand>()) } returns Job().apply { complete() }
 
         viewModel = LoginCheckViewModel(
             rootManager = rootMatchers,
@@ -173,7 +173,7 @@ internal class LoginCheckViewModelTest {
         coVerify {
             addAuthorizationEventUseCase.invoke(any(), eq(false))
         }
-        verify { syncOrchestrator.executeSchedulingCommand(ScheduleCommand.Everything.unschedule()) }
+        verify { syncOrchestrator.execute(ScheduleCommand.Everything.unschedule()) }
         viewModel.showLoginFlow
             .test()
             .assertValue { it.peekContent() == ActionFactory.getIdentifyRequest() }

--- a/feature/login-check/src/test/java/com/simprints/feature/logincheck/usecases/StartBackgroundSyncUseCaseTest.kt
+++ b/feature/login-check/src/test/java/com/simprints/feature/logincheck/usecases/StartBackgroundSyncUseCaseTest.kt
@@ -80,8 +80,8 @@ class StartBackgroundSyncUseCaseTest {
     fun `Does not start event sync on start if not Simprints sync`() = runTest {
         coEvery {
             configRepository
-            .getProjectConfiguration()
-            .synchronization.down.simprints
+                .getProjectConfiguration()
+                .synchronization.down.simprints
         } returns null
 
         assertUseCaseAwaitsSync(ScheduleCommand.Everything.reschedule(withDelay = true))

--- a/feature/login-check/src/test/java/com/simprints/feature/logincheck/usecases/StartBackgroundSyncUseCaseTest.kt
+++ b/feature/login-check/src/test/java/com/simprints/feature/logincheck/usecases/StartBackgroundSyncUseCaseTest.kt
@@ -29,7 +29,7 @@ class StartBackgroundSyncUseCaseTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-        every { syncOrchestrator.executeSchedulingCommand(any()) } returns Job().apply { complete() }
+        every { syncOrchestrator.execute(any<ScheduleCommand>()) } returns Job().apply { complete() }
 
         useCase = StartBackgroundSyncUseCase(
             configRepository,
@@ -89,7 +89,7 @@ class StartBackgroundSyncUseCaseTest {
 
     private suspend fun TestScope.assertUseCaseAwaitsSync(expectedCommand: ScheduleCommand) {
         val syncCommandJob = Job()
-        every { syncOrchestrator.executeSchedulingCommand(any()) } returns syncCommandJob
+        every { syncOrchestrator.execute(any<ScheduleCommand>()) } returns syncCommandJob
 
         val useCaseJob = async { useCase.invoke() }
 
@@ -100,6 +100,6 @@ class StartBackgroundSyncUseCaseTest {
         runCurrent()
         useCaseJob.await()
 
-        verify { syncOrchestrator.executeSchedulingCommand(expectedCommand) }
+        verify { syncOrchestrator.execute(expectedCommand) }
     }
 }

--- a/feature/validate-subject-pool/src/main/java/com/simprints/feature/validatepool/usecase/RunBlockingEventSyncUseCase.kt
+++ b/feature/validate-subject-pool/src/main/java/com/simprints/feature/validatepool/usecase/RunBlockingEventSyncUseCase.kt
@@ -21,7 +21,7 @@ internal class RunBlockingEventSyncUseCase @Inject constructor(
             .firstOrNull { !it.isUninitialized() }
             ?.syncId
         syncOrchestrator
-            .executeOneTime(OneTime.Events.start())
+            .execute(OneTime.Events.start())
             .await()
         syncState
             .map { it.eventSyncState }

--- a/feature/validate-subject-pool/src/test/java/com/simprints/feature/validatepool/usecase/RunBlockingEventSyncUseCaseTest.kt
+++ b/feature/validate-subject-pool/src/test/java/com/simprints/feature/validatepool/usecase/RunBlockingEventSyncUseCaseTest.kt
@@ -51,7 +51,7 @@ class RunBlockingEventSyncUseCaseTest {
         testScheduler.advanceUntilIdle()
 
         verify(exactly = 1) { syncOrchestrator.observeSyncState() }
-        verify(exactly = 1) { syncOrchestrator.executeOneTime(OneTime.Events.start()) }
+        verify(exactly = 1) { syncOrchestrator.execute(OneTime.Events.start()) }
     }
 
     @Test
@@ -66,7 +66,7 @@ class RunBlockingEventSyncUseCaseTest {
         testScheduler.advanceUntilIdle()
 
         verify(exactly = 1) { syncOrchestrator.observeSyncState() }
-        verify(exactly = 1) { syncOrchestrator.executeOneTime(OneTime.Events.start()) }
+        verify(exactly = 1) { syncOrchestrator.execute(OneTime.Events.start()) }
     }
 
     @Test
@@ -81,7 +81,7 @@ class RunBlockingEventSyncUseCaseTest {
         testScheduler.advanceUntilIdle()
 
         verify(exactly = 1) { syncOrchestrator.observeSyncState() }
-        verify(exactly = 1) { syncOrchestrator.executeOneTime(OneTime.Events.start()) }
+        verify(exactly = 1) { syncOrchestrator.execute(OneTime.Events.start()) }
     }
 
     @Test
@@ -92,12 +92,12 @@ class RunBlockingEventSyncUseCaseTest {
         val job = launch { usecase.invoke() }
         testScheduler.advanceUntilIdle()
 
-        verify(exactly = 0) { syncOrchestrator.executeOneTime(OneTime.Events.start()) }
+        verify(exactly = 0) { syncOrchestrator.execute(OneTime.Events.start()) }
 
         syncFlow.value = createSyncStatus("sync", EventSyncWorkerState.Succeeded)
         testScheduler.advanceUntilIdle()
 
-        verify(exactly = 1) { syncOrchestrator.executeOneTime(OneTime.Events.start()) }
+        verify(exactly = 1) { syncOrchestrator.execute(OneTime.Events.start()) }
         job.cancel()
     }
 
@@ -128,7 +128,7 @@ class RunBlockingEventSyncUseCaseTest {
 
     private fun setUpSync(syncFlow: StateFlow<SyncStatus>) {
         every { syncOrchestrator.observeSyncState() } returns syncFlow
-        every { syncOrchestrator.executeOneTime(OneTime.Events.start()) } returns Job().apply { complete() }
+        every { syncOrchestrator.execute(OneTime.Events.start()) } returns Job().apply { complete() }
     }
 
     private fun createPlaceholderSyncStatus(): SyncStatus = createSyncStatus("", null, null, null)

--- a/feature/validate-subject-pool/src/test/java/com/simprints/feature/validatepool/usecase/RunBlockingEventSyncUseCaseTest.kt
+++ b/feature/validate-subject-pool/src/test/java/com/simprints/feature/validatepool/usecase/RunBlockingEventSyncUseCaseTest.kt
@@ -6,8 +6,8 @@ import com.simprints.infra.eventsync.status.models.EventSyncWorkerState
 import com.simprints.infra.eventsync.status.models.EventSyncWorkerType
 import com.simprints.infra.sync.ImageSyncStatus
 import com.simprints.infra.sync.OneTime
-import com.simprints.infra.sync.SyncStatus
 import com.simprints.infra.sync.SyncOrchestrator
+import com.simprints.infra.sync.SyncStatus
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import io.mockk.*
 import io.mockk.impl.annotations.MockK

--- a/id/src/main/java/com/simprints/id/Application.kt
+++ b/id/src/main/java/com/simprints/id/Application.kt
@@ -86,7 +86,7 @@ open class Application :
         appScope.launch {
             realmToRoomMigrationScheduler.scheduleMigrationWorkerIfNeeded()
             syncOrchestrator.cleanupWorkers()
-            syncOrchestrator.executeSchedulingCommand(ScheduleCommand.Everything.reschedule())
+            syncOrchestrator.execute(ScheduleCommand.Everything.reschedule())
         }
         if (DB_ENCRYPTION) {
             System.loadLibrary("sqlcipher")

--- a/id/src/main/java/com/simprints/id/services/sync/events/down/EventDownSyncResetService.kt
+++ b/id/src/main/java/com/simprints/id/services/sync/events/down/EventDownSyncResetService.kt
@@ -52,7 +52,7 @@ class EventDownSyncResetService : Service() {
             eventSyncManager.resetDownSyncInfo()
             // Trigger a new sync
             // Execute in app scope to prevent a timeout cancellation leaving it in a stopped state
-            syncOrchestrator.executeOneTime(OneTime.Events.start()).await()
+            syncOrchestrator.execute(OneTime.Events.start()).await()
         }
         resetJob?.invokeOnCompletion { stopSelf() }
 

--- a/infra/sync/src/main/java/com/simprints/infra/sync/OneTimeSyncCommand.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/OneTimeSyncCommand.kt
@@ -3,7 +3,7 @@ package com.simprints.infra.sync
 /**
  * One-time (immediate) sync control commands.
  *
- * Intended to be executed via [SyncOrchestrator.executeOneTime].
+ * Intended to be executed via [SyncOrchestrator.execute].
  */
 sealed class OneTime {
     internal enum class Action {

--- a/infra/sync/src/main/java/com/simprints/infra/sync/ScheduleSyncCommand.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/ScheduleSyncCommand.kt
@@ -3,7 +3,7 @@ package com.simprints.infra.sync
 /**
  * Periodic/background scheduling commands.
  *
- * Intended to be executed via [SyncOrchestrator.executeSchedulingCommand].
+ * Intended to be executed via [SyncOrchestrator.execute].
  */
 sealed class ScheduleCommand {
     internal enum class Action {

--- a/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestrator.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestrator.kt
@@ -1,8 +1,8 @@
 package com.simprints.infra.sync
 
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 interface SyncOrchestrator {
     /**

--- a/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestrator.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestrator.kt
@@ -14,13 +14,13 @@ interface SyncOrchestrator {
      * Executes an immediate (one-time) sync control command.
      * Returns a job of the ongoing command execution.
      */
-    fun executeOneTime(command: OneTime): Job
+    fun execute(command: OneTime): Job
 
     /**
      * Executes a periodic/background scheduling command.
      * Returns a job of the ongoing command execution.
      */
-    fun executeSchedulingCommand(command: ScheduleCommand): Job
+    fun execute(command: ScheduleCommand): Job
 
     fun startConfigSync()
 

--- a/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestratorImpl.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestratorImpl.kt
@@ -24,10 +24,10 @@ import com.simprints.infra.sync.extensions.anyRunning
 import com.simprints.infra.sync.extensions.cancelWorkers
 import com.simprints.infra.sync.extensions.schedulePeriodicWorker
 import com.simprints.infra.sync.extensions.startWorker
-import com.simprints.infra.sync.usecase.CleanupDeprecatedWorkersUseCase
 import com.simprints.infra.sync.files.FileUpSyncWorker
 import com.simprints.infra.sync.firmware.FirmwareFileUpdateWorker
 import com.simprints.infra.sync.firmware.ShouldScheduleFirmwareUpdateUseCase
+import com.simprints.infra.sync.usecase.CleanupDeprecatedWorkersUseCase
 import com.simprints.infra.sync.usecase.internal.ObserveImageSyncStatusUseCase
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -110,45 +110,41 @@ internal class SyncOrchestratorImpl @Inject constructor(
 
     override fun observeSyncState(): StateFlow<SyncStatus> = sharedSyncState
 
-    override fun execute(command: OneTime): Job {
-        return when (command) {
-            is OneTime.EventsCommand -> executeOneTimeAction(
-                action = command.action,
-                stop = ::stopEventSync,
-                start = { startEventSync(isDownSyncAllowed = command.isDownSyncAllowed) },
-            )
+    override fun execute(command: OneTime): Job = when (command) {
+        is OneTime.EventsCommand -> executeOneTimeAction(
+            action = command.action,
+            stop = ::stopEventSync,
+            start = { startEventSync(isDownSyncAllowed = command.isDownSyncAllowed) },
+        )
 
-            is OneTime.ImagesCommand -> executeOneTimeAction(
-                action = command.action,
-                stop = ::stopImageSync,
-                start = { startImageSync() },
-            )
-        }
+        is OneTime.ImagesCommand -> executeOneTimeAction(
+            action = command.action,
+            stop = ::stopImageSync,
+            start = { startImageSync() },
+        )
     }
 
-    override fun execute(command: ScheduleCommand): Job {
-        return when (command) {
-            is ScheduleCommand.EverythingCommand -> executeSchedulingAction(
-                action = command.action,
-                blockWhileUnscheduled = command.blockWhileUnscheduled,
-                unschedule = ::cancelBackgroundWork,
-                reschedule = { scheduleBackgroundWork(withDelay = command.withDelay) },
-            )
+    override fun execute(command: ScheduleCommand): Job = when (command) {
+        is ScheduleCommand.EverythingCommand -> executeSchedulingAction(
+            action = command.action,
+            blockWhileUnscheduled = command.blockWhileUnscheduled,
+            unschedule = ::cancelBackgroundWork,
+            reschedule = { scheduleBackgroundWork(withDelay = command.withDelay) },
+        )
 
-            is ScheduleCommand.EventsCommand -> executeSchedulingAction(
-                action = command.action,
-                blockWhileUnscheduled = command.blockWhileUnscheduled,
-                unschedule = ::cancelEventSync,
-                reschedule = { rescheduleEventSync(withDelay = command.withDelay) },
-            )
+        is ScheduleCommand.EventsCommand -> executeSchedulingAction(
+            action = command.action,
+            blockWhileUnscheduled = command.blockWhileUnscheduled,
+            unschedule = ::cancelEventSync,
+            reschedule = { rescheduleEventSync(withDelay = command.withDelay) },
+        )
 
-            is ScheduleCommand.ImagesCommand -> executeSchedulingAction(
-                action = command.action,
-                blockWhileUnscheduled = command.blockWhileUnscheduled,
-                unschedule = ::stopImageSync,
-                reschedule = { rescheduleImageUpSync() },
-            )
-        }
+        is ScheduleCommand.ImagesCommand -> executeSchedulingAction(
+            action = command.action,
+            blockWhileUnscheduled = command.blockWhileUnscheduled,
+            unschedule = ::stopImageSync,
+            reschedule = { rescheduleImageUpSync() },
+        )
     }
 
     override fun startConfigSync() {
@@ -196,44 +192,42 @@ internal class SyncOrchestratorImpl @Inject constructor(
         action: OneTime.Action,
         stop: () -> Unit,
         start: suspend () -> Unit,
-    ): Job =
-        when (action) {
-            OneTime.Action.STOP -> {
-                stop()
-                Job().apply { complete() }
-            }
-            OneTime.Action.START -> {
-                appScope.launch(ioDispatcher) {
-                    start()
-                }
-            }
-            OneTime.Action.RESTART -> {
-                stop()
-                appScope.launch(ioDispatcher) {
-                    start()
-                }
+    ): Job = when (action) {
+        OneTime.Action.STOP -> {
+            stop()
+            Job().apply { complete() }
+        }
+        OneTime.Action.START -> {
+            appScope.launch(ioDispatcher) {
+                start()
             }
         }
+        OneTime.Action.RESTART -> {
+            stop()
+            appScope.launch(ioDispatcher) {
+                start()
+            }
+        }
+    }
 
     private fun executeSchedulingAction(
         action: ScheduleCommand.Action,
         blockWhileUnscheduled: (suspend () -> Unit)?,
         unschedule: () -> Unit,
         reschedule: suspend () -> Unit,
-    ): Job =
-        when (action) {
-            ScheduleCommand.Action.UNSCHEDULE -> {
-                unschedule()
-                Job().apply { complete() }
-            }
-            ScheduleCommand.Action.RESCHEDULE -> {
-                unschedule()
-                appScope.launch(ioDispatcher) {
-                    blockWhileUnscheduled?.invoke()
-                    reschedule()
-                }
+    ): Job = when (action) {
+        ScheduleCommand.Action.UNSCHEDULE -> {
+            unschedule()
+            Job().apply { complete() }
+        }
+        ScheduleCommand.Action.RESCHEDULE -> {
+            unschedule()
+            appScope.launch(ioDispatcher) {
+                blockWhileUnscheduled?.invoke()
+                reschedule()
             }
         }
+    }
 
     private suspend fun scheduleBackgroundWork(withDelay: Boolean) {
         if (authStore.signedInProjectId.isNotEmpty()) {

--- a/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestratorImpl.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/SyncOrchestratorImpl.kt
@@ -110,7 +110,7 @@ internal class SyncOrchestratorImpl @Inject constructor(
 
     override fun observeSyncState(): StateFlow<SyncStatus> = sharedSyncState
 
-    override fun executeOneTime(command: OneTime): Job {
+    override fun execute(command: OneTime): Job {
         return when (command) {
             is OneTime.EventsCommand -> executeOneTimeAction(
                 action = command.action,
@@ -126,7 +126,7 @@ internal class SyncOrchestratorImpl @Inject constructor(
         }
     }
 
-    override fun executeSchedulingCommand(command: ScheduleCommand): Job {
+    override fun execute(command: ScheduleCommand): Job {
         return when (command) {
             is ScheduleCommand.EverythingCommand -> executeSchedulingAction(
                 action = command.action,

--- a/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/LogoutUseCase.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/LogoutUseCase.kt
@@ -10,7 +10,7 @@ internal class LogoutUseCase @Inject constructor(
     private val authManager: AuthManager,
 ) {
     suspend operator fun invoke() {
-        syncOrchestrator.executeSchedulingCommand(ScheduleCommand.Everything.unschedule())
+        syncOrchestrator.execute(ScheduleCommand.Everything.unschedule())
         syncOrchestrator.deleteEventSyncInfo()
         authManager.signOut()
     }

--- a/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/LogoutUseCase.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/LogoutUseCase.kt
@@ -1,8 +1,8 @@
 package com.simprints.infra.sync.config.usecase
 
 import com.simprints.infra.authlogic.AuthManager
-import com.simprints.infra.sync.SyncOrchestrator
 import com.simprints.infra.sync.ScheduleCommand
+import com.simprints.infra.sync.SyncOrchestrator
 import javax.inject.Inject
 
 internal class LogoutUseCase @Inject constructor(

--- a/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/RescheduleWorkersIfConfigChangedUseCase.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/RescheduleWorkersIfConfigChangedUseCase.kt
@@ -15,7 +15,7 @@ internal class RescheduleWorkersIfConfigChangedUseCase @Inject constructor(
         newConfig: ProjectConfiguration,
     ) {
         if (shouldRescheduleImageUpload(oldConfig, newConfig)) {
-            syncOrchestrator.executeSchedulingCommand(ScheduleCommand.Images.reschedule()).await()
+            syncOrchestrator.execute(ScheduleCommand.Images.reschedule()).await()
         }
     }
 

--- a/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/ResetLocalRecordsIfConfigChangedUseCase.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/ResetLocalRecordsIfConfigChangedUseCase.kt
@@ -18,12 +18,13 @@ internal class ResetLocalRecordsIfConfigChangedUseCase @Inject constructor(
         newConfig: ProjectConfiguration,
     ) {
         if (hasPartitionTypeChanged(oldConfig, newConfig)) {
-            syncOrchestrator.execute(
-                ScheduleCommand.Events.rescheduleAfter {
-                    eventSyncManager.resetDownSyncInfo()
-                    enrolmentRecordRepository.deleteAll()
-                },
-            ).await()
+            syncOrchestrator
+                .execute(
+                    ScheduleCommand.Events.rescheduleAfter {
+                        eventSyncManager.resetDownSyncInfo()
+                        enrolmentRecordRepository.deleteAll()
+                    },
+                ).await()
         }
     }
 
@@ -37,5 +38,5 @@ internal class ResetLocalRecordsIfConfigChangedUseCase @Inject constructor(
             oldConfig.synchronization.down.simprints
                 ?.partitionType != newConfig.synchronization.down.simprints
                 ?.partitionType
-        )
+            )
 }

--- a/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/ResetLocalRecordsIfConfigChangedUseCase.kt
+++ b/infra/sync/src/main/java/com/simprints/infra/sync/config/usecase/ResetLocalRecordsIfConfigChangedUseCase.kt
@@ -18,7 +18,7 @@ internal class ResetLocalRecordsIfConfigChangedUseCase @Inject constructor(
         newConfig: ProjectConfiguration,
     ) {
         if (hasPartitionTypeChanged(oldConfig, newConfig)) {
-            syncOrchestrator.executeSchedulingCommand(
+            syncOrchestrator.execute(
                 ScheduleCommand.Events.rescheduleAfter {
                     eventSyncManager.resetDownSyncInfo()
                     enrolmentRecordRepository.deleteAll()

--- a/infra/sync/src/test/java/com/simprints/infra/sync/SyncOrchestratorCommandExecutionTest.kt
+++ b/infra/sync/src/test/java/com/simprints/infra/sync/SyncOrchestratorCommandExecutionTest.kt
@@ -81,7 +81,7 @@ class SyncOrchestratorCommandExecutionTest {
         every { authStore.signedInProjectId } returns ""
         coEvery { shouldScheduleFirmwareUpdate.invoke() } returns false
 
-        orchestrator.executeSchedulingCommand(ScheduleCommand.Everything.reschedule()).join()
+        orchestrator.execute(ScheduleCommand.Everything.reschedule()).join()
 
         verify(exactly = 0) { workManager.enqueueUniquePeriodicWork(any(), any(), any()) }
     }
@@ -91,7 +91,7 @@ class SyncOrchestratorCommandExecutionTest {
         every { authStore.signedInProjectId } returns "projectId"
         coEvery { shouldScheduleFirmwareUpdate.invoke() } returns true
 
-        orchestrator.executeSchedulingCommand(ScheduleCommand.Everything.reschedule()).join()
+        orchestrator.execute(ScheduleCommand.Everything.reschedule()).join()
 
         verify {
             workManager.enqueueUniquePeriodicWork(PROJECT_SYNC_WORK_NAME, any(), any())
@@ -111,7 +111,7 @@ class SyncOrchestratorCommandExecutionTest {
         } returns false
         every { authStore.signedInProjectId } returns "projectId"
 
-        orchestrator.executeSchedulingCommand(ScheduleCommand.Everything.reschedule()).join()
+        orchestrator.execute(ScheduleCommand.Everything.reschedule()).join()
 
         verify {
             workManager.enqueueUniquePeriodicWork(
@@ -132,7 +132,7 @@ class SyncOrchestratorCommandExecutionTest {
         every { authStore.signedInProjectId } returns "projectId"
         coEvery { shouldScheduleFirmwareUpdate.invoke() } returns false
 
-        orchestrator.executeSchedulingCommand(ScheduleCommand.Everything.reschedule()).join()
+        orchestrator.execute(ScheduleCommand.Everything.reschedule()).join()
 
         verify {
             workManager.enqueueUniquePeriodicWork(
@@ -148,7 +148,7 @@ class SyncOrchestratorCommandExecutionTest {
         every { authStore.signedInProjectId } returns "projectId"
         coEvery { shouldScheduleFirmwareUpdate.invoke() } returns false
 
-        orchestrator.executeSchedulingCommand(ScheduleCommand.Everything.reschedule()).join()
+        orchestrator.execute(ScheduleCommand.Everything.reschedule()).join()
 
         verify { workManager.cancelUniqueWork(FIRMWARE_UPDATE_WORK_NAME) }
     }
@@ -157,7 +157,7 @@ class SyncOrchestratorCommandExecutionTest {
     fun `unschedule cancels all necessary background workers`() = runTest {
         every { eventSyncManager.getAllWorkerTag() } returns "syncWorkers"
 
-        orchestrator.executeSchedulingCommand(ScheduleCommand.Everything.unschedule())
+        orchestrator.execute(ScheduleCommand.Everything.unschedule())
 
         verify {
             workManager.cancelUniqueWork(PROJECT_SYNC_WORK_NAME)
@@ -174,7 +174,7 @@ class SyncOrchestratorCommandExecutionTest {
     fun `reschedules event sync worker with correct tags`() = runTest {
         every { eventSyncManager.getPeriodicWorkTags() } returns listOf("tag1", "tag2")
 
-        orchestrator.executeSchedulingCommand(ScheduleCommand.Events.reschedule()).join()
+        orchestrator.execute(ScheduleCommand.Events.reschedule()).join()
 
         verify {
             workManager.enqueueUniquePeriodicWork(
@@ -189,7 +189,7 @@ class SyncOrchestratorCommandExecutionTest {
     fun `reschedules event sync worker with correct delay`() = runTest {
         every { eventSyncManager.getPeriodicWorkTags() } returns listOf("tag1", "tag2")
 
-        orchestrator.executeSchedulingCommand(ScheduleCommand.Events.reschedule(withDelay = true)).join()
+        orchestrator.execute(ScheduleCommand.Events.reschedule(withDelay = true)).join()
 
         verify {
             workManager.enqueueUniquePeriodicWork(
@@ -206,7 +206,7 @@ class SyncOrchestratorCommandExecutionTest {
         every { eventSyncManager.getPeriodicWorkTags() } returns listOf("tag1", "tag2")
 
         orchestrator
-            .executeSchedulingCommand(
+            .execute(
                 ScheduleCommand.Events.rescheduleAfter(withDelay = true) { },
             ).join()
 
@@ -229,7 +229,7 @@ class SyncOrchestratorCommandExecutionTest {
     fun `unschedule events cancels correct workers`() = runTest {
         every { eventSyncManager.getAllWorkerTag() } returns "syncWorkers"
 
-        orchestrator.executeSchedulingCommand(ScheduleCommand.Events.unschedule())
+        orchestrator.execute(ScheduleCommand.Events.unschedule())
 
         verify {
             workManager.cancelUniqueWork(EVENT_SYNC_WORK_NAME)
@@ -242,7 +242,7 @@ class SyncOrchestratorCommandExecutionTest {
     fun `start one-time event sync uses correct tags`() = runTest {
         every { eventSyncManager.getOneTimeWorkTags() } returns listOf("tag1", "tag2")
 
-        orchestrator.executeOneTime(OneTime.Events.start()).join()
+        orchestrator.execute(OneTime.Events.start()).join()
 
         verify {
             workManager.enqueueUniqueWork(
@@ -257,7 +257,7 @@ class SyncOrchestratorCommandExecutionTest {
     fun `start one-time event sync uses correct input data`() = runTest {
         every { eventSyncManager.getOneTimeWorkTags() } returns listOf("tag1", "tag2")
 
-        orchestrator.executeOneTime(OneTime.Events.start(isDownSyncAllowed = false)).join()
+        orchestrator.execute(OneTime.Events.start(isDownSyncAllowed = false)).join()
 
         verify {
             workManager.enqueueUniqueWork(
@@ -275,7 +275,7 @@ class SyncOrchestratorCommandExecutionTest {
         every { eventSyncManager.getAllWorkerTag() } returns "syncWorkers"
         every { eventSyncManager.getOneTimeWorkTags() } returns listOf("tag1", "tag2")
 
-        orchestrator.executeOneTime(OneTime.Events.restart(isDownSyncAllowed = false)).join()
+        orchestrator.execute(OneTime.Events.restart(isDownSyncAllowed = false)).join()
 
         verify {
             workManager.cancelUniqueWork(EVENT_SYNC_WORK_NAME_ONE_TIME)
@@ -295,7 +295,7 @@ class SyncOrchestratorCommandExecutionTest {
     fun `stop one-time event sync cancels correct workers`() = runTest {
         every { eventSyncManager.getAllWorkerTag() } returns "syncWorkers"
 
-        orchestrator.executeOneTime(OneTime.Events.stop())
+        orchestrator.execute(OneTime.Events.stop())
 
         verify {
             workManager.cancelUniqueWork(EVENT_SYNC_WORK_NAME_ONE_TIME)
@@ -305,7 +305,7 @@ class SyncOrchestratorCommandExecutionTest {
 
     @Test
     fun `reschedules image worker when requested`() = runTest {
-        orchestrator.executeSchedulingCommand(ScheduleCommand.Images.reschedule()).join()
+        orchestrator.execute(ScheduleCommand.Images.reschedule()).join()
 
         verify {
             workManager.enqueueUniquePeriodicWork(
@@ -318,7 +318,7 @@ class SyncOrchestratorCommandExecutionTest {
 
     @Test
     fun `start one-time image sync re-starts image worker`() = runTest {
-        orchestrator.executeOneTime(OneTime.Images.start()).join()
+        orchestrator.execute(OneTime.Images.start()).join()
 
         verify {
             workManager.cancelUniqueWork(FILE_UP_SYNC_WORK_NAME)
@@ -332,14 +332,14 @@ class SyncOrchestratorCommandExecutionTest {
 
     @Test
     fun `stop one-time image sync cancels image worker`() = runTest {
-        orchestrator.executeOneTime(OneTime.Images.stop())
+        orchestrator.execute(OneTime.Images.stop())
 
         verify { workManager.cancelUniqueWork(FILE_UP_SYNC_WORK_NAME) }
     }
 
     @Test
     fun `unschedule images returns completed job and routes to stop logic`() = runTest {
-        val job = orchestrator.executeSchedulingCommand(ScheduleCommand.Images.unschedule())
+        val job = orchestrator.execute(ScheduleCommand.Images.unschedule())
 
         assertThat(job.isCompleted).isTrue()
         verify { workManager.cancelUniqueWork(FILE_UP_SYNC_WORK_NAME) }
@@ -354,7 +354,7 @@ class SyncOrchestratorCommandExecutionTest {
             unblock.receive()
         }
 
-        val job = orchestrator.executeSchedulingCommand(ScheduleCommand.Images.rescheduleAfter(block))
+        val job = orchestrator.execute(ScheduleCommand.Images.rescheduleAfter(block))
 
         verify { workManager.cancelUniqueWork(FILE_UP_SYNC_WORK_NAME) }
 

--- a/infra/sync/src/test/java/com/simprints/infra/sync/config/usecase/LogoutUseCaseTest.kt
+++ b/infra/sync/src/test/java/com/simprints/infra/sync/config/usecase/LogoutUseCaseTest.kt
@@ -25,7 +25,7 @@ class LogoutUseCaseTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-        every { syncOrchestrator.executeSchedulingCommand(any()) } returns Job().apply { complete() }
+        every { syncOrchestrator.execute(any<ScheduleCommand>()) } returns Job().apply { complete() }
 
         useCase = LogoutUseCase(
             syncOrchestrator = syncOrchestrator,
@@ -37,7 +37,7 @@ class LogoutUseCaseTest {
     fun `Fully logs out when called`() = runTest {
         useCase.invoke()
 
-        verify { syncOrchestrator.executeSchedulingCommand(ScheduleCommand.Everything.unschedule()) }
+        verify { syncOrchestrator.execute(ScheduleCommand.Everything.unschedule()) }
         coVerify {
             syncOrchestrator.deleteEventSyncInfo()
             authManager.signOut()

--- a/infra/sync/src/test/java/com/simprints/infra/sync/config/usecase/RescheduleWorkersIfConfigChangedUseCaseTest.kt
+++ b/infra/sync/src/test/java/com/simprints/infra/sync/config/usecase/RescheduleWorkersIfConfigChangedUseCaseTest.kt
@@ -28,7 +28,7 @@ class RescheduleWorkersIfConfigChangedUseCaseTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-        every { syncOrchestrator.executeSchedulingCommand(any()) } returns Job().apply { complete() }
+        every { syncOrchestrator.execute(any<ScheduleCommand>()) } returns Job().apply { complete() }
 
         useCase = RescheduleWorkersIfConfigChangedUseCase(syncOrchestrator)
     }
@@ -56,13 +56,13 @@ class RescheduleWorkersIfConfigChangedUseCaseTest {
             ),
         )
 
-        verify(exactly = 0) { syncOrchestrator.executeSchedulingCommand(any()) }
+        verify(exactly = 0) { syncOrchestrator.execute(any<ScheduleCommand>()) }
     }
 
     @Test
     fun `should reschedule image upload when unmetered connection flag changes`() = runTest {
         val syncCommandJob = Job()
-        every { syncOrchestrator.executeSchedulingCommand(any()) } returns syncCommandJob
+        every { syncOrchestrator.execute(any<ScheduleCommand>()) } returns syncCommandJob
 
         val useCaseJob = async {
             useCase(
@@ -94,7 +94,7 @@ class RescheduleWorkersIfConfigChangedUseCaseTest {
         runCurrent()
         useCaseJob.await()
 
-        verify { syncOrchestrator.executeSchedulingCommand(ScheduleCommand.Images.reschedule()) }
+        verify { syncOrchestrator.execute(ScheduleCommand.Images.reschedule()) }
         assertThat(useCaseJob.isCompleted).isTrue()
     }
 }

--- a/infra/sync/src/test/java/com/simprints/infra/sync/config/usecase/ResetLocalRecordsIfConfigChangedUseCaseTest.kt
+++ b/infra/sync/src/test/java/com/simprints/infra/sync/config/usecase/ResetLocalRecordsIfConfigChangedUseCaseTest.kt
@@ -36,7 +36,7 @@ class ResetLocalRecordsIfConfigChangedUseCaseTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-        every { syncOrchestrator.executeSchedulingCommand(capture(scheduleCommandSlot)) } returns noopJob()
+        every { syncOrchestrator.execute(capture(scheduleCommandSlot)) } returns noopJob()
 
         useCase = ResetLocalRecordsIfConfigChangedUseCase(
             eventSyncManager = eventSyncManager,
@@ -68,7 +68,7 @@ class ResetLocalRecordsIfConfigChangedUseCaseTest {
             ),
         )
 
-        verify(exactly = 0) { syncOrchestrator.executeSchedulingCommand(any()) }
+        verify(exactly = 0) { syncOrchestrator.execute(any<ScheduleCommand>()) }
         coVerify(exactly = 0) {
             eventSyncManager.resetDownSyncInfo()
             enrolmentRecordRepository.deleteAll()
@@ -98,7 +98,7 @@ class ResetLocalRecordsIfConfigChangedUseCaseTest {
             ),
         )
 
-        verify { syncOrchestrator.executeSchedulingCommand(any()) }
+        verify { syncOrchestrator.execute(any<ScheduleCommand>()) }
         val command = scheduleCommandSlot.captured as ScheduleCommand.EventsCommand
         assertThat(command.action).isEqualTo(ScheduleCommand.Action.RESCHEDULE)
         assertThat(command.withDelay).isFalse()
@@ -135,7 +135,7 @@ class ResetLocalRecordsIfConfigChangedUseCaseTest {
             ),
         )
 
-        verify { syncOrchestrator.executeSchedulingCommand(any()) }
+        verify { syncOrchestrator.execute(any<ScheduleCommand>()) }
         val command = scheduleCommandSlot.captured as ScheduleCommand.EventsCommand
         assertThat(command.action).isEqualTo(ScheduleCommand.Action.RESCHEDULE)
         assertThat(command.blockWhileUnscheduled).isNotNull()
@@ -171,7 +171,7 @@ class ResetLocalRecordsIfConfigChangedUseCaseTest {
             ),
         )
 
-        verify { syncOrchestrator.executeSchedulingCommand(any()) }
+        verify { syncOrchestrator.execute(any<ScheduleCommand>()) }
         val command = scheduleCommandSlot.captured as ScheduleCommand.EventsCommand
         assertThat(command.action).isEqualTo(ScheduleCommand.Action.RESCHEDULE)
         assertThat(command.blockWhileUnscheduled).isNotNull()
@@ -207,7 +207,7 @@ class ResetLocalRecordsIfConfigChangedUseCaseTest {
             ),
         )
 
-        verify { syncOrchestrator.executeSchedulingCommand(any()) }
+        verify { syncOrchestrator.execute(any<ScheduleCommand>()) }
         val command = scheduleCommandSlot.captured as ScheduleCommand.EventsCommand
         assertThat(command.action).isEqualTo(ScheduleCommand.Action.RESCHEDULE)
         assertThat(command.blockWhileUnscheduled).isNotNull()
@@ -243,7 +243,7 @@ class ResetLocalRecordsIfConfigChangedUseCaseTest {
             ),
         )
 
-        verify(exactly = 0) { syncOrchestrator.executeSchedulingCommand(any()) }
+        verify(exactly = 0) { syncOrchestrator.execute(any<ScheduleCommand>()) }
         coVerify(exactly = 0) {
             eventSyncManager.resetDownSyncInfo()
             enrolmentRecordRepository.deleteAll()
@@ -273,7 +273,7 @@ class ResetLocalRecordsIfConfigChangedUseCaseTest {
             ),
         )
 
-        verify(exactly = 0) { syncOrchestrator.executeSchedulingCommand(any()) }
+        verify(exactly = 0) { syncOrchestrator.execute(any<ScheduleCommand>()) }
         coVerify(exactly = 0) {
             eventSyncManager.resetDownSyncInfo()
             enrolmentRecordRepository.deleteAll()
@@ -303,7 +303,7 @@ class ResetLocalRecordsIfConfigChangedUseCaseTest {
             ),
         )
 
-        verify(exactly = 0) { syncOrchestrator.executeSchedulingCommand(any()) }
+        verify(exactly = 0) { syncOrchestrator.execute(any<ScheduleCommand>()) }
         coVerify(exactly = 0) {
             eventSyncManager.resetDownSyncInfo()
             enrolmentRecordRepository.deleteAll()
@@ -333,7 +333,7 @@ class ResetLocalRecordsIfConfigChangedUseCaseTest {
             ),
         )
 
-        verify(exactly = 0) { syncOrchestrator.executeSchedulingCommand(any()) }
+        verify(exactly = 0) { syncOrchestrator.execute(any<ScheduleCommand>()) }
         coVerify(exactly = 0) {
             eventSyncManager.resetDownSyncInfo()
             enrolmentRecordRepository.deleteAll()


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1300)
Will be released in: **2026.2.0**

**Boundaries for the changes** - what's intentionally out of scope:
* `WorkManager` and workers. This is already the optimal foundation for sync - both foreground and background.
* `SyncInfoViewModel`. Already observes sync state.
* UI/UX. Nothing visually new.

### Notable changes

- [x] (Phase 1) (Done) `SyncOrchestrator.observeSyncState` implementation.
- [x] (Phase 2) (Done) `SyncOrchestrator.execute` implementation.
- [ ] (Phase 3) **(This)** `SyncOrchestrator.execute` cleanup - a lot of call sites involved, making it a small yet separate phase to keep changes focused.
- [ ] (Phase 4) (Next) Extracting usecases from `SyncOrchestrator` & `EventSyncManager`.

### Testing guidance

_Note: Infra Unit Tests 1 may be failing due to an unrelated [issue](https://simprints.atlassian.net/browse/MS-1316) unless `main` with a fix is merged into the current branch._

* Sync counters and buttons on dashboard, sync info and logout screens should work correctly.
* Some `SyncOrchestrator.execute` calls were changed in other places - full regression testing recommended when the work is completed.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
