### PR TITLE
MS-1411 Use timestamp model for last location time

### DIFF
--- a/feature/setup/src/main/java/com/simprints/feature/setup/location/LocationManager.kt
+++ b/feature/setup/src/main/java/com/simprints/feature/setup/location/LocationManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.CancellationTokenSource
+import com.simprints.core.tools.time.Timestamp
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.experimental
 import com.simprints.infra.events.event.domain.models.scope.Location
@@ -15,6 +16,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 internal class LocationManager @Inject constructor(
     @param:ApplicationContext val ctx: Context,
@@ -44,7 +47,11 @@ internal class LocationManager @Inject constructor(
                     Location(
                         latitude = lastLocation.latitude,
                         longitude = lastLocation.longitude,
-                        lastLocationTime = lastLocation.time,
+                        lastLocationTime = Timestamp(
+                            ms = lastLocation.time,
+                            isTrustworthy = false,
+                            msSinceBoot = lastLocation.elapsedRealtimeNanos.toDuration(DurationUnit.NANOSECONDS).inWholeMilliseconds,
+                        ),
                     ),
                 )
             }

--- a/feature/setup/src/test/java/com/simprints/feature/setup/location/LocationManagerTest.kt
+++ b/feature/setup/src/test/java/com/simprints/feature/setup/location/LocationManagerTest.kt
@@ -77,7 +77,7 @@ internal class LocationManagerTest {
 
         assertThat(results[0]?.latitude).isEqualTo(10.0)
         assertThat(results[0]?.longitude).isEqualTo(10.0)
-        assertThat(results[0]?.lastLocationTime).isEqualTo(1000L)
+        assertThat(results[0]?.lastLocationTime?.ms).isEqualTo(1000L)
 
         assertThat(results[1]?.latitude).isEqualTo(20.0)
         assertThat(results[1]?.longitude).isEqualTo(20.0)
@@ -112,6 +112,8 @@ internal class LocationManagerTest {
         val fakeLastLocation = TestLocationData.buildFakeLocation().apply {
             latitude = 40.0
             longitude = 40.0
+            time = 1000L
+            elapsedRealtimeNanos = 3000_000_000L // Using nanos since it is supported on older API levels
         }
 
         every { mockedLocationClient.lastLocation } returns Tasks.forResult(fakeLastLocation)
@@ -126,6 +128,8 @@ internal class LocationManagerTest {
 
         assertThat(results[0]?.latitude).isEqualTo(40.0)
         assertThat(results[0]?.longitude).isEqualTo(40.0)
+        assertThat(results[0]?.lastLocationTime?.ms).isEqualTo(1000L)
+        assertThat(results[0]?.lastLocationTime?.msSinceBoot).isEqualTo(3000L)
     }
 
     @Test

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/session/ApiLocation.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/session/ApiLocation.kt
@@ -2,6 +2,8 @@ package com.simprints.infra.eventsync.event.remote.models.session
 
 import androidx.annotation.Keep
 import com.simprints.infra.events.event.domain.models.scope.Location
+import com.simprints.infra.eventsync.event.remote.models.ApiTimestamp
+import com.simprints.infra.eventsync.event.remote.models.fromDomainToApi
 import kotlinx.serialization.Serializable
 
 @Keep
@@ -9,6 +11,15 @@ import kotlinx.serialization.Serializable
 internal data class ApiLocation(
     var latitude: Double = 0.0,
     var longitude: Double = 0.0,
+    val lastLocationTime: ApiTimestamp? = null,
+    var noPermission: Boolean? = null,
 )
 
-internal fun Location?.fromDomainToApi() = this?.let { ApiLocation(latitude, longitude) }
+internal fun Location?.fromDomainToApi() = this?.let {
+    ApiLocation(
+        latitude = latitude,
+        longitude = longitude,
+        lastLocationTime = lastLocationTime?.fromDomainToApi(),
+        noPermission = noPermission,
+    )
+}

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventScopeToApiUseCaseTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventScopeToApiUseCaseTest.kt
@@ -8,6 +8,7 @@ import com.simprints.infra.events.event.domain.models.scope.Device
 import com.simprints.infra.events.event.domain.models.scope.EventScope
 import com.simprints.infra.events.event.domain.models.scope.EventScopePayload
 import com.simprints.infra.events.event.domain.models.scope.EventScopeType
+import com.simprints.infra.events.event.domain.models.scope.Location
 import com.simprints.infra.eventsync.event.remote.models.ApiEvent
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
@@ -57,7 +58,7 @@ internal class MapDomainEventScopeToApiUseCaseTest {
             assertEquals(id, scope.id)
             assertEquals(projectId, scope.projectId)
             assertEquals(startTime.unixMs, scope.createdAt.ms)
-            assertEquals(endTime, scope.endedAt)
+            assertEquals(endTime?.unixMs, scope.endedAt?.ms)
         }
     }
 
@@ -77,7 +78,11 @@ internal class MapDomainEventScopeToApiUseCaseTest {
             databaseInfo = DatabaseInfo(0, 0),
             projectConfigurationUpdatedAt = "",
             projectConfigurationId = "",
-            location = null,
+            location = Location(
+                latitude = 56.0,
+                longitude = 27.0,
+                lastLocationTime = Timestamp(1000L),
+            ),
         ),
     )
 }

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/scope/Location.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/scope/Location.kt
@@ -1,6 +1,7 @@
 package com.simprints.infra.events.event.domain.models.scope
 
 import androidx.annotation.Keep
+import com.simprints.core.tools.time.Timestamp
 import kotlinx.serialization.Serializable
 
 @Keep
@@ -8,7 +9,7 @@ import kotlinx.serialization.Serializable
 data class Location(
     var latitude: Double = 0.0,
     var longitude: Double = 0.0,
-    val lastLocationTime: Long? = null,
+    val lastLocationTime: Timestamp? = null,
     val noPermission: Boolean? = null,
 ) {
     companion object {


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1411)
Will be released in: **2026.2.0**

### Notable changes

* As per last-minute suggestion, changing last location time from long to timestamp model.
* Also noticed that the time was not being sent to the API all together, fixed that as well.

### Testing guidance

* Run several sessions before installing the changes, do not up-sync data
* Install changes
* Run couple more sessions and trigger the upsync - there should be no errors

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
