### PR TITLE
MS-1203 Update to use MFID version of LibSimprints Identification

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapper.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapper.kt
@@ -14,9 +14,8 @@ import com.simprints.libsimprints.contracts.data.Enrolment
 import com.simprints.libsimprints.contracts.data.Identification
 import com.simprints.libsimprints.contracts.data.Identification.Companion.toJson
 import com.simprints.libsimprints.contracts.data.RefusalForm
+import com.simprints.libsimprints.contracts.data.ScannedCredential
 import com.simprints.libsimprints.contracts.data.Verification
-import org.json.JSONArray
-import org.json.JSONObject
 import javax.inject.Inject
 import com.simprints.libsimprints.Identification as LegacyIdentification
 import com.simprints.libsimprints.RefusalForm as LegacyRefusalForm
@@ -34,7 +33,7 @@ internal class LibSimprintsResponseMapper @Inject constructor(
             Constants.SIMPRINTS_DEVICE_ID to deviceId,
             Constants.SIMPRINTS_APP_VERSION_NAME to appVersionName,
             Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK to true,
-            HAS_CREDENTIAL to (response.externalCredential != null),
+            Constants.SIMPRINTS_HAS_CREDENTIAL to (response.externalCredential != null),
         ).appendDataPerContractVersion(response) { version ->
             when {
                 version < VersionsList.INITIAL_REWORK -> putParcelable(
@@ -54,11 +53,6 @@ internal class LibSimprintsResponseMapper @Inject constructor(
             Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK to true,
         ).appendDataPerContractVersion(response) { version ->
             when {
-                response.isMultiFactorIdEnabled -> putString(
-                    Constants.SIMPRINTS_IDENTIFICATIONS,
-                    response.mapIdentificationsWithCredentials(),
-                )
-
                 version < VersionsList.INITIAL_REWORK -> putParcelableArrayList(
                     Constants.SIMPRINTS_IDENTIFICATIONS,
                     response.identifications
@@ -69,8 +63,19 @@ internal class LibSimprintsResponseMapper @Inject constructor(
                 else -> putString(
                     Constants.SIMPRINTS_IDENTIFICATIONS,
                     response.identifications
-                        .map { Identification(it.guid, it.confidenceScore.toFloat(), ConfidenceBand.valueOf(it.matchConfidence.name)) }
-                        .toJson(),
+                        .map {
+                            Identification(
+                                guid = it.guid,
+                                confidence = it.confidenceScore.toFloat(),
+                                confidenceBand = ConfidenceBand.valueOf(it.matchConfidence.name),
+                                isLinkedToCredential = if (response.isMultiFactorIdEnabled) {
+                                    it.isLinkedToScannedCredential ?: false
+                                } else {
+                                    null
+                                },
+                                isCredentialVerified = it.isCredentialVerified,
+                            )
+                        }.toJson(),
                 )
             }
         }
@@ -81,7 +86,7 @@ internal class LibSimprintsResponseMapper @Inject constructor(
                 Constants.SIMPRINTS_DEVICE_ID to deviceId,
                 Constants.SIMPRINTS_APP_VERSION_NAME to appVersionName,
                 Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK to true,
-                HAS_CREDENTIAL to (response.externalCredential != null),
+                Constants.SIMPRINTS_HAS_CREDENTIAL to (response.externalCredential != null),
             ).appendExternalCredential(response.externalCredential)
         }
 
@@ -159,31 +164,13 @@ internal class LibSimprintsResponseMapper @Inject constructor(
     }
 
     private fun Bundle.appendExternalCredential(credential: AppExternalCredential?) = apply {
-        if (credential != null) {
-            val credentialJson =
-                JSONObject()
-                    .also {
-                        it.put(SCANNED_CREDENTIAL_VALUE, credential.value)
-                        it.put(SCANNED_CREDENTIAL_TYPE, credential.type)
-                    }.toString()
-            putString(SCANNED_CREDENTIAL, credentialJson)
+        credential?.let {
+            putString(
+                Constants.SIMPRINTS_SCANNED_CREDENTIAL,
+                ScannedCredential(it.type.name, it.value.value).toJson(),
+            )
         }
     }
-
-    private fun ActionResponse.IdentifyActionResponse.mapIdentificationsWithCredentials(): String = identifications
-        .map { identification ->
-            JSONObject()
-                .also { json ->
-                    json.put(KEY_GUID, identification.guid)
-                    json.put(KEY_CONFIDENCE_BAND, identification.matchConfidence.name)
-                    json.put(KEY_CONFIDENCE, identification.confidenceScore.toFloat())
-                    json.put(KEY_IS_LINKED_TO_CREDENTIAL, identification.isLinkedToScannedCredential ?: false)
-                    identification.isCredentialVerified?.let {
-                        json.put(KEY_IS_CREDENTIAL_VERIFIED, it)
-                    }
-                }
-        }.run(::JSONArray)
-        .toString()
 
     private fun AppErrorReason.libSimprintsResultCode() = when (this) {
         AppErrorReason.UNEXPECTED_ERROR -> Constants.SIMPRINTS_UNEXPECTED_ERROR
@@ -221,16 +208,5 @@ internal class LibSimprintsResponseMapper @Inject constructor(
 
     companion object {
         internal const val RESULT_CODE_OVERRIDE = "result_code_override"
-        internal const val HAS_CREDENTIAL = "hasCredential"
-        internal const val SCANNED_CREDENTIAL = "scannedCredential"
-        internal const val SCANNED_CREDENTIAL_VALUE = "value"
-        internal const val SCANNED_CREDENTIAL_TYPE = "type"
-
-        // TODO [MS-1190] Move implementation to LibSimprints. These constats are copies of com.simprints.libsimprints.contracts.data.Identification
-        private const val KEY_GUID = "guid"
-        private const val KEY_CONFIDENCE = "confidence"
-        private const val KEY_CONFIDENCE_BAND = "confidenceBand"
-        private const val KEY_IS_LINKED_TO_CREDENTIAL = "isLinkedToCredential"
-        private const val KEY_IS_CREDENTIAL_VERIFIED = "isVerified"
     }
 }

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapperTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapperTest.kt
@@ -11,10 +11,6 @@ import com.simprints.feature.clientapi.mappers.request.requestFactories.EnrolAct
 import com.simprints.feature.clientapi.mappers.request.requestFactories.EnrolLastBiometricsActionFactory
 import com.simprints.feature.clientapi.mappers.request.requestFactories.IdentifyRequestActionFactory
 import com.simprints.feature.clientapi.mappers.request.requestFactories.VerifyActionFactory
-import com.simprints.feature.clientapi.mappers.response.LibSimprintsResponseMapper.Companion.HAS_CREDENTIAL
-import com.simprints.feature.clientapi.mappers.response.LibSimprintsResponseMapper.Companion.SCANNED_CREDENTIAL
-import com.simprints.feature.clientapi.mappers.response.LibSimprintsResponseMapper.Companion.SCANNED_CREDENTIAL_TYPE
-import com.simprints.feature.clientapi.mappers.response.LibSimprintsResponseMapper.Companion.SCANNED_CREDENTIAL_VALUE
 import com.simprints.infra.orchestration.data.ActionResponse
 import com.simprints.infra.orchestration.data.responses.AppMatchResult
 import com.simprints.libsimprints.Constants
@@ -139,7 +135,7 @@ class LibSimprintsResponseMapperTest {
     fun `correctly maps confirm response`() {
         val expectedValue = "expectedValue".asTokenizableRaw()
         val expectedType = ExternalCredentialType.NHISCard
-        val expectedJson = "{\"$SCANNED_CREDENTIAL_VALUE\":\"$expectedValue\",\"$SCANNED_CREDENTIAL_TYPE\":\"$expectedType\"}"
+        val expectedJson = """{"type":"$expectedType","value":"$expectedValue"}"""
         val extras = mapper(
             ActionResponse.ConfirmActionResponse(
                 actionIdentifier = ConfirmIdentityActionFactory.getIdentifier(),
@@ -156,8 +152,8 @@ class LibSimprintsResponseMapperTest {
         assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
         assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extras.getBoolean(Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK)).isTrue()
-        assertThat(extras.getBoolean(HAS_CREDENTIAL)).isTrue()
-        assertThat(extras.getString(SCANNED_CREDENTIAL)).isEqualTo(expectedJson)
+        assertThat(extras.getBoolean(Constants.SIMPRINTS_HAS_CREDENTIAL)).isTrue()
+        assertThat(extras.getString(Constants.SIMPRINTS_SCANNED_CREDENTIAL)).isEqualTo(expectedJson)
     }
 
     @Test
@@ -406,7 +402,7 @@ class LibSimprintsResponseMapperTest {
     fun `correctly maps enrol response with external credential`() {
         val expectedValue = "expectedValue".asTokenizableRaw()
         val expectedType = ExternalCredentialType.NHISCard
-        val expectedJson = "{\"$SCANNED_CREDENTIAL_VALUE\":\"$expectedValue\",\"$SCANNED_CREDENTIAL_TYPE\":\"$expectedType\"}"
+        val expectedJson = """{"type":"$expectedType","value":"$expectedValue"}"""
 
         val extras = mapper(
             ActionResponse.EnrolActionResponse(
@@ -421,8 +417,8 @@ class LibSimprintsResponseMapperTest {
             ),
         )
 
-        assertThat(extras.getBoolean(HAS_CREDENTIAL)).isTrue()
-        assertThat(extras.getString(SCANNED_CREDENTIAL)).isEqualTo(expectedJson)
+        assertThat(extras.getBoolean(Constants.SIMPRINTS_HAS_CREDENTIAL)).isTrue()
+        assertThat(extras.getString(Constants.SIMPRINTS_SCANNED_CREDENTIAL)).isEqualTo(expectedJson)
     }
 
     @Test
@@ -440,8 +436,8 @@ class LibSimprintsResponseMapperTest {
         assertThat(extras.getString(Constants.SIMPRINTS_DEVICE_ID)).isEqualTo("deviceId")
         assertThat(extras.getString(Constants.SIMPRINTS_APP_VERSION_NAME)).isEqualTo("appVersionName")
         assertThat(extras.getBoolean(Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK)).isTrue()
-        assertThat(extras.getBoolean(HAS_CREDENTIAL)).isFalse()
-        assertThat(extras.keySet()).doesNotContain(SCANNED_CREDENTIAL)
+        assertThat(extras.getBoolean(Constants.SIMPRINTS_HAS_CREDENTIAL)).isFalse()
+        assertThat(extras.keySet()).doesNotContain(Constants.SIMPRINTS_SCANNED_CREDENTIAL)
     }
 
     @Test
@@ -465,7 +461,9 @@ class LibSimprintsResponseMapperTest {
 
         val extras = mapper(
             ActionResponse.IdentifyActionResponse(
-                actionIdentifier = IdentifyRequestActionFactory.getIdentifier(),
+                actionIdentifier = IdentifyRequestActionFactory
+                    .getIdentifier()
+                    .copy(contractVersion = VersionsList.ADDED_EXTERNAL_CREDENTIALS),
                 sessionId = "sessionId",
                 identifications = listOf(identification1, identification2),
                 isMultiFactorIdEnabled = true,
@@ -484,7 +482,9 @@ class LibSimprintsResponseMapperTest {
         val guid = "guid"
         val extras = mapper(
             ActionResponse.IdentifyActionResponse(
-                actionIdentifier = IdentifyRequestActionFactory.getIdentifier(),
+                actionIdentifier = IdentifyRequestActionFactory
+                    .getIdentifier()
+                    .copy(contractVersion = VersionsList.ADDED_EXTERNAL_CREDENTIALS),
                 sessionId = "sessionId",
                 identifications = listOf(
                     AppMatchResult(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,7 @@ circleImageView_version = "3.1.0"
 kermit_version = "2.0.8"
 zip4j_version = "2.11.6"
 
-libsimprints_version = "2025.2.2"
+libsimprints_version = "2026.1.0"
 simmatcher_version = "1.3.0"
 roc_wrapper_version = "1.23.0"
 roc_wrapper-v3_version = "3.1.0"


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1203)
Will be released in: **2026.2.0**

### Notable changes

* Switch from using custom constants to LibSimprints definitions in the resposne mapper

### Testing guidance

* Run workflows with Intent Launcher (newest vesrsions) and check the returned object.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
