### PR TITLE
MS-1433 Persist data for MFID analytics events across activity recreation

### DIFF
--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/controller/ExternalCredentialViewModel.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/controller/ExternalCredentialViewModel.kt
@@ -2,6 +2,7 @@ package com.simprints.feature.externalcredential.screens.controller
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.simprints.core.domain.externalcredential.ExternalCredentialType
@@ -23,6 +24,7 @@ internal class ExternalCredentialViewModel @Inject internal constructor(
     private val timeHelper: TimeHelper,
     private val configRepository: ConfigRepository,
     private val eventsTracker: ExternalCredentialEventTrackerUseCase,
+    private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     private var isInitialized = false
     lateinit var params: ExternalCredentialParams
@@ -50,6 +52,10 @@ internal class ExternalCredentialViewModel @Inject internal constructor(
     private var selectedSkipOtherText: String? = null
 
     init {
+        savedStateHandle.get<Timestamp>(KEY_SELECTION_START_TIME)?.let { selectionStartTime = it }
+        savedStateHandle.get<String>(KEY_SELECTION_EVENT_ID)?.let { selectionEventId = it }
+        savedStateHandle.get<Timestamp>(KEY_CAPTURE_START_TIME)?.let { captureStartTime = it }
+
         viewModelScope.launch {
             val config = configRepository.getProjectConfiguration()
             val allowedExternalCredentials = config.multifactorId?.allowedExternalCredentials.orEmpty()
@@ -58,7 +64,13 @@ internal class ExternalCredentialViewModel @Inject internal constructor(
     }
 
     fun selectionStarted() {
+        if (savedStateHandle.contains(KEY_SELECTION_START_TIME)) {
+            // Selection time has been recorded, which means the user has already started selection before process death.
+            return
+        }
+
         selectionStartTime = timeHelper.now()
+        savedStateHandle[KEY_SELECTION_START_TIME] = selectionStartTime
     }
 
     fun skipOptionSelected(skipOption: ExternalCredentialSelectionEvent.SkipReason) {
@@ -78,7 +90,9 @@ internal class ExternalCredentialViewModel @Inject internal constructor(
             if (selectedType != null) {
                 val selectionEndTime = timeHelper.now()
                 selectionEventId = eventsTracker.saveSelectionEvent(selectionStartTime, selectionEndTime, selectedType)
+                savedStateHandle[KEY_SELECTION_EVENT_ID] = selectionEventId
                 captureStartTime = timeHelper.now()
+                savedStateHandle[KEY_CAPTURE_START_TIME] = captureStartTime
             }
             updateState { it.copy(selectedType = selectedType) }
         }
@@ -117,5 +131,11 @@ internal class ExternalCredentialViewModel @Inject internal constructor(
             }
             _finishEvent.send(result)
         }
+    }
+
+    internal companion object {
+        internal const val KEY_SELECTION_START_TIME = "selection_start_time"
+        internal const val KEY_SELECTION_EVENT_ID = "selection_event_id"
+        internal const val KEY_CAPTURE_START_TIME = "capture_start_time"
     }
 }

--- a/feature/external-credential/src/test/java/com/simprints/feature/externalcredential/screens/controller/ExternalCredentialViewModelTest.kt
+++ b/feature/external-credential/src/test/java/com/simprints/feature/externalcredential/screens/controller/ExternalCredentialViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.simprints.feature.externalcredential.screens.controller
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.*
 import com.jraska.livedata.test
 import com.simprints.core.domain.common.FlowType
@@ -37,17 +38,106 @@ internal class ExternalCredentialViewModelTest {
 
     @MockK
     private lateinit var configRepository: ConfigRepository
+    private lateinit var savedStateHandle: SavedStateHandle
     private lateinit var viewModel: ExternalCredentialViewModel
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
+        savedStateHandle = SavedStateHandle()
         viewModel = ExternalCredentialViewModel(
             configRepository = configRepository,
             timeHelper = timeHelper,
             eventsTracker = eventsTracker,
+            savedStateHandle = savedStateHandle,
         )
         every { timeHelper.now() } returns Timestamp(1L)
+    }
+
+    @Test
+    fun `selectionStarted persists selectionStartTime to savedStateHandle`() {
+        val expected = Timestamp(11L)
+        every { timeHelper.now() } returns expected
+
+        viewModel.selectionStarted()
+
+        assertThat(savedStateHandle.get<Timestamp>(ExternalCredentialViewModel.KEY_SELECTION_START_TIME))
+            .isEqualTo(expected)
+    }
+
+    @Test
+    fun `setSelectedExternalCredentialType persists selection event id and capture start time`() = runTest {
+        val selectionStartTime = Timestamp(10L)
+        val selectionEndTime = Timestamp(20L)
+        val captureStartTime = Timestamp(30L)
+        coEvery { eventsTracker.saveSelectionEvent(any(), any(), any()) } returns "selection-id"
+        every { timeHelper.now() } returnsMany listOf(selectionStartTime, selectionEndTime, captureStartTime)
+
+        viewModel.selectionStarted()
+        viewModel.setSelectedExternalCredentialType(ExternalCredentialType.QRCode)
+
+        assertThat(savedStateHandle.get<String>(ExternalCredentialViewModel.KEY_SELECTION_EVENT_ID))
+            .isEqualTo("selection-id")
+        assertThat(savedStateHandle.get<Timestamp>(ExternalCredentialViewModel.KEY_CAPTURE_START_TIME))
+            .isEqualTo(captureStartTime)
+    }
+
+    @Test
+    fun `finish complete uses restored selection event state from savedStateHandle`() = runTest {
+        val restoredCaptureStartTime = Timestamp(123L)
+        val restoredSelectionEventId = "restored-selection-id"
+        val restoredStateHandle = SavedStateHandle(
+            mapOf(
+                ExternalCredentialViewModel.KEY_CAPTURE_START_TIME to restoredCaptureStartTime,
+                ExternalCredentialViewModel.KEY_SELECTION_EVENT_ID to restoredSelectionEventId,
+            ),
+        )
+        val restoredViewModel = ExternalCredentialViewModel(
+            configRepository = configRepository,
+            timeHelper = timeHelper,
+            eventsTracker = eventsTracker,
+            savedStateHandle = restoredStateHandle,
+        )
+        val result = mockk<ExternalCredentialSearchResult.Complete>(relaxed = true) {
+            every { scannedCredentialResult } returns mockk(relaxed = true)
+        }
+
+        restoredViewModel.init(createParams(subjectId = "subjectId", flowType = FlowType.IDENTIFY))
+        restoredViewModel.finish(result)
+
+        coVerify {
+            eventsTracker.saveCaptureEvents(
+                credentialSearchResult = result,
+                subjectId = "subjectId",
+                startTime = restoredCaptureStartTime,
+                selectionEventId = restoredSelectionEventId,
+            )
+        }
+    }
+
+    @Test
+    fun `finish skipped uses restored selection start time from savedStateHandle`() = runTest {
+        val restoredSelectionStartTime = Timestamp(456L)
+        val restoredStateHandle = SavedStateHandle(
+            mapOf(ExternalCredentialViewModel.KEY_SELECTION_START_TIME to restoredSelectionStartTime),
+        )
+        val restoredViewModel = ExternalCredentialViewModel(
+            configRepository = configRepository,
+            timeHelper = timeHelper,
+            eventsTracker = eventsTracker,
+            savedStateHandle = restoredStateHandle,
+        )
+        val result = mockk<ExternalCredentialSearchResult.Skipped>(relaxed = true)
+
+        restoredViewModel.finish(result)
+
+        coVerify {
+            eventsTracker.saveSkippedEvent(
+                startTime = restoredSelectionStartTime,
+                skipReason = result.skipReason,
+                skipOther = null,
+            )
+        }
     }
 
     @Test
@@ -195,6 +285,7 @@ internal class ExternalCredentialViewModelTest {
             configRepository = configRepository,
             timeHelper = timeHelper,
             eventsTracker = eventsTracker,
+            savedStateHandle = SavedStateHandle(),
         )
     }
 


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1433)
Will be released in: **2026.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.1.0**

* Lateinit fields are not persisted if the "Don't keep activities" flag is enabled.
* Fields in question are used for analytics and cannot be "recreated".

### Notable changes

* Add a basic persistence for the lateinit fields.

### Testing guidance

* Have “Don’t keep activities” enabled. Have MFID enabled in the project.
* Start identification flow, capture face.
* Press “Skip” on MFID selection screen
* Press home/minimise the app
* Reopen the app and press “Skip scanning”

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
