### PR TITLE
[MS-1036] Close ImageProxy even when preview is empty to avoid leaks

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/CropToTargetOverlayAnalyzer.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/CropToTargetOverlayAnalyzer.kt
@@ -12,40 +12,39 @@ internal class CropToTargetOverlayAnalyzer(
     private val onImageCropped: (Bitmap) -> Unit,
 ) : ImageAnalysis.Analyzer {
     override fun analyze(image: ImageProxy) {
-        val previewRect = targetOverlay.circleRect
-        if (previewRect.isEmpty) return
+        val croppedBitmap = image.use {
+            val previewRect = targetOverlay.circleRect
+            if (previewRect.isEmpty) return
 
-        // Adjust overlay size to be fit-center with the image size
-        val scale = getSmallerRatio(
-            image.width,
-            image.height,
-            targetOverlay.width,
-            targetOverlay.height,
-        )
-        val scaledWidth = (targetOverlay.width * scale).toInt()
-        val scaledHeight = (targetOverlay.height * scale).toInt()
+            // Adjust overlay size to be fit-center with the image size
+            val scale = getSmallerRatio(
+                it.width,
+                it.height,
+                targetOverlay.width,
+                targetOverlay.height,
+            )
+            val scaledWidth = (targetOverlay.width * scale).toInt()
+            val scaledHeight = (targetOverlay.height * scale).toInt()
 
-        // Find the offsets caused by fit-center scaling
-        val offsetX = (max(image.width, scaledWidth) - min(image.width, scaledWidth)) / 2
-        val offsetY = (max(image.height, scaledHeight) - min(image.height, scaledHeight)) / 2
+            // Find the offsets caused by fit-center scaling
+            val offsetX = (max(it.width, scaledWidth) - min(it.width, scaledWidth)) / 2
+            val offsetY = (max(it.height, scaledHeight) - min(it.height, scaledHeight)) / 2
 
-        // Scale the preview target to the new scale and offset
-        val cropLeft = offsetX + (previewRect.left * scale).toInt()
-        val cropWidth = (previewRect.width() * scale).toInt()
-        val cropTop = offsetY + (previewRect.top * scale).toInt()
-        val cropHeight = (previewRect.height() * scale).toInt()
+            // Scale the preview target to the new scale and offset
+            val cropLeft = offsetX + (previewRect.left * scale).toInt()
+            val cropWidth = (previewRect.width() * scale).toInt()
+            val cropTop = offsetY + (previewRect.top * scale).toInt()
+            val cropHeight = (previewRect.height() * scale).toInt()
 
-        onImageCropped(
-            image.use {
-                Bitmap.createBitmap(
-                    it.toBitmap(),
-                    cropLeft,
-                    cropTop,
-                    cropWidth,
-                    cropHeight,
-                )
-            },
-        )
+            Bitmap.createBitmap(
+                it.toBitmap(),
+                cropLeft,
+                cropTop,
+                cropWidth,
+                cropHeight,
+            )
+        }
+        onImageCropped(croppedBitmap)
     }
 
     private fun getSmallerRatio(

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/CropToTargetOverlayAnalyzerTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/CropToTargetOverlayAnalyzerTest.kt
@@ -10,6 +10,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.justRun
+import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -46,6 +47,7 @@ internal class CropToTargetOverlayAnalyzerTest {
         // Cropped should be still square and half the side length of original
         assertThat(capturedBitmap?.width).isNull()
         assertThat(capturedBitmap?.height).isNull()
+        verify(exactly = 1) { imageProxy.close() }
     }
 
     @Test
@@ -60,6 +62,23 @@ internal class CropToTargetOverlayAnalyzerTest {
         // Cropped should be still square and half the side length of original
         assertThat(capturedBitmap?.width).isEqualTo(300)
         assertThat(capturedBitmap?.height).isEqualTo(300)
+    }
+
+    @Test
+    fun `Closes ImageProxy before invoking cropped callback`() {
+        setupScreenSize(1000, 2000)
+        every { targetOverlay.circleRect } returns RectF(200f, 200f, 800f, 800f)
+        setupImageSize(1000, 1000)
+
+        var closed = false
+        every { imageProxy.close() } answers { closed = true }
+        var closedBeforeCallback = false
+        val analyzer = CropToTargetOverlayAnalyzer(targetOverlay) { closedBeforeCallback = closed }
+
+        analyzer.analyze(imageProxy)
+
+        assertThat(closedBeforeCallback).isTrue()
+        verify(exactly = 1) { imageProxy.close() }
     }
 
     @Test


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1036)
Will be released in: **2026.2.0** if considered safe, if not - will rebase to main and leave for next release

### Root cause analysis (for bugfixes only)

First known affected version: **2025.1.0**

* There's a small trickle of crashes from all versions since 2025.1.0 when preview is empty (during initialization or onStop/onStart). In that case we exit early but don't close the ImageProxy so it gets leaked. When all 4 slots get occupied - *KABOOM*

### Notable changes

* Fix is straightforward - just wrap the whole body in a use {} so that ImageProxy gets closed in any case. Should be perfectly safe, too.

### Testing guidance

* Probably hard to reproduce but open face preview, minimize and bring back to foreground a few times, rotate the device, etc.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
