### PR TITLE
[MS-1380] Launch camera setup in viewLifecycleOwner.lifecycleScope

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -141,7 +141,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
     }
 
     /** Initialize CameraX, and prepare to bind the camera use cases  */
-    private fun setUpCamera() = lifecycleScope.launch {
+    private fun setUpCamera() = viewLifecycleOwner.lifecycleScope.launch {
         if (::cameraExecutor.isInitialized && !cameraExecutor.isShutdown) {
             return@launch
         }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1380)
Will be released in: **2026.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **since face capture exists!?**

* There's a suspension point in `setUpCamera()` after which the binding is accessed
* If user navigates to the exit screen while camera is setting up, view will be destroyed (and hence null) when suspension resumes

### Notable changes

* Use `viewLifecycleOwner` for the whole camera setup coroutine so it's lifecycle safe

### Testing guidance

* Navigate to face capture and immediately press back button (multiple times)

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
