### PR TITLE
[MS-1068] Navigation crash upon state restoration

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/controller/FaceCaptureControllerFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/controller/FaceCaptureControllerFragment.kt
@@ -48,6 +48,19 @@ internal class FaceCaptureControllerFragment : Fragment(R.layout.fragment_face_c
         super.onViewCreated(view, savedInstanceState)
         Simber.i("FaceCaptureControllerFragment started", tag = ORCHESTRATION)
 
+        internalNavController
+            ?.navInflater
+            ?.inflate(R.navigation.graph_face_capture_internal)
+            ?.also {
+                it.setStartDestination(
+                    if (viewModel.shouldShowInstructionsScreen()) {
+                        R.id.facePreparationFragment
+                    } else {
+                        R.id.faceLiveFeedbackFragment
+                    },
+                )
+            }?.let { internalNavController?.setGraph(it, null) }
+
         findNavController().handleResult<ExitFormResult>(
             this,
             R.id.faceCaptureControllerFragment,
@@ -117,19 +130,6 @@ internal class FaceCaptureControllerFragment : Fragment(R.layout.fragment_face_c
                 else -> findNavController().popBackStack()
             }
         }
-
-        internalNavController
-            ?.navInflater
-            ?.inflate(R.navigation.graph_face_capture_internal)
-            ?.also {
-                it.setStartDestination(
-                    if (viewModel.shouldShowInstructionsScreen()) {
-                        R.id.facePreparationFragment
-                    } else {
-                        R.id.faceLiveFeedbackFragment
-                    },
-                )
-            }?.let { internalNavController?.setGraph(it, null) }
     }
 
     private fun initFaceBioSdk() {

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/controller/ExternalCredentialControllerFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/controller/ExternalCredentialControllerFragment.kt
@@ -42,6 +42,8 @@ internal class ExternalCredentialControllerFragment : Fragment(R.layout.fragment
 
         viewModel.init(params)
 
+        internalNavController?.setGraph(R.navigation.graph_external_credential_internal)
+
         findNavController().handleResult<ExitFormResult>(
             this,
             R.id.externalCredentialControllerFragment,
@@ -57,7 +59,6 @@ internal class ExternalCredentialControllerFragment : Fragment(R.layout.fragment
                 )
             }
         }
-        internalNavController?.setGraph(R.navigation.graph_external_credential_internal)
 
         initObservers()
         initListeners()

--- a/infra/ui-base/src/main/java/com/simprints/infra/uibase/navigation/NavigationResultExt.kt
+++ b/infra/ui-base/src/main/java/com/simprints/infra/uibase/navigation/NavigationResultExt.kt
@@ -185,14 +185,15 @@ private fun NavController.navigateIfPossible(
  *  @param currentFragment - currently displayed fragment in the [NavController]
  *  @return true if [NavController.currentDestination] is set and its class name matches
  *  [currentFragment], or if [NavController.currentDestination] is not a [FragmentNavigator.Destination].
- *  false if [currentFragment] is null or [NavController.currentDestination] is null.
+ *  false if [currentFragment] is null, [NavController.currentDestination] is null, or the
+ *  destination class name does not match [currentFragment] (indicating a navigation already occurred).
  */
 @ExcludedFromGeneratedTestCoverageReports("There is no reasonable way to test this")
 private fun NavController.canNavigate(currentFragment: Fragment?): Boolean {
+    currentFragment ?: return false
     val currentDest = currentDestination ?: return false
-    val fragmentName = currentFragment?.let { it::class.java.name }
     val targetClassName = (currentDest as? FragmentNavigator.Destination)?.className
-    return currentFragment != null && (targetClassName == null || targetClassName == fragmentName)
+    return targetClassName == null || targetClassName == currentFragment::class.java.name
 }
 
 /**

--- a/infra/ui-base/src/main/java/com/simprints/infra/uibase/navigation/NavigationResultExt.kt
+++ b/infra/ui-base/src/main/java/com/simprints/infra/uibase/navigation/NavigationResultExt.kt
@@ -173,31 +173,25 @@ private fun NavController.navigateIfPossible(
 }
 
 /**
- * Only one navigation request needs to be processed from the fragment. This method checks if the
- * no other navigation is scheduled in the [NavController]. It does so by checking whether the
- * class name in the [NavController.currentDestination] is null or equals to the current fragment
- * name.
+ * Checks whether the [NavController] is in a state that allows navigation from [currentFragment].
+ * This prevents duplicate navigation requests when a fragment triggers navigation more than once.
  *
- *  - On the app startup, the [NavController.currentDestination] is null, since there were no
- *  navigation requests.
- *  - When the first navigation request to the target 'A' happens, then the field 'className' in the
- *  [NavController.currentDestination] becomes 'A'.
- *  - When the [currentFragment] 'A' wants to navigate to the destination 'B', this method checks if
- *  the current value of the [NavController.currentDestination] is still 'A' (it was set to 'A'
- *  during the previous navigation request).
- *  - If the name of the [currentFragment] is different to the 'className' in the
- *  [NavController.currentDestination], it means that the the current fragment has a navigation
- *  request scheduled already, and the navigation cannot be executed.
+ *  - If [NavController.currentDestination] is null (no graph set), navigation is not possible.
+ *  - When the [currentFragment] 'A' wants to navigate to destination 'B', this method checks if
+ *  the 'className' in [NavController.currentDestination] still matches 'A'.
+ *  - If it doesn't match, another navigation request has already been processed and navigation
+ *  is rejected to prevent double-navigation.
  *
  *  @param currentFragment - currently displayed fragment in the [NavController]
- *  @return true if the class name of the [currentFragment] is equal to the 'className' field in the
- *  [NavController.currentDestination], or if the [NavController.currentDestination] is null. false
- *  otherwise.
+ *  @return true if [NavController.currentDestination] is set and its class name matches
+ *  [currentFragment], or if [NavController.currentDestination] is not a [FragmentNavigator.Destination].
+ *  false if [currentFragment] is null or [NavController.currentDestination] is null.
  */
 @ExcludedFromGeneratedTestCoverageReports("There is no reasonable way to test this")
 private fun NavController.canNavigate(currentFragment: Fragment?): Boolean {
+    val currentDest = currentDestination ?: return false
     val fragmentName = currentFragment?.let { it::class.java.name }
-    val targetClassName = (currentDestination as? FragmentNavigator.Destination)?.className
+    val targetClassName = (currentDest as? FragmentNavigator.Destination)?.className
     return currentFragment != null && (targetClassName == null || targetClassName == fragmentName)
 }
 


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1068)
Will be released in: **2026.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **since last major refactor**

* In `FaceCaptureControllerFragment` nav graph is set after result handlers
* canNavigate() does not protect against graph not set (null currentDestination)
* As a result the following situation leads to a crash:

1. A workflow is initiated and face capture step is reached
2. User navigates to the exit screen
3. App is minimized and then gets killed by the OS (can be simulated with "Don't keep activities")
4. App is brought to the foreground
5. User presses the "Capture biometrics" button on the exit screen
6. In `FaceCaptureControllerFragment` exit screen handler tries to navigate but graph is not yet set
7. *KABOOM*

### Notable changes

* Moves `setGraph()` before result handlers so it's set before any result handler can fire
* `ExternalCredentialControllerFragment` was also vulnerable to this so the same change was applied there
* In addition, `canNavigate()` was updated to return false if `currentDestination` is null. This would prevent crashing if similar situation arises elsewhere (although user might get stuck).

### Testing guidance

* Go through the reproduction steps - #7 should not happen :D 

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
