### PR TITLE
MS-1411 Session location collection improvements

### DIFF
--- a/feature/setup/src/main/java/com/simprints/feature/setup/location/LocationManager.kt
+++ b/feature/setup/src/main/java/com/simprints/feature/setup/location/LocationManager.kt
@@ -2,16 +2,17 @@ package com.simprints.feature.setup.location
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.location.Location
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.tasks.CancellationTokenSource
 import com.google.android.gms.tasks.Task
+import com.simprints.infra.events.event.domain.models.scope.Location
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import javax.inject.Inject
+import android.location.Location as SystemLocation
 
 internal class LocationManager @Inject constructor(
     @param:ApplicationContext val ctx: Context,
@@ -21,10 +22,10 @@ internal class LocationManager @Inject constructor(
     @SuppressLint("MissingPermission")
     fun requestLocation(request: LocationRequest): Flow<Location?> = channelFlow {
         val cancellationTokenSource = CancellationTokenSource()
-        val currentLocationTask: Task<Location> = locationClient.getCurrentLocation(request.priority, cancellationTokenSource.token)
+        val currentLocationTask: Task<SystemLocation> = locationClient.getCurrentLocation(request.priority, cancellationTokenSource.token)
 
         currentLocationTask.addOnCompleteListener { task ->
-            trySend(task.takeIf { it.isSuccessful }?.result)
+            trySend(task.takeIf { it.isSuccessful }?.result?.let { Location(it.latitude, it.longitude) })
         }
 
         awaitClose {

--- a/feature/setup/src/main/java/com/simprints/feature/setup/location/LocationManager.kt
+++ b/feature/setup/src/main/java/com/simprints/feature/setup/location/LocationManager.kt
@@ -2,33 +2,57 @@ package com.simprints.feature.setup.location
 
 import android.annotation.SuppressLint
 import android.content.Context
-import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.CancellationTokenSource
-import com.google.android.gms.tasks.Task
 import com.simprints.infra.events.event.domain.models.scope.Location
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag
+import com.simprints.infra.logging.Simber
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
-import android.location.Location as SystemLocation
 
 internal class LocationManager @Inject constructor(
     @param:ApplicationContext val ctx: Context,
 ) {
     private val locationClient = LocationServices.getFusedLocationProviderClient(ctx)
 
+    /**
+     * Returns up to 2 results in order - lastLocation and getCurrentLocation.
+     * Current location is more accurate, but takes longer to return.
+     */
     @SuppressLint("MissingPermission")
-    fun requestLocation(request: LocationRequest): Flow<Location?> = channelFlow {
+    fun requestLocation(): Flow<Location?> = flow {
         val cancellationTokenSource = CancellationTokenSource()
-        val currentLocationTask: Task<SystemLocation> = locationClient.getCurrentLocation(request.priority, cancellationTokenSource.token)
 
-        currentLocationTask.addOnCompleteListener { task ->
-            trySend(task.takeIf { it.isSuccessful }?.result?.let { Location(it.latitude, it.longitude) })
-        }
+        try {
+            val lastLocation = locationClient.lastLocation.await()
+            if (lastLocation != null) {
+                Simber.i("Returning last known location", tag = CrashReportTag.SESSION)
+                emit(
+                    Location(
+                        latitude = lastLocation.latitude,
+                        longitude = lastLocation.longitude,
+                        lastLocationTime = lastLocation.time,
+                    ),
+                )
+            }
 
-        awaitClose {
+            val currentLocation = locationClient
+                .getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, cancellationTokenSource.token)
+                .await()
+            if (currentLocation != null) {
+                Simber.i("Returning current location", tag = CrashReportTag.SESSION)
+                emit(
+                    Location(
+                        latitude = currentLocation.latitude,
+                        longitude = currentLocation.longitude,
+                    ),
+                )
+            }
+        } finally {
             cancellationTokenSource.cancel()
         }
     }

--- a/feature/setup/src/main/java/com/simprints/feature/setup/location/LocationManager.kt
+++ b/feature/setup/src/main/java/com/simprints/feature/setup/location/LocationManager.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.CancellationTokenSource
+import com.simprints.infra.config.store.ConfigRepository
+import com.simprints.infra.config.store.models.experimental
 import com.simprints.infra.events.event.domain.models.scope.Location
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag
 import com.simprints.infra.logging.Simber
@@ -16,6 +18,7 @@ import javax.inject.Inject
 
 internal class LocationManager @Inject constructor(
     @param:ApplicationContext val ctx: Context,
+    private val configRepository: ConfigRepository,
 ) {
     private val locationClient = LocationServices.getFusedLocationProviderClient(ctx)
 
@@ -26,6 +29,12 @@ internal class LocationManager @Inject constructor(
     @SuppressLint("MissingPermission")
     fun requestLocation(): Flow<Location?> = flow {
         val cancellationTokenSource = CancellationTokenSource()
+
+        val priority = if (configRepository.getProjectConfiguration().experimental().useBalancedLocationAccuracy) {
+            Priority.PRIORITY_BALANCED_POWER_ACCURACY
+        } else {
+            Priority.PRIORITY_HIGH_ACCURACY
+        }
 
         try {
             val lastLocation = locationClient.lastLocation.await()
@@ -41,7 +50,7 @@ internal class LocationManager @Inject constructor(
             }
 
             val currentLocation = locationClient
-                .getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, cancellationTokenSource.token)
+                .getCurrentLocation(priority, cancellationTokenSource.token)
                 .await()
             if (currentLocation != null) {
                 Simber.i("Returning current location", tag = CrashReportTag.SESSION)

--- a/feature/setup/src/main/java/com/simprints/feature/setup/location/StoreUserLocationIntoCurrentSessionWorker.kt
+++ b/feature/setup/src/main/java/com/simprints/feature/setup/location/StoreUserLocationIntoCurrentSessionWorker.kt
@@ -3,8 +3,6 @@ package com.simprints.feature.setup.location
 import android.content.Context
 import androidx.hilt.work.HiltWorker
 import androidx.work.WorkerParameters
-import com.google.android.gms.location.LocationRequest
-import com.google.android.gms.location.Priority
 import com.simprints.core.DispatcherMain
 import com.simprints.core.workers.SimCoroutineWorker
 import com.simprints.infra.events.event.domain.models.scope.Location
@@ -12,9 +10,7 @@ import com.simprints.infra.logging.Simber
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.withContext
 
 /**
@@ -34,21 +30,14 @@ internal class StoreUserLocationIntoCurrentSessionWorker @AssistedInject constru
         showProgressNotification()
         crashlyticsLog("Started")
         try {
-            createLocationFlow()
+            locationManager
+                .requestLocation()
                 .filterNotNull()
-                .collect { location ->
-                    runCatching { saveUserLocation(location) }
-                }
+                .collect { location -> runCatching { saveUserLocation(location) } }
         } catch (t: Throwable) {
             fail(t)
         }
         success()
-    }
-
-    private fun createLocationFlow(): Flow<Location?> {
-        val locationRequest =
-            LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, DEFAULT_INTERVAL).build()
-        return locationManager.requestLocation(locationRequest).take(1)
     }
 
     private suspend fun saveUserLocation(location: Location) {
@@ -57,10 +46,5 @@ internal class StoreUserLocationIntoCurrentSessionWorker @AssistedInject constru
             updateSessionScopeLocationUseCase(location)
             Simber.d("Saving user's location into the current session", tag = tag)
         }
-    }
-
-    companion object {
-        // Based on the default value of minUpdateIntervalMillis in LocationRequest
-        private const val DEFAULT_INTERVAL = 10 * 60 * 1000L
     }
 }

--- a/feature/setup/src/main/java/com/simprints/feature/setup/location/StoreUserLocationIntoCurrentSessionWorker.kt
+++ b/feature/setup/src/main/java/com/simprints/feature/setup/location/StoreUserLocationIntoCurrentSessionWorker.kt
@@ -8,7 +8,6 @@ import com.google.android.gms.location.Priority
 import com.simprints.core.DispatcherMain
 import com.simprints.core.workers.SimCoroutineWorker
 import com.simprints.infra.events.event.domain.models.scope.Location
-import com.simprints.infra.events.session.SessionEventRepository
 import com.simprints.infra.logging.Simber
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -25,7 +24,7 @@ import kotlinx.coroutines.withContext
 internal class StoreUserLocationIntoCurrentSessionWorker @AssistedInject constructor(
     @Assisted context: Context,
     @Assisted params: WorkerParameters,
-    private val eventRepository: SessionEventRepository,
+    private val updateSessionScopeLocationUseCase: UpdateSessionScopeLocationUseCase,
     private val locationManager: LocationManager,
     @param:DispatcherMain private val dispatcher: CoroutineDispatcher,
 ) : SimCoroutineWorker(context, params) {
@@ -46,22 +45,16 @@ internal class StoreUserLocationIntoCurrentSessionWorker @AssistedInject constru
         success()
     }
 
-    private fun createLocationFlow(): Flow<android.location.Location?> {
+    private fun createLocationFlow(): Flow<Location?> {
         val locationRequest =
             LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, DEFAULT_INTERVAL).build()
         return locationManager.requestLocation(locationRequest).take(1)
     }
 
-    private suspend fun saveUserLocation(lastLocation: android.location.Location) {
+    private suspend fun saveUserLocation(location: Location) {
         if (!isStopped) {
             // Only store location if SID didn't yet sent the response to the calling app
-            val sessionScope = eventRepository.getCurrentSessionScope()
-            val updatesSessionScope = sessionScope.copy(
-                payload = sessionScope.payload.copy(
-                    location = Location(lastLocation.latitude, lastLocation.longitude),
-                ),
-            )
-            eventRepository.saveSessionScope(updatesSessionScope)
+            updateSessionScopeLocationUseCase(location)
             Simber.d("Saving user's location into the current session", tag = tag)
         }
     }

--- a/feature/setup/src/main/java/com/simprints/feature/setup/location/UpdateSessionScopeLocationUseCase.kt
+++ b/feature/setup/src/main/java/com/simprints/feature/setup/location/UpdateSessionScopeLocationUseCase.kt
@@ -1,0 +1,19 @@
+package com.simprints.feature.setup.location
+
+import com.simprints.infra.events.event.domain.models.scope.Location
+import com.simprints.infra.events.session.SessionEventRepository
+import javax.inject.Inject
+
+internal class UpdateSessionScopeLocationUseCase @Inject constructor(
+    private val eventRepository: SessionEventRepository,
+) {
+    suspend operator fun invoke(location: Location) {
+        val sessionScope = eventRepository.getCurrentSessionScope()
+        val updatedSessionScope = sessionScope.copy(
+            payload = sessionScope.payload.copy(
+                location = location,
+            ),
+        )
+        eventRepository.saveSessionScope(updatedSessionScope)
+    }
+}

--- a/feature/setup/src/main/java/com/simprints/feature/setup/screen/SetupViewModel.kt
+++ b/feature/setup/src/main/java/com/simprints/feature/setup/screen/SetupViewModel.kt
@@ -8,17 +8,21 @@ import androidx.lifecycle.viewModelScope
 import com.simprints.core.DeviceID
 import com.simprints.core.domain.common.Modality
 import com.simprints.feature.setup.LocationStore
+import com.simprints.feature.setup.location.UpdateSessionScopeLocationUseCase
 import com.simprints.infra.authstore.AuthStore
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.ModalitySdkType
 import com.simprints.infra.config.store.models.ProjectConfiguration
 import com.simprints.infra.config.store.models.isCommCareEventDownSyncAllowed
+import com.simprints.infra.events.event.domain.models.scope.Location
 import com.simprints.infra.license.LicenseRepository
 import com.simprints.infra.license.LicenseStatus
 import com.simprints.infra.license.SaveLicenseCheckEventUseCase
 import com.simprints.infra.license.models.LicenseState
 import com.simprints.infra.license.models.LicenseVersion
 import com.simprints.infra.license.models.Vendor
+import com.simprints.infra.logging.LoggingConstants.CrashReportTag
+import com.simprints.infra.logging.Simber
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -31,6 +35,7 @@ internal class SetupViewModel @Inject constructor(
     @param:DeviceID private val deviceID: String,
     private val authStore: AuthStore,
     private val saveLicenseCheckEvent: SaveLicenseCheckEventUseCase,
+    private val updateSessionScopeLocation: UpdateSessionScopeLocationUseCase,
 ) : ViewModel() {
     val requestLocationPermission: LiveData<Unit>
         get() = _requestLocationPermission
@@ -77,6 +82,11 @@ internal class SetupViewModel @Inject constructor(
     fun locationPermissionCheckDone(granted: Boolean) {
         if (granted) {
             locationStore.collectLocationInBackground()
+        } else {
+            viewModelScope.launch {
+                Simber.i("No permission to use location data", tag = CrashReportTag.SESSION)
+                updateSessionScopeLocation(Location.NO_PERMISSION)
+            }
         }
         requestCommCarePermissionIfNeeded()
     }

--- a/feature/setup/src/test/java/com/simprints/feature/setup/location/LocationManagerTest.kt
+++ b/feature/setup/src/test/java/com/simprints/feature/setup/location/LocationManagerTest.kt
@@ -5,12 +5,16 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.ext.junit.runners.*
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.Tasks
 import com.google.common.truth.Truth.*
+import com.simprints.infra.config.store.ConfigRepository
+import com.simprints.infra.config.store.models.ProjectConfiguration
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -27,6 +31,12 @@ internal class LocationManagerTest {
     @MockK
     private lateinit var mockedLocationClient: FusedLocationProviderClient
 
+    @MockK
+    private lateinit var configRepository: ConfigRepository
+
+    @MockK
+    private lateinit var config: ProjectConfiguration
+
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
@@ -36,7 +46,10 @@ internal class LocationManagerTest {
             LocationServices.getFusedLocationProviderClient(any<Context>())
         } returns mockedLocationClient
 
-        locationManager = LocationManager(mockk())
+        coEvery { configRepository.getProjectConfiguration() } returns config
+        every { config.custom } returns emptyMap()
+
+        locationManager = LocationManager(mockk(), configRepository)
     }
 
     @Test
@@ -127,5 +140,34 @@ internal class LocationManagerTest {
         // Then
         val results = flow.toList()
         assertThat(results).isEmpty()
+    }
+
+    @Test
+    fun `uses high accuracy if no custom configuration`() = runTest {
+        // Given
+        every { mockedLocationClient.lastLocation } returns Tasks.forResult(null)
+        every { mockedLocationClient.getCurrentLocation(any<Int>(), any()) } returns Tasks.forResult(null)
+
+        // When
+        locationManager.requestLocation().toList()
+
+        // Then
+        coVerify(exactly = 1) { mockedLocationClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, any()) }
+    }
+
+    @Test
+    fun `uses balanced accuracy if has custom configuration`() = runTest {
+        // Given
+        clearMocks(config)
+        every { config.custom } returns mapOf("useBalancedLocationAccuracy" to JsonPrimitive(true))
+
+        every { mockedLocationClient.lastLocation } returns Tasks.forResult(null)
+        every { mockedLocationClient.getCurrentLocation(any<Int>(), any()) } returns Tasks.forResult(null)
+
+        // When
+        locationManager.requestLocation().toList()
+
+        // Then
+        coVerify { mockedLocationClient.getCurrentLocation(Priority.PRIORITY_BALANCED_POWER_ACCURACY, any()) }
     }
 }

--- a/feature/setup/src/test/java/com/simprints/feature/setup/location/LocationManagerTest.kt
+++ b/feature/setup/src/test/java/com/simprints/feature/setup/location/LocationManagerTest.kt
@@ -1,47 +1,35 @@
 package com.simprints.feature.setup.location
 
 import android.content.Context
-import android.location.Location
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.ext.junit.runners.*
 import com.google.android.gms.location.FusedLocationProviderClient
-import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
-import com.google.android.gms.tasks.OnCompleteListener
-import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
 import com.google.common.truth.Truth.*
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 internal class LocationManagerTest {
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
     @MockK
     private lateinit var locationManager: LocationManager
 
     @MockK
     private lateinit var mockedLocationClient: FusedLocationProviderClient
 
-    @MockK
-    private lateinit var mockedLocationTask: Task<Location>
-
-    @MockK
-    private lateinit var locationResponseTask: Task<Location>
-
-    private var captureCallback = slot<OnCompleteListener<Location>>()
-
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-
-        every { mockedLocationTask.addOnCompleteListener(capture(captureCallback)) } answers {
-            captureCallback.captured.onComplete(locationResponseTask)
-            mockk()
-        }
-        every {
-            mockedLocationClient.getCurrentLocation(any<Int>(), any())
-        } returns mockedLocationTask
 
         mockkStatic(LocationServices::class)
         every {
@@ -52,26 +40,92 @@ internal class LocationManagerTest {
     }
 
     @Test
-    fun `test requestLocation success`() = runTest {
+    fun `test requestLocation success both locations`() = runTest {
         // Given
-        val fakeLocation = TestLocationData.buildFakeLocation()
-        every { locationResponseTask.isSuccessful } returns true
-        every { locationResponseTask.result } returns fakeLocation
+        val fakeLastLocation = TestLocationData.buildFakeLocation().apply {
+            latitude = 10.0
+            longitude = 10.0
+            time = 1000L
+        }
+        val fakeCurrentLocation = TestLocationData.buildFakeLocation().apply {
+            latitude = 20.0
+            longitude = 20.0
+        }
+
+        every { mockedLocationClient.lastLocation } returns Tasks.forResult(fakeLastLocation)
+        every { mockedLocationClient.getCurrentLocation(any<Int>(), any()) } returns Tasks.forResult(fakeCurrentLocation)
+
         // When
-        val flow = locationManager.requestLocation(LocationRequest.create()).take(1)
+        val flow = locationManager.requestLocation()
+
         // Then
-        val result = flow.firstOrNull()
-        assertThat(result?.latitude).isEqualTo(fakeLocation.latitude)
-        assertThat(result?.longitude).isEqualTo(fakeLocation.longitude)
+        val results = flow.toList()
+        assertThat(results).hasSize(2)
+
+        assertThat(results[0]?.latitude).isEqualTo(10.0)
+        assertThat(results[0]?.longitude).isEqualTo(10.0)
+        assertThat(results[0]?.lastLocationTime).isEqualTo(1000L)
+
+        assertThat(results[1]?.latitude).isEqualTo(20.0)
+        assertThat(results[1]?.longitude).isEqualTo(20.0)
+        assertThat(results[1]?.lastLocationTime).isNull()
     }
 
     @Test
-    fun `test requestLocation failure`() = runTest {
+    fun `test requestLocation success only current location`() = runTest {
         // Given
-        every { locationResponseTask.isSuccessful } returns false
+        val fakeCurrentLocation = TestLocationData.buildFakeLocation().apply {
+            latitude = 30.0
+            longitude = 30.0
+        }
+
+        every { mockedLocationClient.lastLocation } returns Tasks.forResult(null)
+        every { mockedLocationClient.getCurrentLocation(any<Int>(), any()) } returns Tasks.forResult(fakeCurrentLocation)
+
         // When
-        val flow = locationManager.requestLocation(LocationRequest.create()).take(1)
+        val flow = locationManager.requestLocation()
+
         // Then
-        assertThat(flow.firstOrNull()).isEqualTo(null)
+        val results = flow.toList()
+        assertThat(results).hasSize(1)
+
+        assertThat(results[0]?.latitude).isEqualTo(30.0)
+        assertThat(results[0]?.longitude).isEqualTo(30.0)
+    }
+
+    @Test
+    fun `test requestLocation success only last location`() = runTest {
+        // Given
+        val fakeLastLocation = TestLocationData.buildFakeLocation().apply {
+            latitude = 40.0
+            longitude = 40.0
+        }
+
+        every { mockedLocationClient.lastLocation } returns Tasks.forResult(fakeLastLocation)
+        every { mockedLocationClient.getCurrentLocation(any<Int>(), any()) } returns Tasks.forResult(null)
+
+        // When
+        val flow = locationManager.requestLocation()
+
+        // Then
+        val results = flow.toList()
+        assertThat(results).hasSize(1)
+
+        assertThat(results[0]?.latitude).isEqualTo(40.0)
+        assertThat(results[0]?.longitude).isEqualTo(40.0)
+    }
+
+    @Test
+    fun `test requestLocation failure both locations absent`() = runTest {
+        // Given
+        every { mockedLocationClient.lastLocation } returns Tasks.forResult(null)
+        every { mockedLocationClient.getCurrentLocation(any<Int>(), any()) } returns Tasks.forResult(null)
+
+        // When
+        val flow = locationManager.requestLocation()
+
+        // Then
+        val results = flow.toList()
+        assertThat(results).isEmpty()
     }
 }

--- a/feature/setup/src/test/java/com/simprints/feature/setup/location/LocationManagerTest.kt
+++ b/feature/setup/src/test/java/com/simprints/feature/setup/location/LocationManagerTest.kt
@@ -7,13 +7,9 @@ import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.tasks.OnCompleteListener
 import com.google.android.gms.tasks.Task
-import com.google.common.truth.Truth
-import io.mockk.MockKAnnotations
-import io.mockk.every
+import com.google.common.truth.Truth.*
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.slot
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.test.runTest
@@ -64,7 +60,9 @@ internal class LocationManagerTest {
         // When
         val flow = locationManager.requestLocation(LocationRequest.create()).take(1)
         // Then
-        Truth.assertThat(flow.firstOrNull()).isEqualTo(fakeLocation)
+        val result = flow.firstOrNull()
+        assertThat(result?.latitude).isEqualTo(fakeLocation.latitude)
+        assertThat(result?.longitude).isEqualTo(fakeLocation.longitude)
     }
 
     @Test
@@ -74,6 +72,6 @@ internal class LocationManagerTest {
         // When
         val flow = locationManager.requestLocation(LocationRequest.create()).take(1)
         // Then
-        Truth.assertThat(flow.firstOrNull()).isEqualTo(null)
+        assertThat(flow.firstOrNull()).isEqualTo(null)
     }
 }

--- a/feature/setup/src/test/java/com/simprints/feature/setup/location/StoreUserLocationIntoCurrentSessionWorkerTest.kt
+++ b/feature/setup/src/test/java/com/simprints/feature/setup/location/StoreUserLocationIntoCurrentSessionWorkerTest.kt
@@ -1,15 +1,10 @@
 package com.simprints.feature.setup.location
 
 import android.os.PowerManager
-import com.simprints.infra.events.sampledata.createSessionScope
-import com.simprints.infra.events.session.SessionEventRepository
+import com.simprints.infra.events.event.domain.models.scope.Location
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
-import io.mockk.MockKAnnotations
-import io.mockk.coEvery
-import io.mockk.coVerify
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -24,14 +19,13 @@ internal class StoreUserLocationIntoCurrentSessionWorkerTest {
     private lateinit var locationManager: LocationManager
 
     @MockK
-    private lateinit var eventRepository: SessionEventRepository
+    private lateinit var updateSessionScopeLocationUseCase: UpdateSessionScopeLocationUseCase
 
     private lateinit var worker: StoreUserLocationIntoCurrentSessionWorker
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-        coEvery { eventRepository.getCurrentSessionScope() } returns createSessionScope()
 
         worker = StoreUserLocationIntoCurrentSessionWorker(
             mockk(relaxed = true) {
@@ -40,7 +34,7 @@ internal class StoreUserLocationIntoCurrentSessionWorkerTest {
                 }
             },
             mockk(relaxed = true),
-            eventRepository,
+            updateSessionScopeLocationUseCase,
             locationManager,
             testCoroutineRule.testCoroutineDispatcher,
         )
@@ -48,34 +42,32 @@ internal class StoreUserLocationIntoCurrentSessionWorkerTest {
 
     @Test
     fun storeUserLocationIntoCurrentSession() = runTest {
-        every { locationManager.requestLocation(any()) } returns flowOf(TestLocationData.buildFakeLocation())
+        every { locationManager.requestLocation(any()) } returns flowOf(Location(latitude = 23.0, longitude = 54.0))
         worker.doWork()
-        coVerify(exactly = 1) { eventRepository.getCurrentSessionScope() }
-        coVerify(exactly = 1) { eventRepository.saveSessionScope(any()) }
+        coVerify(exactly = 1) { updateSessionScopeLocationUseCase.invoke(any()) }
     }
 
     @Test
     fun `storeUserLocationIntoCurrentSession requestLocation throw exception`() = runTest {
         every { locationManager.requestLocation(any()) } throws Exception("Location collect exception")
         worker.doWork()
-        coVerify(exactly = 0) { eventRepository.getCurrentSessionScope() }
+        coVerify(exactly = 0) { updateSessionScopeLocationUseCase.invoke(any()) }
     }
 
     @Test(expected = Test.None::class)
     fun `storeUserLocationIntoCurrentSession can't save event should not crash the app`() = runTest {
-        every { locationManager.requestLocation(any()) } returns flowOf(TestLocationData.buildFakeLocation())
+        every { locationManager.requestLocation(any()) } returns flowOf(Location(latitude = 23.0, longitude = 54.0))
         coEvery {
-            eventRepository.getCurrentSessionScope()
+            updateSessionScopeLocationUseCase.invoke(any())
         } throws Exception("No session capture event found")
         worker.doWork()
-        coVerify(exactly = 0) { eventRepository.saveSessionScope(any()) }
     }
 
     @Test
     fun `storeUserLocationIntoCurrentSession can't save events if the worker is canceled`() = runTest {
-        every { locationManager.requestLocation(any()) } returns flowOf(TestLocationData.buildFakeLocation())
+        every { locationManager.requestLocation(any()) } returns flowOf(Location(latitude = 23.0, longitude = 54.0))
         worker.stop(0)
         worker.doWork()
-        coVerify(exactly = 0) { eventRepository.saveSessionScope(any()) }
+        coVerify(exactly = 0) { updateSessionScopeLocationUseCase.invoke(any()) }
     }
 }

--- a/feature/setup/src/test/java/com/simprints/feature/setup/location/StoreUserLocationIntoCurrentSessionWorkerTest.kt
+++ b/feature/setup/src/test/java/com/simprints/feature/setup/location/StoreUserLocationIntoCurrentSessionWorkerTest.kt
@@ -42,21 +42,21 @@ internal class StoreUserLocationIntoCurrentSessionWorkerTest {
 
     @Test
     fun storeUserLocationIntoCurrentSession() = runTest {
-        every { locationManager.requestLocation(any()) } returns flowOf(Location(latitude = 23.0, longitude = 54.0))
+        every { locationManager.requestLocation() } returns flowOf(Location(latitude = 23.0, longitude = 54.0))
         worker.doWork()
         coVerify(exactly = 1) { updateSessionScopeLocationUseCase.invoke(any()) }
     }
 
     @Test
     fun `storeUserLocationIntoCurrentSession requestLocation throw exception`() = runTest {
-        every { locationManager.requestLocation(any()) } throws Exception("Location collect exception")
+        every { locationManager.requestLocation() } throws Exception("Location collect exception")
         worker.doWork()
         coVerify(exactly = 0) { updateSessionScopeLocationUseCase.invoke(any()) }
     }
 
     @Test(expected = Test.None::class)
     fun `storeUserLocationIntoCurrentSession can't save event should not crash the app`() = runTest {
-        every { locationManager.requestLocation(any()) } returns flowOf(Location(latitude = 23.0, longitude = 54.0))
+        every { locationManager.requestLocation() } returns flowOf(Location(latitude = 23.0, longitude = 54.0))
         coEvery {
             updateSessionScopeLocationUseCase.invoke(any())
         } throws Exception("No session capture event found")
@@ -65,7 +65,7 @@ internal class StoreUserLocationIntoCurrentSessionWorkerTest {
 
     @Test
     fun `storeUserLocationIntoCurrentSession can't save events if the worker is canceled`() = runTest {
-        every { locationManager.requestLocation(any()) } returns flowOf(Location(latitude = 23.0, longitude = 54.0))
+        every { locationManager.requestLocation() } returns flowOf(Location(latitude = 23.0, longitude = 54.0))
         worker.stop(0)
         worker.doWork()
         coVerify(exactly = 0) { updateSessionScopeLocationUseCase.invoke(any()) }

--- a/feature/setup/src/test/java/com/simprints/feature/setup/location/UpdateSessionScopeLocationUseCaseTest.kt
+++ b/feature/setup/src/test/java/com/simprints/feature/setup/location/UpdateSessionScopeLocationUseCaseTest.kt
@@ -1,0 +1,48 @@
+package com.simprints.feature.setup.location
+
+import com.google.common.truth.Truth.*
+import com.simprints.infra.events.event.domain.models.scope.Location
+import com.simprints.infra.events.sampledata.createSessionScope
+import com.simprints.infra.events.session.SessionEventRepository
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class UpdateSessionScopeLocationUseCaseTest {
+    @MockK
+    private lateinit var eventRepository: SessionEventRepository
+
+    private lateinit var updateSessionScopeLocationUseCase: UpdateSessionScopeLocationUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+        coEvery { eventRepository.getCurrentSessionScope() } returns createSessionScope()
+
+        updateSessionScopeLocationUseCase = UpdateSessionScopeLocationUseCase(eventRepository)
+    }
+
+    @Test
+    fun `invoke adds location to current session scope`() = runTest {
+        updateSessionScopeLocationUseCase.invoke(
+            Location(
+                latitude = 23.0,
+                longitude = 54.0,
+            ),
+        )
+
+        coVerify(exactly = 1) { eventRepository.getCurrentSessionScope() }
+        coVerify(exactly = 1) {
+            eventRepository.saveSessionScope(
+                withArg { scope ->
+                    scope.payload.location.let {
+                        assertThat(it?.longitude).isEqualTo(54.0)
+                        assertThat(it?.latitude).isEqualTo(23.0)
+                    }
+                },
+            )
+        }
+    }
+}

--- a/feature/setup/src/test/java/com/simprints/feature/setup/screen/SetupViewModelTest.kt
+++ b/feature/setup/src/test/java/com/simprints/feature/setup/screen/SetupViewModelTest.kt
@@ -4,10 +4,12 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.jraska.livedata.test
 import com.simprints.core.domain.common.Modality
 import com.simprints.feature.setup.LocationStore
+import com.simprints.feature.setup.location.UpdateSessionScopeLocationUseCase
 import com.simprints.infra.authstore.AuthStore
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.ModalitySdkType
 import com.simprints.infra.config.store.models.ProjectConfiguration
+import com.simprints.infra.events.event.domain.models.scope.Location
 import com.simprints.infra.license.LicenseRepository
 import com.simprints.infra.license.LicenseStatus
 import com.simprints.infra.license.SaveLicenseCheckEventUseCase
@@ -43,6 +45,9 @@ class SetupViewModelTest {
     @MockK
     private lateinit var saveLicenseCheckEvent: SaveLicenseCheckEventUseCase
 
+    @MockK
+    private lateinit var updateSessionScopeLocation: UpdateSessionScopeLocationUseCase
+
     private val configRepository = mockk<ConfigRepository>()
     private lateinit var viewModel: SetupViewModel
 
@@ -53,15 +58,17 @@ class SetupViewModelTest {
     fun setUp() {
         MockKAnnotations.init(this)
         every { authStore.signedInProjectId } returns projectId
-        viewModel =
-            SetupViewModel(
-                locationStore,
-                configRepository,
-                licenseRepository,
-                deviceID,
-                authStore,
-                saveLicenseCheckEvent,
-            )
+        coJustRun { updateSessionScopeLocation.invoke(any()) }
+
+        viewModel = SetupViewModel(
+            locationStore,
+            configRepository,
+            licenseRepository,
+            deviceID,
+            authStore,
+            saveLicenseCheckEvent,
+            updateSessionScopeLocation,
+        )
     }
 
     @Test
@@ -112,7 +119,7 @@ class SetupViewModelTest {
     }
 
     @Test
-    fun `should not call locationStore collectLocationInBackground() if location permission is not granted`() = runTest {
+    fun `saves explicit missing permission if location permission is not granted`() = runTest {
         // Given
         justRun { locationStore.collectLocationInBackground() }
         coEvery { configRepository.getProjectConfiguration() } returns mockk<ProjectConfiguration>()
@@ -127,6 +134,7 @@ class SetupViewModelTest {
 
         // Then
         verify(exactly = 0) { locationStore.collectLocationInBackground() }
+        coVerify { updateSessionScopeLocation.invoke(eq(Location.NO_PERMISSION)) }
     }
 
     @Test
@@ -150,6 +158,7 @@ class SetupViewModelTest {
     fun `should request CommCare permission if needed when location permission is not granted`() = runTest {
         // Given
         justRun { locationStore.collectLocationInBackground() }
+
         coEvery {
             configRepository
                 .getProjectConfiguration()

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
@@ -179,6 +179,13 @@ data class ExperimentalProjectConfiguration(
             ?.coerceAtLeast(0)
             ?: MINIMUM_FREE_SPACE_MB_DEFAULT
 
+    val useBalancedLocationAccuracy: Boolean
+        get() = customConfig
+            ?.get(USE_BALANCED_LOCATION_ACCURACY)
+            ?.jsonPrimitive
+            ?.booleanOrNull
+            .let { it == true }
+
     companion object {
         internal const val ENABLE_ID_POOL_VALIDATION = "validateIdentificationPool"
         internal const val SINGLE_GOOD_QUALITY_FALLBACK_REQUIRED = "singleQualityFallbackRequired"
@@ -240,5 +247,7 @@ data class ExperimentalProjectConfiguration(
 
         const val MINIMUM_FREE_SPACE_MB = "minimumFreeSpaceMb"
         const val MINIMUM_FREE_SPACE_MB_DEFAULT = 1024 // 1GB
+
+        const val USE_BALANCED_LOCATION_ACCURACY = "useBalancedLocationAccuracy"
     }
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
@@ -376,7 +376,7 @@ internal class ExperimentalProjectConfigurationTest {
     }
 
     @Test
-    fun `minimal free space requirement value correctly`() {
+    fun `check minimal free space requirement value parsed correctly`() {
         mapOf(
             emptyMap<String, JsonElement>() to ExperimentalProjectConfiguration.MINIMUM_FREE_SPACE_MB_DEFAULT,
             mapOf(ExperimentalProjectConfiguration.MINIMUM_FREE_SPACE_MB to JsonPrimitive(true))
@@ -385,6 +385,18 @@ internal class ExperimentalProjectConfigurationTest {
             mapOf(ExperimentalProjectConfiguration.MINIMUM_FREE_SPACE_MB to JsonPrimitive(-20)) to 0,
         ).forEach { (config, result) ->
             assertThat(ExperimentalProjectConfiguration(config).minimumFreeSpaceMb).isEqualTo(result)
+        }
+    }
+
+    @Test
+    fun `check use balanced location accuracy value parsed correctly`() {
+        mapOf(
+            emptyMap<String, JsonElement>() to false,
+            mapOf(ExperimentalProjectConfiguration.USE_BALANCED_LOCATION_ACCURACY to JsonPrimitive(2)) to false,
+            mapOf(ExperimentalProjectConfiguration.USE_BALANCED_LOCATION_ACCURACY to JsonPrimitive(false)) to false,
+            mapOf(ExperimentalProjectConfiguration.USE_BALANCED_LOCATION_ACCURACY to JsonPrimitive(true)) to true,
+        ).forEach { (config, result) ->
+            assertThat(ExperimentalProjectConfiguration(config).useBalancedLocationAccuracy).isEqualTo(result)
         }
     }
 }

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/scope/Location.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/scope/Location.kt
@@ -8,4 +8,6 @@ import kotlinx.serialization.Serializable
 data class Location(
     var latitude: Double = 0.0,
     var longitude: Double = 0.0,
+    val lastLocationTime: Long? = null,
+    val noPermission: Boolean? = null,
 )

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/scope/Location.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/scope/Location.kt
@@ -10,4 +10,8 @@ data class Location(
     var longitude: Double = 0.0,
     val lastLocationTime: Long? = null,
     val noPermission: Boolean? = null,
-)
+) {
+    companion object {
+        val NO_PERMISSION = Location(noPermission = true)
+    }
+}


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1411 )
Will be released in: **2026.2.0**

### Notable changes

* Added explicit signal for cases when location permission was denied to distinguish those cases from just missing location data.
* Changed the location request to first emit the last cached location and then try to request a more current location. This ensures that session has a higher chance to contain any kind of location data, even if slightly outdated.
* Added a feature flag to try out the balanced accuracy option - it might provide enough precision while returning the result sooner.

### Testing guidance

* On debug - start sessions and watch logs. Try removing permission.
* On release - run sessions with different conditions. Up-sync. Check session scope information.
* There is no UI indication for the location being collected.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
