### PR TITLE
MS-1232 Separate session closing from orchestrator cache reset

### DIFF
--- a/feature/orchestrator/src/main/AndroidManifest.xml
+++ b/feature/orchestrator/src/main/AndroidManifest.xml
@@ -85,7 +85,7 @@
             android:name=".receivers.CacheResetReceiver"
             android:exported="false">
             <intent-filter>
-                <action android:name="android.intent.action.ACTION_MY_PACKAGE_REPLACED" />
+                <action android:name="com.simprints.id.broadcasts.SESSION_CLOSED_ACTION" />
             </intent-filter>
         </receiver>
 

--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/receivers/CacheResetReceiver.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/receivers/CacheResetReceiver.kt
@@ -4,28 +4,17 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
-import com.simprints.core.SessionCoroutineScope
+import com.simprints.core.broadcasts.InternalBroadcaster
 import com.simprints.feature.orchestrator.cache.OrchestratorCache
-import com.simprints.infra.events.session.SessionEventRepository
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
- * Cached step structure might change between SID versions therefore caches should be cleared to avoid unmarshalling exceptions.
- * Since we do not support cross-version sessions, any ongoing scopes should be closed as well.
+ * Step cache should be cleared when session is closed to avoid mixing data between sessions.
  */
 @ExcludedFromGeneratedTestCoverageReports("Platform glue code")
 @AndroidEntryPoint
 internal class CacheResetReceiver : BroadcastReceiver() {
-    @Inject
-    @SessionCoroutineScope
-    lateinit var externalScope: CoroutineScope
-
-    @Inject
-    lateinit var sessionEventRepository: SessionEventRepository
-
     @Inject
     lateinit var orchestratorCache: OrchestratorCache
 
@@ -33,9 +22,8 @@ internal class CacheResetReceiver : BroadcastReceiver() {
         context: Context,
         intent: Intent,
     ) {
-        if (Intent.ACTION_MY_PACKAGE_REPLACED == intent.action) {
+        if (InternalBroadcaster.SESSION_CLOSED_ACTION == intent.action) {
             orchestratorCache.clearCache()
-            externalScope.launch { sessionEventRepository.closeCurrentSession() }
         }
     }
 }

--- a/infra/core/src/main/java/com/simprints/core/broadcasts/InternalBroadcaster.kt
+++ b/infra/core/src/main/java/com/simprints/core/broadcasts/InternalBroadcaster.kt
@@ -1,0 +1,20 @@
+package com.simprints.core.broadcasts
+
+import android.content.Context
+import android.content.Intent
+import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+@ExcludedFromGeneratedTestCoverageReports("Wrapper for intent broadcast sending")
+class InternalBroadcaster @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) {
+    fun sessionClosed() {
+        context.sendBroadcast(Intent(SESSION_CLOSED_ACTION).setPackage(context.packageName))
+    }
+
+    companion object {
+        const val SESSION_CLOSED_ACTION = "com.simprints.id.broadcasts.SESSION_CLOSED_ACTION"
+    }
+}

--- a/infra/events/src/main/AndroidManifest.xml
+++ b/infra/events/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
 
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
     </application>

--- a/infra/events/src/main/java/com/simprints/infra/events/receivers/SessionTerminationReceiver.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/receivers/SessionTerminationReceiver.kt
@@ -3,6 +3,8 @@ package com.simprints.infra.events.receivers
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.ACTION_BOOT_COMPLETED
+import android.content.Intent.ACTION_MY_PACKAGE_REPLACED
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
 import com.simprints.core.tools.time.TimeHelper
 import dagger.hilt.android.AndroidEntryPoint
@@ -22,7 +24,7 @@ internal class SessionTerminationReceiver : BroadcastReceiver() {
         intent: Intent,
     ) {
         timeHelper.ensureTrustworthiness()
-        if (Intent.ACTION_BOOT_COMPLETED == intent.action) {
+        if (ACTION_BOOT_COMPLETED == intent.action || ACTION_MY_PACKAGE_REPLACED == intent.action) {
             closeSessionUseCase()
         }
     }

--- a/infra/events/src/main/java/com/simprints/infra/events/session/SessionEventRepositoryImpl.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/session/SessionEventRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.simprints.infra.events.session
 
+import com.simprints.core.broadcasts.InternalBroadcaster
 import com.simprints.infra.credential.store.CredentialImageRepository
 import com.simprints.infra.events.EventRepository
 import com.simprints.infra.events.event.domain.models.Event
@@ -17,6 +18,7 @@ internal class SessionEventRepositoryImpl @Inject constructor(
     private val eventRepository: EventRepository,
     private val sessionDataCache: SessionDataCache,
     private val credentialImageRepository: CredentialImageRepository,
+    private val broadcaster: InternalBroadcaster,
 ) : SessionEventRepository {
     private val eventsLock = Mutex()
 
@@ -77,6 +79,7 @@ internal class SessionEventRepositoryImpl @Inject constructor(
         credentialImageRepository.deleteAllCredentialScans()
         sessionDataCache.eventCache.clear()
         sessionDataCache.eventScope = null
+        broadcaster.sessionClosed()
     }
 
     /**

--- a/infra/events/src/test/java/com/simprints/infra/events/session/SessionEventRepositoryImplTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/session/SessionEventRepositoryImplTest.kt
@@ -1,6 +1,7 @@
 package com.simprints.infra.events.session
 
 import com.google.common.truth.Truth.*
+import com.simprints.core.broadcasts.InternalBroadcaster
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.infra.credential.store.CredentialImageRepository
 import com.simprints.infra.events.EventRepository
@@ -24,6 +25,9 @@ internal class SessionEventRepositoryImplTest {
     @MockK
     private lateinit var credentialImageRepository: CredentialImageRepository
 
+    @MockK
+    private lateinit var broadcaster: InternalBroadcaster
+
     private lateinit var sessionEventRepository: SessionEventRepositoryImpl
 
     @Before
@@ -35,6 +39,7 @@ internal class SessionEventRepositoryImplTest {
             eventRepository = eventRepository,
             sessionDataCache = sessionDataCache,
             credentialImageRepository = credentialImageRepository,
+            broadcaster = broadcaster,
         )
     }
 
@@ -227,5 +232,14 @@ internal class SessionEventRepositoryImplTest {
         coVerify { eventRepository.closeEventScope(any<EventScope>(), null) }
         assertThat(sessionDataCache.eventScope).isNull()
         assertThat(sessionDataCache.eventCache).isEmpty()
+    }
+
+    @Test
+    fun `broadcasts session closure internally`() = runTest {
+        coEvery { eventRepository.createEventScope(any()) } returns createSessionScope("mockId")
+
+        sessionEventRepository.closeCurrentSession(null)
+
+        verify { broadcaster.sessionClosed() }
     }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1232)
Will be released in: **2026.2.0**

### Notable changes

* Close session on package upgrade and reboot in a dedicated receiver.
* When session is closed, internal broadcast is sent.
* When local broadcast is received, reset orchestrator cache.

### Testing guidance

* Run an identification intent
* Restart device

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
