### PR TITLE
[MS-1377] Remove graph init state persistence that was never called

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorActivity.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorActivity.kt
@@ -2,7 +2,6 @@ package com.simprints.feature.orchestrator
 
 import android.content.Intent
 import android.os.Bundle
-import android.os.PersistableBundle
 import androidx.core.os.bundleOf
 import androidx.navigation.findNavController
 import com.simprints.core.tools.activity.BaseActivity
@@ -29,7 +28,7 @@ internal class OrchestratorActivity : BaseActivity() {
 
     /**
      * Flag for the navigation graph initialization state. The graph should only be initialized once
-     * during the existence of this activity, and the flag tracks graph's state.
+     * while the activity is in memory. Recreation of the activity should result in graph re-init
      */
     private var isGraphInitialized = false
 
@@ -37,7 +36,6 @@ internal class OrchestratorActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         Simber.d("OrchestratorActivity.onCreate isGraphInitialized=$isGraphInitialized", tag = ORCHESTRATION)
 
-        isGraphInitialized = savedInstanceState?.getBoolean(KEY_IS_GRAPH_INITIALIZED) ?: false
         lifecycle.addObserver(activityTracker)
 
         setContentView(binding.root)
@@ -79,17 +77,5 @@ internal class OrchestratorActivity : BaseActivity() {
             Simber.i("Orchestrator already executing, finishing with RESULT_CANCELED", tag = ORCHESTRATION)
             finish()
         }
-    }
-
-    override fun onSaveInstanceState(
-        outState: Bundle,
-        outPersistentState: PersistableBundle,
-    ) {
-        outState.putBoolean(KEY_IS_GRAPH_INITIALIZED, isGraphInitialized)
-        super.onSaveInstanceState(outState, outPersistentState)
-    }
-
-    companion object {
-        private const val KEY_IS_GRAPH_INITIALIZED = "KEY_IS_GRAPH_INITIALIZED"
     }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1377)
Will be released in: **2026.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **an old one**

### Notable changes

* Activity used the two parameter `onSaveInstanceState()` which is only called when `persistableMode="persistAcrossReboots"` flag is set
* It is not set for this activity and as a result this method was not never called
* This resulted in the `isGraphInitialized` flag not persisting between activity recreations
* In a surprising plot twist it turned out that this is actually the desired behaviour which explains why rotation was working as expected and it broke once I switched from the two parameter to the single parameter `onSaveInstanceState()` :D
* To avoid confusion and someone re-finding this issue and "fixing it", I'm deleting the dead code and changing the comment to state desired behaviour
* @alexandr-simprints since you wrote this initially, I'll wait for your review specifically before merging, in case I missed something

### Testing guidance

* Trigger any workflow
* Rotate the device
* Continue workflow

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
