### PR TITLE
[MS-1379] Don't crash on huge metadata

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorActivity.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorActivity.kt
@@ -2,12 +2,9 @@ package com.simprints.feature.orchestrator
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.core.os.bundleOf
 import androidx.navigation.findNavController
 import com.simprints.core.tools.activity.BaseActivity
-import com.simprints.feature.clientapi.models.ClientApiConstants
 import com.simprints.feature.orchestrator.databinding.ActivityOrchestratorBinding
-import com.simprints.infra.config.store.LastCallingPackageStore
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.orchestration.data.results.AppResult
@@ -22,9 +19,6 @@ internal class OrchestratorActivity : BaseActivity() {
 
     @Inject
     lateinit var activityTracker: ExecutionTracker
-
-    @Inject
-    lateinit var lastCallingPackageStore: LastCallingPackageStore
 
     /**
      * Flag for the navigation graph initialization state. The graph should only be initialized once
@@ -57,19 +51,8 @@ internal class OrchestratorActivity : BaseActivity() {
 
         if (activityTracker.isMain(activity = this)) {
             if (!isGraphInitialized) {
-                val action = intent.action.orEmpty()
-                val extras = intent.extras ?: bundleOf()
-                Simber.setUserProperty("Intent_received", action)
-                Simber.setUserProperty("Caller", callingPackage.orEmpty())
-
-                // Some co-sync functionality depends on the exact package name of the caller app,
-                // e.g. to switch content providers of debug and release variants of the caller app
-                extras.putString(ClientApiConstants.CALLER_PACKAGE_NAME, callingPackage)
-                lastCallingPackageStore.lastCallingPackageName = callingPackage
-
                 findNavController(R.id.orchestrationHost).setGraph(
                     R.navigation.graph_orchestration,
-                    OrchestratorFragmentArgs(action, extras).toBundle(),
                 )
                 isGraphInitialized = true
             }

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorFragment.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/OrchestratorFragment.kt
@@ -2,11 +2,11 @@ package com.simprints.feature.orchestrator
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
 import com.simprints.core.domain.response.AppErrorReason
 import com.simprints.core.livedata.LiveDataEventObserver
 import com.simprints.core.livedata.LiveDataEventWithContentObserver
@@ -16,6 +16,7 @@ import com.simprints.feature.alert.AlertResult
 import com.simprints.feature.alert.toArgs
 import com.simprints.feature.clientapi.ClientApiViewModel
 import com.simprints.feature.clientapi.extensions.getResultCodeFromExtras
+import com.simprints.feature.clientapi.models.ClientApiConstants
 import com.simprints.feature.consent.ConsentContract
 import com.simprints.feature.enrollast.EnrolLastBiometricContract
 import com.simprints.feature.exitform.ExitFormContract
@@ -30,6 +31,7 @@ import com.simprints.feature.selectsubject.SelectSubjectContract
 import com.simprints.feature.setup.SetupContract
 import com.simprints.feature.validatepool.ValidateSubjectPoolContract
 import com.simprints.fingerprint.capture.FingerprintCaptureContract
+import com.simprints.infra.config.store.LastCallingPackageStore
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.orchestration.data.responses.AppConfirmationResponse
@@ -72,7 +74,10 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
     @Inject
     lateinit var orchestratorCache: OrchestratorCache
 
-    private val args by navArgs<OrchestratorFragmentArgs>()
+    @Inject
+    lateinit var lastCallingPackageStore: LastCallingPackageStore
+
+    private val intentAction get() = requireActivity().intent.action.orEmpty()
 
     private val loginCheckVm by viewModels<LoginCheckViewModel>()
     private val clientApiVm by viewModels<ClientApiViewModel>()
@@ -231,7 +236,7 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
 
                 if (response.request == null) {
                     clientApiVm.handleErrorResponse(
-                        args.requestAction,
+                        intentAction,
                         AppErrorResponse(AppErrorReason.UNEXPECTED_ERROR),
                     )
                 } else {
@@ -257,7 +262,7 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
                         }
 
                         is AppErrorResponse -> {
-                            clientApiVm.handleErrorResponse(args.requestAction, response.response)
+                            clientApiVm.handleErrorResponse(intentAction, response.response)
                         }
                     }
                 }
@@ -282,8 +287,18 @@ internal class OrchestratorFragment : Fragment(R.layout.fragment_orchestrator) {
             Simber.i("Start processing action request", tag = ORCHESTRATION)
             if (loginCheckVm.isDeviceSafe()) {
                 lifecycleScope.launch {
-                    val actionRequest =
-                        clientApiVm.handleIntent(args.requestAction, args.requestParams)
+                    val extras = requireActivity().intent.extras ?: bundleOf()
+                    val callingPackage = requireActivity().callingPackage
+
+                    Simber.setUserProperty("Intent_received", intentAction)
+                    Simber.setUserProperty("Caller", callingPackage.orEmpty())
+
+                    // Some co-sync functionality depends on the exact package name of the caller app,
+                    // e.g. to switch content providers of debug and release variants of the caller app
+                    lastCallingPackageStore.lastCallingPackageName = callingPackage
+                    extras.putString(ClientApiConstants.CALLER_PACKAGE_NAME, callingPackage)
+
+                    val actionRequest = clientApiVm.handleIntent(intentAction, extras)
                     if (actionRequest != null) {
                         Simber.i("Action request parsed successfully", tag = ORCHESTRATION)
                         loginCheckVm.validateSignInAndProceed(actionRequest)

--- a/feature/orchestrator/src/main/res/navigation/graph_orchestration.xml
+++ b/feature/orchestrator/src/main/res/navigation/graph_orchestration.xml
@@ -10,13 +10,6 @@
         android:name="com.simprints.feature.orchestrator.OrchestratorFragment"
         android:label="ClientApiFragment"
         tools:layout="@layout/fragment_orchestrator">
-
-        <argument
-            android:name="requestAction"
-            app:argType="string" />
-        <argument
-            android:name="requestParams"
-            app:argType="android.os.Bundle" />
     </fragment>
 
     <include app:graph="@navigation/graph_alert" />


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1379)
Will be released in: **2026.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **at least since the last navigation refactoring**

* Calling app can send in the metadata whatever extra info they want
* When this data is ~ 200K (!) we accept and pass it to OrchestratorFragment as argument
* OrchestratorFragment has 3 lazily initialized VM (loginCheck, clientApi, orchestrator)
* When app is minimized, each VM saves the fragment args in addition to a few more copies from the fragment and Nav controller
* This leads to the saved state Bundle exceeding the max size of 1MB
* *KABOOM*

### Notable changes

* Instead of doing risky changes and jumping through hoops, we simply don't pass intent data as fragment args but read it directly through the activity
* This avoids all the data copies on saving state while having no down sides

### Testing guidance

* Send an Intent with at least 200K metadata (I've made a modification in Intent Launcher that does this as otherwise copy-paste buffer cannot handle so much data)
* Wait for SID to open and process the request (e.g. reach the Consent screen)
* Minimize it
* Bring it back - should still be on the same screen which means it didn't crash

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
