### PR TITLE
[MS-1409] Fixing issue where the image preprocessing job is never started when fragment is opened

### DIFF
--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrFragment.kt
@@ -328,8 +328,8 @@ internal class ExternalCredentialScanOcrFragment : Fragment(R.layout.fragment_ex
         imagePreProcessingJob?.cancel()
         imagePreProcessingJob = lifecycleScope.launch(bgDispatcher) {
             try {
-                val (bitmap, imageInfo) = imageProxy.toBitmap() to imageProxy.imageInfo
                 if (isActive) {
+                    val (bitmap, imageInfo) = imageProxy.toBitmap() to imageProxy.imageInfo
                     val cropConfig: OcrCropConfig = buildOcrCropConfigUseCase(
                         rotationDegrees = imageInfo.rotationDegrees,
                         cameraPreview = binding.preview,

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrFragment.kt
@@ -47,6 +47,7 @@ import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -328,7 +329,7 @@ internal class ExternalCredentialScanOcrFragment : Fragment(R.layout.fragment_ex
         imagePreProcessingJob = lifecycleScope.launch(bgDispatcher) {
             try {
                 val (bitmap, imageInfo) = imageProxy.toBitmap() to imageProxy.imageInfo
-                if (imagePreProcessingJob?.isActive == true) {
+                if (isActive) {
                     val cropConfig: OcrCropConfig = buildOcrCropConfigUseCase(
                         rotationDegrees = imageInfo.rotationDegrees,
                         cameraPreview = binding.preview,


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1409)
Will be released in: **2026.2.1**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.4.0**

In rare cases, when the user comes back to the OCR screen, the OCR pre-processing job cannot be started because of the incorrect coroutine reference check:
```
if (imagePreProcessingJob?.isActive == true) { 
    // start OCR pre-process 
} else {
   // Log message, do nothing     <--- the app goes here during the fragment start
}
```

This is because the `imagePreProcessingJob` reference might be cancelled by the time this check happens.

### Notable changes

The coroutine checks its own status instead of the reference: `if (imagePreProcessingJob.isActive)` refactored into `if (isActive) { ... }`


* [x] Effect on other features and security has been considered
