### PR TITLE
Add serialization to AlertButtonConfig

### DIFF
--- a/feature/alert/src/main/java/com/simprints/feature/alert/config/AlertButtonConfig.kt
+++ b/feature/alert/src/main/java/com/simprints/feature/alert/config/AlertButtonConfig.kt
@@ -2,6 +2,7 @@ package com.simprints.feature.alert.config
 
 import androidx.annotation.Keep
 import androidx.annotation.StringRes
+import com.simprints.core.domain.step.StepParams
 import com.simprints.feature.alert.AlertContract
 import kotlinx.serialization.Serializable
 import com.simprints.infra.resources.R as IDR
@@ -13,7 +14,7 @@ data class AlertButtonConfig(
     @StringRes val textRes: Int?,
     val resultKey: String?,
     val closeOnClick: Boolean,
-) {
+) : StepParams {
     companion object {
         val Close = AlertButtonConfig(
             text = null,


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1429)
Will be released in: **2026.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **Long time ago  **

* It was found in crashlytics because AlertButtonConfig is not a step param and can't be saved  and restored form the steps cache

### Notable changes

* Make AlertButtonConfig a step param

### Testing guidance

* force activity recreate when an alert diagloge displayed 

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
