### PR TITLE
MS-1074 Use login error block instead of toast message

### DIFF
--- a/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/form/LoginFormFragment.kt
@@ -2,7 +2,6 @@ package com.simprints.feature.login.screens.form
 
 import android.os.Bundle
 import android.view.View
-import android.widget.Toast
 import androidx.activity.addCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
@@ -127,6 +126,7 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
             binding.loginProgress.isVisible = isProcessingSignIn
             binding.loginButtonScanQr.isEnabled = !isProcessingSignIn
             binding.loginButtonSignIn.isEnabled = !isProcessingSignIn
+            binding.loginErrorCard.isVisible = false
         }
         viewModel.signInState.observe(viewLifecycleOwner) { event ->
             event?.getContentIfNotHandled()?.let(::handleSignInResult)
@@ -138,16 +138,16 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
 
         when (result) {
             // Showing toast
-            MissingCredential -> showToast(IDR.string.login_missing_credentials_error)
-            BadCredentials -> showToast(IDR.string.login_invalid_credentials_error)
-            ProjectIdMismatch -> showToast(IDR.string.login_project_id_intent_mismatch_error)
-            Offline -> showToast(IDR.string.login_no_network_error)
-            IntegrityServiceTemporaryDown -> showToast(IDR.string.login_integrity_service_down_error)
-            TechnicalFailure -> showToast(IDR.string.login_server_error)
-            QrCameraUnavailable -> showToast(IDR.string.login_qr_code_scanning_camera_unavailable_error)
-            QrGenericError -> showToast(IDR.string.login_qr_code_scanning_problem_error)
-            QrInvalidCode -> showToast(IDR.string.login_invalid_qr_code_error)
-            QrNoCameraPermission -> showToast(IDR.string.login_qr_code_scanning_camera_permission_error)
+            MissingCredential -> showErrorCard(IDR.string.login_missing_credentials_error)
+            BadCredentials -> showErrorCard(IDR.string.login_invalid_credentials_error)
+            ProjectIdMismatch -> showErrorCard(IDR.string.login_project_id_intent_mismatch_error)
+            Offline -> showErrorCard(IDR.string.login_no_network_error)
+            IntegrityServiceTemporaryDown -> showErrorCard(IDR.string.login_integrity_service_down_error)
+            TechnicalFailure -> showErrorCard(IDR.string.login_server_error)
+            QrCameraUnavailable -> showErrorCard(IDR.string.login_qr_code_scanning_camera_unavailable_error)
+            QrGenericError -> showErrorCard(IDR.string.login_qr_code_scanning_problem_error)
+            QrInvalidCode -> showErrorCard(IDR.string.login_invalid_qr_code_error)
+            QrNoCameraPermission -> showErrorCard(IDR.string.login_qr_code_scanning_camera_permission_error)
 
             is ShowUrlChangeDialog -> createChangeUrlDialog(result).show()
 
@@ -181,10 +181,11 @@ internal class LoginFormFragment : Fragment(R.layout.fragment_login_form) {
         binding.loginErrorCard.isVisible = true
     }
 
-    private fun showToast(
+    private fun showErrorCard(
         @StringRes messageId: Int,
     ) {
-        Toast.makeText(requireContext(), getString(messageId), Toast.LENGTH_LONG).show()
+        binding.loginErrorText.setText(messageId)
+        binding.loginErrorCard.isVisible = true
     }
 
     private fun createChangeUrlDialog(result: ShowUrlChangeDialog): AlertDialog {

--- a/feature/login/src/main/res/layout/fragment_login_form.xml
+++ b/feature/login/src/main/res/layout/fragment_login_form.xml
@@ -84,39 +84,38 @@
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 android:layout_marginTop="16dp"
-                app:icon="@drawable/scan_qr"
-                app:iconGravity="textEnd"
-                app:iconTint="@null"
-                android:textAlignment="center"
+                android:layout_marginBottom="12dp"
                 android:includeFontPadding="false"
                 android:padding="8dp"
-                android:text="@string/login_scan_qr_button" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/loginButtonSignIn"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="@string/login_log_in_button" />
+                android:text="@string/login_scan_qr_button"
+                android:textAlignment="center"
+                app:icon="@drawable/scan_qr"
+                app:iconGravity="textEnd"
+                app:iconTint="@null" />
 
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/loginErrorCard"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                android:background="@color/simprints_white"
                 android:visibility="gone"
+                app:cardBackgroundColor="@color/simprints_red_dark"
                 tools:visibility="visible">
 
                 <TextView
                     android:id="@+id/loginErrorText"
-                    android:layout_gravity="center"
-                    style="@style/Text.Body1.Secondary"
+                    style="@style/Text.Body1.White"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_gravity="center"
                     android:padding="12dp"
-                    tools:text="Some text goes heretext goes here" />
+                    tools:text="Some text goes here text goes here Some text goes here text goes hereSome text goes here text goes here " />
             </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/loginButtonSignIn"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/login_log_in_button" />
         </LinearLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -160,9 +159,9 @@
             android:alpha="0.5"
             android:text="@string/login_change_url"
             android:textAllCaps="false"
-            app:layout_constraintTop_toBottomOf="@+id/form_container"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/form_container" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1074)
Will be released in: **2026.2.0**

### Notable changes

* Use already existing login error block for login errors instead of toast message to ensure consistent look on all Android version:

<img width="240" src="https://github.com/user-attachments/assets/984dd67b-94a4-4b0a-aa63-faf5e33d12db" />


### Testing guidance

* Set project to PAUSED state
* Try to log into the project

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
