### PR TITLE
MS-1435 MFID skip text fix

### DIFF
--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/skip/ExternalCredentialSkipFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/skip/ExternalCredentialSkipFragment.kt
@@ -41,21 +41,29 @@ class ExternalCredentialSkipFragment : Fragment(R.layout.fragment_external_crede
     }
 
     private fun initViews(credentialTypes: List<ExternalCredentialType>) = with(binding) {
-        mapOf(
-            title to IDR.string.mfid_skip_title,
-            skipReasonHasNumberNoId to IDR.string.mfid_skip_reason_has_number_no_id,
-            skipReasonDoesNotHaveDocument to IDR.string.mfid_skip_reason_does_not_have,
-            skipReasonDidNotBring to IDR.string.mfid_skip_reason_did_not_bring,
-            skipReasonIncorrect to IDR.string.mfid_skip_reason_incorrect,
-            skipReasonDoesNotWantToProvide to IDR.string.mfid_skip_reason_does_not_want_to_provide,
-            skipReasonDamaged to IDR.string.mfid_skip_reason_damaged,
-            skipReasonUnableToScan to IDR.string.mfid_skip_reason_unable_to_scan,
-        ).forEach { (textView, stringRes) ->
-            val credentialText = when (credentialTypes.size) {
-                1 -> resources.getCredentialTypeString(credentialTypes.first())
-                else -> getString(IDR.string.mfid_type_any_document)
-            }
-            textView.text = getString(stringRes, credentialText)
+        if (credentialTypes.size == 1) {
+            val credentialText = resources.getCredentialTypeString(credentialTypes.first())
+            mapOf(
+                title to IDR.string.mfid_skip_title_generic,
+                skipReasonHasNumberNoId to IDR.string.mfid_skip_reason_generic_has_number_no_id,
+                skipReasonDoesNotHaveDocument to IDR.string.mfid_skip_reason_generic_does_not_have,
+                skipReasonDidNotBring to IDR.string.mfid_skip_reason_generic_did_not_bring,
+                skipReasonIncorrect to IDR.string.mfid_skip_reason_generic_incorrect,
+                skipReasonDoesNotWantToProvide to IDR.string.mfid_skip_reason_generic_does_not_want_to_provide,
+                skipReasonDamaged to IDR.string.mfid_skip_reason_generic_damaged,
+                skipReasonUnableToScan to IDR.string.mfid_skip_reason_generic_unable_to_scan,
+            ).forEach { (textView, stringRes) -> textView.text = getString(stringRes, credentialText) }
+        } else {
+            mapOf(
+                title to IDR.string.mfid_skip_title,
+                skipReasonHasNumberNoId to IDR.string.mfid_skip_reason_has_number_no_id,
+                skipReasonDoesNotHaveDocument to IDR.string.mfid_skip_reason_does_not_have,
+                skipReasonDidNotBring to IDR.string.mfid_skip_reason_did_not_bring,
+                skipReasonIncorrect to IDR.string.mfid_skip_reason_incorrect,
+                skipReasonDoesNotWantToProvide to IDR.string.mfid_skip_reason_does_not_want_to_provide,
+                skipReasonDamaged to IDR.string.mfid_skip_reason_damaged,
+                skipReasonUnableToScan to IDR.string.mfid_skip_reason_unable_to_scan,
+            ).forEach { (textView, stringRes) -> textView.text = getString(stringRes) }
         }
     }
 

--- a/infra/resources/src/main/res/values/strings.xml
+++ b/infra/resources/src/main/res/values/strings.xml
@@ -542,6 +542,16 @@
     <string name="mfid_skip_reason_other">Other</string>
     <string name="mfid_skip_reason_hint">Reason</string>
     <string name="mfid_skip_reason_helper_text">Please provide a reason for skipping</string>
+    <string name="mfid_skip_title_generic">Why did you skip the document scan?</string>
+    <string name="mfid_skip_reason_generic_has_number_no_id">Has number, no document (Booklet)</string>
+    <string name="mfid_skip_reason_generic_does_not_have">Does not have a document</string>
+    <string name="mfid_skip_reason_generic_did_not_bring">Did not bring a document</string>
+    <string name="mfid_skip_reason_generic_incorrect">Brought incorrect document</string>
+    <string name="mfid_skip_reason_generic_does_not_want_to_provide">Does not want to provide a document</string>
+    <string name="mfid_skip_reason_generic_damaged">Document damaged or unreadable</string>
+    <string name="mfid_skip_reason_generic_unable_to_scan">Unable to scan document</string>
+    <string name="mfid_skip_reason_generic_other">Other</string>
+    <string name="mfid_skip_reason_generic_hint">Reason</string>
     <string name="mfid_skip_confirm">Skip Scanning</string>
     <string name="mfid_skip_go_back">Go Back</string>
 


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1435)
Will be released in: **2026.2.0**

### Notable changes

* Due to how English works and to avoid same issues with other languages, the MFID skip reasons have been split into separate sets of stings - current one for cases when a single document type is used and can be inlined into the string and new generic set that does not have any placeholders.
* Unfortunately, this change will require a merge into main for Transifex to pick up the changes and then cherry-pick of the translated values.

### Testing guidance

* Configure MFID with a single type and check the skip reason list
* Then configure additional types and check skip reasons again

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
