### PR TITLE
[MS-1430] Migrate models from Java Serializable to StepParams and StepResult interfaces

### DIFF
--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/model/BoundingBox.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/model/BoundingBox.kt
@@ -2,8 +2,8 @@ package com.simprints.feature.externalcredential.model
 
 import android.graphics.Rect
 import androidx.annotation.Keep
+import com.simprints.core.domain.step.StepParams
 import kotlinx.serialization.Serializable
-import java.io.Serializable as JavaSerializable
 
 /**
  * A serializable substitute for Android's Rect class, which is not serializable.
@@ -16,7 +16,7 @@ data class BoundingBox(
     val top: Int,
     val right: Int,
     val bottom: Int,
-) : JavaSerializable
+) : StepParams
 
 fun Rect?.toBoundingBox(): BoundingBox = if (this == null) {
     BoundingBox(0, 0, 0, 0)

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/reader/OcrModel.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/reader/OcrModel.kt
@@ -1,9 +1,9 @@
 package com.simprints.feature.externalcredential.screens.scanocr.reader
 
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
+import com.simprints.core.domain.step.StepParams
 import com.simprints.feature.externalcredential.model.BoundingBox
 import kotlinx.serialization.Serializable
-import java.io.Serializable as JavaSerializable
 
 /**
  * Wrapper for all scanned text after the OCR
@@ -14,7 +14,7 @@ import java.io.Serializable as JavaSerializable
 @ExcludedFromGeneratedTestCoverageReports("Data class")
 internal data class OcrText(
     val allLines: List<OcrLine>,
-) : JavaSerializable
+) : StepParams
 
 /**
  * A single line of text detected by the OCR kit.
@@ -33,4 +33,4 @@ internal data class OcrLine(
     val boundingBox: BoundingBox,
     val blockBoundingBox: BoundingBox,
     val confidence: Float,
-) : JavaSerializable
+) : StepParams

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/search/model/MfidDocument.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/search/model/MfidDocument.kt
@@ -2,15 +2,15 @@ package com.simprints.feature.externalcredential.screens.search.model
 
 import androidx.annotation.Keep
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
+import com.simprints.core.domain.step.StepResult
 import com.simprints.core.domain.tokenization.TokenizableString
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.io.Serializable as JavaSerializable
 
 @Keep
 @Serializable
 @ExcludedFromGeneratedTestCoverageReports("Data class")
-sealed class MfidDocument : JavaSerializable {
+sealed class MfidDocument : StepResult {
     abstract val credential: TokenizableString.Raw
 
     @Serializable

--- a/infra/core/src/main/java/com/simprints/core/domain/tokenization/TokenizableString.kt
+++ b/infra/core/src/main/java/com/simprints/core/domain/tokenization/TokenizableString.kt
@@ -1,13 +1,14 @@
 package com.simprints.core.domain.tokenization
 
 import androidx.annotation.Keep
+import com.simprints.core.domain.step.StepParams
+import com.simprints.core.domain.step.StepResult
 import com.simprints.core.domain.tokenization.TokenizableString.Raw
 import com.simprints.core.domain.tokenization.TokenizableString.Tokenized
 import com.simprints.core.domain.tokenization.serialization.TokenizableStringSerializer
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonClassDiscriminator
-import java.io.Serializable as JavaSerializable
 
 /**
  * Sealed class for values that might be tokenized (symmetrically encrypted). Use this wrapping
@@ -21,7 +22,9 @@ import java.io.Serializable as JavaSerializable
 @Serializable(with = TokenizableStringSerializer::class)
 @OptIn(ExperimentalSerializationApi::class)
 @JsonClassDiscriminator("className")
-sealed class TokenizableString : JavaSerializable {
+sealed class TokenizableString :
+    StepParams,
+    StepResult {
     abstract val value: String
     abstract val className: String
 

--- a/infra/core/src/main/java/com/simprints/core/tools/time/Timestamp.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/time/Timestamp.kt
@@ -1,8 +1,8 @@
 package com.simprints.core.tools.time
 
 import androidx.annotation.Keep
+import com.simprints.core.domain.step.StepParams
 import kotlinx.serialization.Serializable
-import java.io.Serializable as JavaSerializable
 
 @Keep
 @Serializable
@@ -11,6 +11,6 @@ data class Timestamp(
     val isTrustworthy: Boolean = false,
     val msSinceBoot: Long? = null,
 ) : Comparable<Timestamp>,
-    JavaSerializable {
+    StepParams {
     override fun compareTo(other: Timestamp): Int = ms.compareTo(other.ms)
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1430)
Will be released in: **2026.3.0**

### Notable changes

* Migrates several Kotlin model types from implementing java.io.Serializable directly  to using the project’s StepParams / StepResult marker interfaces, aligning these models with the step contract types used across the app.

### Testing guidance

* Normal flow navigation especially when "don't keep activities" setting is active 

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
