### PR TITLE
[MS-1426] `MapStepsForLastBiometricEnrolUseCase` now considers matching results from the External Credential matching

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/MapStepsForLastBiometricEnrolUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/MapStepsForLastBiometricEnrolUseCase.kt
@@ -4,6 +4,7 @@ import com.simprints.core.domain.capture.BiometricReferenceCapture
 import com.simprints.core.domain.comparison.ComparisonResult
 import com.simprints.feature.enrollast.EnrolLastBiometricResult
 import com.simprints.feature.enrollast.EnrolLastBiometricStepResult
+import com.simprints.feature.externalcredential.ExternalCredentialSearchResult
 import com.simprints.infra.matching.MatchResult
 import java.io.Serializable
 import javax.inject.Inject
@@ -12,6 +13,15 @@ import javax.inject.Inject
 internal class MapStepsForLastBiometricEnrolUseCase @Inject constructor() {
     operator fun invoke(results: List<Serializable>) = results.mapNotNull { result ->
         when (result) {
+            is ExternalCredentialSearchResult -> result.matchResults.takeUnless { it.isEmpty() }?.let { credentialMatches ->
+                EnrolLastBiometricStepResult.MatchResult(
+                    results = credentialMatches.map { credentialMatch ->
+                        ComparisonResult(credentialMatch.comparisonResult.subjectId, credentialMatch.comparisonResult.comparisonScore)
+                    },
+                    sdk = credentialMatches.first().bioSdk,
+                )
+            }
+
             is EnrolLastBiometricResult -> EnrolLastBiometricStepResult.EnrolLastBiometricsResult(result.newSubjectId)
 
             is BiometricReferenceCapture -> EnrolLastBiometricStepResult.CaptureResult(result)

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/MapStepsForLastBiometricEnrolUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/MapStepsForLastBiometricEnrolUseCaseTest.kt
@@ -5,10 +5,15 @@ import com.simprints.core.domain.capture.BiometricReferenceCapture
 import com.simprints.core.domain.capture.BiometricTemplateCapture
 import com.simprints.core.domain.common.Modality
 import com.simprints.core.domain.common.TemplateIdentifier
+import com.simprints.core.domain.comparison.ComparisonResult
 import com.simprints.feature.enrollast.EnrolLastBiometricResult
 import com.simprints.feature.enrollast.EnrolLastBiometricStepResult
+import com.simprints.feature.externalcredential.ExternalCredentialSearchResult
+import com.simprints.feature.externalcredential.model.CredentialMatch
 import com.simprints.infra.config.store.models.ModalitySdkType
 import com.simprints.infra.matching.MatchResult
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Before
 import org.junit.Test
 
@@ -123,6 +128,71 @@ internal class MapStepsForLastBiometricEnrolUseCaseTest {
                         ),
                     ),
                 ),
+            ),
+        )
+    }
+
+    @Test
+    fun `maps ExternalCredentialSearchResult with matches correctly`() {
+        val matchResult = ComparisonResult("subjectId", 0.95f)
+        val match = mockk<CredentialMatch>
+            {
+                every { comparisonResult } returns matchResult
+                every { bioSdk } returns ModalitySdkType.SIM_FACE
+            }
+        val result = useCase(
+            listOf(
+                mockk<ExternalCredentialSearchResult> {
+                    every { matchResults } returns listOf(match)
+                },
+            ),
+        )
+
+        assertThat(result.first()).isEqualTo(
+            EnrolLastBiometricStepResult.MatchResult(
+                results = listOf(matchResult),
+                sdk = ModalitySdkType.SIM_FACE,
+            ),
+        )
+    }
+
+    @Test
+    fun `maps ExternalCredentialSearchResult with empty matches to null (filtered out)`() {
+        val result = useCase(
+            listOf(
+                mockk<ExternalCredentialSearchResult> {
+                    every { matchResults } returns emptyList()
+                },
+            ),
+        )
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `maps ExternalCredentialSearchResult with multiple matches correctly`() {
+        val matchResult1 = ComparisonResult("subjectId1", 0.90f)
+        val matchResult2 = ComparisonResult("subjectId2", 0.85f)
+        val match1 = mockk<CredentialMatch> {
+            every { comparisonResult } returns matchResult1
+            every { bioSdk } returns ModalitySdkType.SIM_FACE
+        }
+        val match2 = mockk<CredentialMatch> {
+            every { comparisonResult } returns matchResult2
+            every { bioSdk } returns ModalitySdkType.SIM_FACE
+        }
+        val result = useCase(
+            listOf(
+                mockk<ExternalCredentialSearchResult> {
+                    every { matchResults } returns listOf(match1, match2)
+                },
+            ),
+        )
+
+        assertThat(result.first()).isEqualTo(
+            EnrolLastBiometricStepResult.MatchResult(
+                results = listOf(matchResult1, matchResult2),
+                sdk = ModalitySdkType.SIM_FACE,
             ),
         )
     }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1426)
Will be released in: **2026.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.4.0**

The following is given:
- `10` `50` `200`  decision policy thresholds. Due to 'high' threshold being `200`, even identical matches should not yield a match score above `100`, thus allowing any duplicates to be enrolled.
- `Duplicate enrolment check` is enabled

In theory, this should allow to enrol duplicates after identification, however, that’s not the case: an error screen is displayed, saying that SID is Unable to save the last enrolment.
<img width="636" height="1356" alt="image" src="https://github.com/user-attachments/assets/eeee0157-a3f4-4ccf-b3f1-328f6eb803ba" />

More details are available in the [MS-1426 ticket](https://simprints.atlassian.net/browse/MS-1426). The main issue is that Enrol Last does not work for matches found on the External Credential screen.

### Notable changes

`MapStepsForLastBiometricEnrolUseCase` now checks for presence of the matches from the `ExternalCredentialSearchResult`, and creates `EnrolLastBiometricStepResult.MatchResult` from them.

### Testing guidance

#### Steps to test

- Configure a project for 10-50-200 thresholds

- Enable 'Duplicate Enrolment check'

- Enrol a `subject x` with a credential `C`

- Identify the `subject x` with credential `C`. Make sure that SID is saying that the record is found on the MFID credential preview screen.

- Start 'Enrol Last' workflow with the GUID of `subject x`

#### Expected

Subject is enroled, duplicate is created

### Additional work checklist

* [x] Effect on other features and security has been considered
