### PR TITLE
[MS-1412] Fix area calculation in RectF to handle negative values

### DIFF
--- a/infra/core/src/main/java/com/simprints/core/tools/extentions/RectF.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extentions/RectF.ext.kt
@@ -1,5 +1,6 @@
 package com.simprints.core.tools.extentions
 
 import android.graphics.RectF
+import kotlin.math.abs
 
-fun RectF.area() = height() * width()
+fun RectF.area() = abs(height() * width())

--- a/infra/core/src/test/java/com/simprints/core/tools/extensions/RectFExtTest.kt
+++ b/infra/core/src/test/java/com/simprints/core/tools/extensions/RectFExtTest.kt
@@ -1,0 +1,23 @@
+package com.simprints.core.tools.extensions
+
+import android.graphics.RectF
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.*
+import com.simprints.core.tools.extentions.area
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RectFExtTest {
+    @Test
+    fun `area should return correct value`() {
+        val rect = RectF(0f, 0f, 2f, 3f)
+        Truth.assertThat(rect.area()).isEqualTo(6f)
+    }
+
+    @Test
+    fun `area should return positive value for negative dimensions`() {
+        val rect = RectF(0f, 0f, -2f, -3f)
+        Truth.assertThat(rect.area()).isEqualTo(6f)
+    }
+}


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2026.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **long time ago**

* LambdaTest devices are returning negative bounding box position, resulting in a negative box area and causing the entire capture process to fail.

### Notable changes

* now the area should be positive 

### Testing guidance

* LT should work

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
