### PR TITLE
[MS-1376] Add a guard against a race condition in MatcherFragment

### DIFF
--- a/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchFragment.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchFragment.kt
@@ -121,7 +121,11 @@ internal class MatchFragment : Fragment(R.layout.fragment_matcher) {
         viewModel.matchResponse.observe(
             viewLifecycleOwner,
             LiveDataEventWithContentObserver {
-                findNavController().finishWithResult(this, it)
+                // Guard against delivering the match result after the fragment has already
+                // been popped (e.g. exit form submitted after match finished in the background).
+                if (findNavController().currentDestination?.id == R.id.matcherFragment) {
+                    findNavController().finishWithResult(this, it)
+                }
             },
         )
         viewModel.matchState.observe(viewLifecycleOwner) { matchState ->


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1376)
Will be released in: **2026.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **a very old one!?**

* If matcher finishes while user has navigated to exit screen, exit result is delivered first and then the matcher result gets forwarded to the Orchestrator which expects AppResult and crashes

### Notable changes

* Adds a guard to the matchResponse observer - if current destination is not MatcherFragment anymore - drop the result as the user has already navigated away

### Testing guidance

* Trigger and identification (preferably with a large pool and/or just-in-time CoSync so you have time to react)
* Proceed through the steps
* When you reach the matching step press back to go to the exit screen
* Wait some time to give the matcher time to finish (monitor logcat if device is connected)
* Select an exit reason and submit
* App should return a refusal without *KABOOM*

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
