### PR TITLE
MS-1441 Force an update of selected modules list after sync completion

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveConfigurationChangesUseCase.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveConfigurationChangesUseCase.kt
@@ -9,19 +9,27 @@ import com.simprints.infra.config.store.models.TokenKeyType
 import com.simprints.infra.config.store.tokenization.TokenizationProcessor
 import com.simprints.infra.enrolment.records.repository.EnrolmentRecordRepository
 import com.simprints.infra.enrolment.records.repository.domain.models.EnrolmentRecordQuery
+import com.simprints.infra.sync.SyncOrchestrator
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import javax.inject.Inject
 
 internal class ObserveConfigurationChangesUseCase @Inject constructor(
     private val configRepository: ConfigRepository,
     private val tokenizationProcessor: TokenizationProcessor,
     private val enrolmentRecordRepository: EnrolmentRecordRepository,
+    private val syncOrchestrator: SyncOrchestrator,
 ) {
     operator fun invoke() = combine(
         configRepository.observeIsProjectRefreshing(),
         configRepository.observeProjectConfiguration(),
         configRepository.observeDeviceConfiguration(),
-    ) { isRefreshing, projectConfig, deviceConfig ->
+        syncCompletedSignalFlow(),
+    ) { isRefreshing, projectConfig, deviceConfig, _ ->
         val project = configRepository.getProject()
 
         val moduleCounts = if (project != null) {
@@ -52,6 +60,15 @@ internal class ObserveConfigurationChangesUseCase @Inject constructor(
             projectConfig = projectConfig,
         )
     }
+
+    // Force update of module list when sync completes
+    private fun syncCompletedSignalFlow(): Flow<Unit> = syncOrchestrator
+        .observeSyncState()
+        .map { it.eventSyncState.isSyncCompleted() }
+        .distinctUntilChanged()
+        .filter { it }
+        .map { Unit }
+        .onStart { emit(Unit) }
 }
 
 internal data class ConfigurationState(

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveConfigurationChangesUseCaseTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveConfigurationChangesUseCaseTest.kt
@@ -11,11 +11,21 @@ import com.simprints.infra.config.store.models.ProjectConfiguration
 import com.simprints.infra.config.store.models.ProjectState
 import com.simprints.infra.config.store.tokenization.TokenizationProcessor
 import com.simprints.infra.enrolment.records.repository.EnrolmentRecordRepository
+import com.simprints.infra.eventsync.status.models.EventSyncState
+import com.simprints.infra.sync.ImageSyncStatus
+import com.simprints.infra.sync.SyncOrchestrator
+import com.simprints.infra.sync.SyncStatus
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -39,16 +49,24 @@ class ObserveConfigurationChangesUseCaseTest {
     @MockK
     private lateinit var deviceConfiguration: DeviceConfiguration
 
+    @MockK
+    private lateinit var syncOrchestrator: SyncOrchestrator
+
+    private lateinit var syncStateFlow: MutableStateFlow<SyncStatus>
+
     private lateinit var useCase: ObserveConfigurationChangesUseCase
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
+        syncStateFlow = MutableStateFlow(createSyncStatus(isSyncCompleted = false))
+        every { syncOrchestrator.observeSyncState() } returns syncStateFlow
 
         useCase = ObserveConfigurationChangesUseCase(
             configRepository = configRepository,
             tokenizationProcessor = tokenizationProcessor,
             enrolmentRecordRepository = enrolmentRepository,
+            syncOrchestrator = syncOrchestrator,
         )
     }
 
@@ -72,7 +90,7 @@ class ObserveConfigurationChangesUseCaseTest {
         every { configRepository.observeProjectConfiguration() } returns flowOf(projectConfiguration)
         every { configRepository.observeDeviceConfiguration() } returns flowOf(deviceConfiguration)
 
-        val result = useCase().toList()
+        val result = useCase().take(2).toList()
 
         assertThat(result.first().isRefreshing).isTrue()
         assertThat(result.last().isRefreshing).isFalse()
@@ -101,6 +119,78 @@ class ObserveConfigurationChangesUseCaseTest {
         assertThat(result.selectedModules).containsExactly(
             ModuleCount("moduleRaw", 1),
             ModuleCount("moduleUntokenized", 2),
+        )
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `re-emits configuration state when sync completes`() = runTest {
+        every { syncOrchestrator.observeSyncState() } returns syncStateFlow
+
+        coEvery { configRepository.getProject() } returns project
+        every { project.id } returns "projectId"
+        every { project.state } returns ProjectState.RUNNING
+        every { deviceConfiguration.selectedModules } returns listOf("moduleRaw".asTokenizableRaw())
+        coEvery { enrolmentRepository.count(any(), any()) } returnsMany listOf(1, 2)
+
+        every { configRepository.observeIsProjectRefreshing() } returns flowOf(false)
+        every { configRepository.observeProjectConfiguration() } returns flowOf(projectConfiguration)
+        every { configRepository.observeDeviceConfiguration() } returns flowOf(deviceConfiguration)
+
+        val emissions = mutableListOf<ConfigurationState>()
+        val job = backgroundScope.launch {
+            useCase().take(2).toList(emissions)
+        }
+
+        advanceUntilIdle()
+        syncStateFlow.value = createSyncStatus(isSyncCompleted = true)
+        advanceUntilIdle()
+        job.join()
+
+        assertThat(emissions).hasSize(2)
+        assertThat(emissions[0].selectedModules).containsExactly(ModuleCount("moduleRaw", 1))
+        assertThat(emissions[1].selectedModules).containsExactly(ModuleCount("moduleRaw", 2))
+        coVerify(exactly = 2) { enrolmentRepository.count(any(), any()) }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `does not re-emit when sync completed state is repeated`() = runTest {
+        every { syncOrchestrator.observeSyncState() } returns syncStateFlow
+
+        coEvery { configRepository.getProject() } returns project
+        every { project.id } returns "projectId"
+        every { project.state } returns ProjectState.RUNNING
+        every { deviceConfiguration.selectedModules } returns listOf("moduleRaw".asTokenizableRaw())
+        coEvery { enrolmentRepository.count(any(), any()) } returnsMany listOf(1, 2, 3)
+
+        every { configRepository.observeIsProjectRefreshing() } returns flowOf(false)
+        every { configRepository.observeProjectConfiguration() } returns flowOf(projectConfiguration)
+        every { configRepository.observeDeviceConfiguration() } returns flowOf(deviceConfiguration)
+
+        val emissions = mutableListOf<ConfigurationState>()
+        val job = launch {
+            useCase().toList(emissions)
+        }
+
+        advanceUntilIdle()
+        syncStateFlow.value = createSyncStatus(isSyncCompleted = true)
+        advanceUntilIdle()
+        syncStateFlow.value = createSyncStatus(isSyncCompleted = true)
+        advanceUntilIdle()
+        job.cancelAndJoin()
+
+        assertThat(emissions).hasSize(2)
+        assertThat(emissions.map { it.selectedModules.single().count }).containsExactly(1, 2).inOrder()
+        coVerify(exactly = 2) { enrolmentRepository.count(any(), any()) }
+    }
+
+    private fun createSyncStatus(isSyncCompleted: Boolean): SyncStatus {
+        val eventSyncState = mockk<EventSyncState>()
+        every { eventSyncState.isSyncCompleted() } returns isSyncCompleted
+        return SyncStatus(
+            eventSyncState = eventSyncState,
+            imageSyncStatus = mockk<ImageSyncStatus>(relaxed = true),
         )
     }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1441)
Will be released in: **2026.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.2.0**

* After module selection changes on the device, the new list is displayed with 0 in all modules. After that the sync is started. 
* Selected module list does not have an active observer for the sync state or record count - it is only updated when either device or project config is updated. Therefore the module record count is not updated.

### Notable changes

* Added a trigger signal to force refresh selected module list after every sync.

### Testing guidance

* Authenticate into project with module sync. 
* Go to sync info and press "select modules"
* Select set of modules (should have at least couple of records) and save - return to sync info
* Change the set of selected modules
* On the return to info a new sync should start and once it is complete module record counts gets updated.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
