### PR TITLE
[MS-1444] Reset accumulators upon scanner disconnect to prevent lefto…

### DIFF
--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/MainMessageInputStream.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/MainMessageInputStream.kt
@@ -44,8 +44,15 @@ class MainMessageInputStream @Inject constructor(
         }
     }
 
-    // only disconnecting the packet router as the other three streams are derived from it as shared flows and will be disconnected automatically
-    override fun disconnect() = packetRouter.disconnect()
+    // Disconnect the packet router (the derived shared-flow streams are cleaned up with it) and
+    // reset every accumulator so that any partial bytes received before the disconnect do not
+    // corrupt message parsing on the next connection.
+    override fun disconnect() {
+        packetRouter.disconnect()
+        veroResponseAccumulator.reset()
+        veroEventAccumulator.reset()
+        un20ResponseAccumulator.reset()
+    }
 
     @ExcludedFromGeneratedTestCoverageReports(
         "This function is already tested in MainMessageInputStreamTest, but it does not appear in the test coverage report because it is an inline function.",

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/packet/PacketRouter.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/packet/PacketRouter.kt
@@ -46,6 +46,7 @@ class PacketRouter @Inject constructor(
 
     override fun disconnect() {
         packetProcessingJob?.cancel()
+        byteArrayToPacketAccumulator.reset()
         internalPacketRoutes.values.forEach { it.resetReplayCache() }
     }
 }

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/root/RootMessageInputStream.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/incoming/root/RootMessageInputStream.kt
@@ -21,7 +21,9 @@ class RootMessageInputStream @Inject constructor(
     }
 
     override fun disconnect() {
-        // No action needed as this stream is not usable anymore
+        // Reset the accumulator so any partial bytes received before disconnect do not corrupt
+        // message parsing on the next connection.
+        rootResponseAccumulator.reset()
     }
 
     suspend inline fun <reified R : RootResponse> receiveResponse(): R = rootResponseStream.filterIsInstance<R>().first()

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/accumulator/Accumulator.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/accumulator/Accumulator.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.flow
  * @param buildElementFromCompleteCollection Method with which to build the next available Element from the collection
  */
 abstract class Accumulator<in Fragment, in FragmentCollection, Element>(
-    initialFragmentCollection: FragmentCollection,
+    private val initialFragmentCollection: FragmentCollection,
     private val addFragmentToCollection: FragmentCollection.(Fragment) -> FragmentCollection,
     private val canComputeElementLengthFromCollection: (FragmentCollection) -> Boolean,
     private val computeElementLengthFromCollection: (FragmentCollection) -> Int,
@@ -38,6 +38,16 @@ abstract class Accumulator<in Fragment, in FragmentCollection, Element>(
     private var fragmentCollection: FragmentCollection = initialFragmentCollection
 
     private var currentElementLength: Int? = null
+
+    /**
+     * Resets the accumulator to its initial empty state. Should be called when the underlying
+     * stream is disconnected so that any partial element bytes do not leak into the next
+     * connection's stream and corrupt subsequent message parsing.
+     */
+    fun reset() {
+        fragmentCollection = initialFragmentCollection
+        currentElementLength = null
+    }
 
     fun updateWithNewFragment(fragment: Fragment) {
         fragmentCollection = fragmentCollection.addFragmentToCollection(fragment)

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/accumulator/Accumulator.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/accumulator/Accumulator.kt
@@ -18,7 +18,9 @@ import kotlinx.coroutines.flow.flow
  * @param FragmentCollection The type of the collection in which Fragments are stored as they are accumulated
  * @param Element The type of the output of the Accumulator
  *
- * @param initialFragmentCollection The initial empty collection with which to accumulate elements into
+ * @param initialFragmentCollection Factory for the initial empty collection with which to accumulate elements into.
+ * Invoked on construction and on every [reset] so that the accumulator is always restored to a fresh instance,
+ * even if a concrete subclass uses a mutable collection type as its fragment collection.
  * @param addFragmentToCollection The method in which fragments are added to the collection
  * @param canComputeElementLengthFromCollection Whether there is sufficient information within the collection to determine the next Element's length
  * @param computeElementLengthFromCollection Compute the length of the current Element from the information within the Collection
@@ -27,7 +29,7 @@ import kotlinx.coroutines.flow.flow
  * @param buildElementFromCompleteCollection Method with which to build the next available Element from the collection
  */
 abstract class Accumulator<in Fragment, in FragmentCollection, Element>(
-    private val initialFragmentCollection: FragmentCollection,
+    private val initialFragmentCollection: () -> FragmentCollection,
     private val addFragmentToCollection: FragmentCollection.(Fragment) -> FragmentCollection,
     private val canComputeElementLengthFromCollection: (FragmentCollection) -> Boolean,
     private val computeElementLengthFromCollection: (FragmentCollection) -> Int,
@@ -35,7 +37,7 @@ abstract class Accumulator<in Fragment, in FragmentCollection, Element>(
     private val sliceCollection: FragmentCollection.(IntRange) -> FragmentCollection,
     private val buildElementFromCompleteCollection: (FragmentCollection) -> Element,
 ) {
-    private var fragmentCollection: FragmentCollection = initialFragmentCollection
+    private var fragmentCollection: FragmentCollection = initialFragmentCollection()
 
     private var currentElementLength: Int? = null
 
@@ -45,7 +47,7 @@ abstract class Accumulator<in Fragment, in FragmentCollection, Element>(
      * connection's stream and corrupt subsequent message parsing.
      */
     fun reset() {
-        fragmentCollection = initialFragmentCollection
+        fragmentCollection = initialFragmentCollection()
         currentElementLength = null
     }
 

--- a/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/accumulator/ByteArrayAccumulator.kt
+++ b/fingerprint/infra/scanner/src/main/java/com/simprints/fingerprint/infra/scanner/v2/tools/accumulator/ByteArrayAccumulator.kt
@@ -14,7 +14,7 @@ abstract class ByteArrayAccumulator<in Fragment, Element>(
     computeElementLength: (ByteArray) -> Int,
     buildElement: (ByteArray) -> Element,
 ) : Accumulator<Fragment, ByteArray, Element>(
-        byteArrayOf(),
+        { byteArrayOf() },
         { fragment -> this + fragmentAsByteArray(fragment) },
         canComputeElementLength,
         computeElementLength,

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/MainMessageInputStreamTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/MainMessageInputStreamTest.kt
@@ -24,6 +24,7 @@ import com.simprints.fingerprint.infra.scanner.v2.tools.primitives.hexToByteArra
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -41,9 +42,9 @@ class MainMessageInputStreamTest {
         justRun { connect(any()) }
         justRun { disconnect() }
     }
-    private val veroResponseAccumulator = VeroResponseAccumulator(VeroResponseParser())
-    private val veroEventAccumulator = VeroEventAccumulator(VeroEventParser())
-    private val un20ResponseAccumulator = Un20ResponseAccumulator(Un20ResponseParser())
+    private val veroResponseAccumulator = spyk(VeroResponseAccumulator(VeroResponseParser()))
+    private val veroEventAccumulator = spyk(VeroEventAccumulator(VeroEventParser()))
+    private val un20ResponseAccumulator = spyk(Un20ResponseAccumulator(Un20ResponseParser()))
     private lateinit var messageInputStream: MainMessageInputStream
 
     @Before
@@ -207,6 +208,26 @@ class MainMessageInputStreamTest {
         verify {
             packetRouter.disconnect()
         }
+    }
+
+    @Test
+    fun messageInputStream_disconnect_resetsAllMessageAccumulators() = runTest {
+        val routes = mapOf(
+            VeroServer as Route to emptyFlow<Packet>(),
+            VeroEvent as Route to emptyFlow(),
+            Un20Server as Route to emptyFlow(),
+        )
+
+        every { packetRouter.incomingPacketRoutes } returns routes
+        justRun { packetRouter.disconnect() }
+        messageInputStream.connect(mockk())
+        messageInputStream.disconnect()
+
+        // Resetting prevents partial bytes received before the disconnect from corrupting
+        // subsequent message parsing once the channel is reconnected.
+        verify { veroResponseAccumulator.reset() }
+        verify { veroEventAccumulator.reset() }
+        verify { un20ResponseAccumulator.reset() }
     }
 
     private suspend fun MutableSharedFlow<Packet>.emitAll(

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/packet/PacketRouterTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/main/packet/PacketRouterTest.kt
@@ -5,6 +5,8 @@ import com.simprints.fingerprint.infra.scanner.testtools.randomPacketWithSource
 import com.simprints.fingerprint.infra.scanner.v2.domain.main.packet.Route
 import com.simprints.fingerprint.infra.scanner.v2.tools.lang.objects
 import com.simprints.testtools.common.syntax.failTest
+import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
@@ -15,14 +17,16 @@ import org.junit.Before
 import org.junit.Test
 
 class PacketRouterTest {
+    private lateinit var byteArrayToPacketAccumulator: ByteArrayToPacketAccumulator
     private lateinit var router: PacketRouter
 
     @Before
     fun setUp() {
+        byteArrayToPacketAccumulator = spyk(ByteArrayToPacketAccumulator(PacketParser()))
         router = PacketRouter(
             Route.Remote::class.objects(),
             { source },
-            ByteArrayToPacketAccumulator(PacketParser()),
+            byteArrayToPacketAccumulator,
             Dispatchers.IO,
         )
     }
@@ -55,6 +59,15 @@ class PacketRouterTest {
 
         // Assert job  is cancelled
         assertThat(router.packetProcessingJob?.isCancelled).isTrue()
+    }
+
+    @Test
+    fun `disconnect resets the packet accumulator so stale bytes do not leak across reconnects`() = runTest {
+        router.connect(flowOf(byteArrayOf(0x01, 0x02)))
+
+        router.disconnect()
+
+        verify { byteArrayToPacketAccumulator.reset() }
     }
 
     @Test

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/root/RootMessageInputStreamTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/incoming/root/RootMessageInputStreamTest.kt
@@ -4,6 +4,8 @@ import com.google.common.truth.Truth.assertThat
 import com.simprints.fingerprint.infra.scanner.v2.domain.root.responses.EnterMainModeResponse
 import com.simprints.fingerprint.infra.scanner.v2.tools.primitives.chunked
 import com.simprints.fingerprint.infra.scanner.v2.tools.primitives.hexToByteArray
+import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emitAll
@@ -12,7 +14,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class RootMessageInputStreamTest {
-    private val rootMessageAccumulator = RootResponseAccumulator(RootResponseParser())
+    private val rootMessageAccumulator = spyk(RootResponseAccumulator(RootResponseParser()))
     private val rootMessageInputStream = RootMessageInputStream(rootMessageAccumulator)
 
     @Test
@@ -50,5 +52,16 @@ class RootMessageInputStreamTest {
         val testResponseSubscriber =
             rootMessageInputStream.receiveResponse<EnterMainModeResponse>()
         assertThat(testResponseSubscriber).isInstanceOf(expectedResponse::class.java)
+    }
+
+    @Test
+    fun rootMessageInputStream_disconnect_resetsAccumulator() = runTest {
+        rootMessageInputStream.connect(MutableSharedFlow())
+
+        rootMessageInputStream.disconnect()
+
+        // Resetting prevents partial bytes received before the disconnect from corrupting
+        // subsequent message parsing once the channel is reconnected.
+        verify { rootMessageAccumulator.reset() }
     }
 }

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/tools/accumulator/AccumulatorTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/tools/accumulator/AccumulatorTest.kt
@@ -52,7 +52,7 @@ class AccumulatorTest {
 
     class StringAccumulator :
         Accumulator<String, String, String>(
-            initialFragmentCollection = "",
+            initialFragmentCollection = { "" },
             addFragmentToCollection = { this + it },
             canComputeElementLengthFromCollection = { it.length >= LENGTH_INDICES.count() },
             computeElementLengthFromCollection = ::computeLength,

--- a/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/tools/accumulator/AccumulatorTest.kt
+++ b/fingerprint/infra/scanner/src/test/java/com/simprints/fingerprint/infra/scanner/v2/tools/accumulator/AccumulatorTest.kt
@@ -33,6 +33,23 @@ class AccumulatorTest {
         assertThat(result.toList()).containsExactlyElementsIn(strings).inOrder()
     }
 
+    @Test
+    fun accumulator_resetAfterPartialElement_subsequentElementsAreCorrect() = runTest {
+        val accumulator = StringAccumulator()
+
+        // Feed a partial element header that announces a 28-byte element but only supply a few
+        // bytes. Without a reset the partial header would corrupt any later element parsing.
+        accumulator.updateWithNewFragment("28abc")
+        assertThat(accumulator.takeElements().toList()).isEmpty()
+
+        accumulator.reset()
+
+        // After reset, accumulating a fresh complete element should produce exactly that element,
+        // with no contamination from the partial bytes received before reset.
+        accumulator.updateWithNewFragment("05xyz")
+        assertThat(accumulator.takeElements().toList()).containsExactly("05xyz")
+    }
+
     class StringAccumulator :
         Accumulator<String, String, String>(
             initialFragmentCollection = "",


### PR DESCRIPTION
…ver bytes from corrupting parsing on next connection

[JIRA ticket](https://simprints.atlassian.net/browse/MS-1444)
Will be released in: **2026.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **since forever**

* See ticket for reproduction steps
* What happens upon timeout is that the Accumulator's buffer is not cleared so there are some leftover bytes from the previous connection when a new one is established. This leads to parsing errors that then lead to consistent timeouts and reconnections. Since the whole thing is a singleton, the only way to recover is to kill the app.

### Notable changes

* Added an explicit reset in the Accumulator that is called upon disconnect. This should be safe since there is no use case where we want state preservation through reconnects.

### Testing guidance

* Test a few normal/happy paths
* Check out the ticket for reproduction steps of the bug

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
