### PR TITLE
[MS-1448] Separate upsync and downsync worker chains

### DIFF
--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorker.kt
@@ -84,14 +84,15 @@ class EventSyncMasterWorker @AssistedInject internal constructor(
             if (!isSyncRunning()) {
                 val startSyncReporterWorker =
                     eventSyncSubMasterWorkersBuilder.buildStartSyncReporterWorker(uniqueSyncId)
-                val workerChain = mutableListOf<OneTimeWorkRequest>()
+                val upSyncChain = mutableListOf<OneTimeWorkRequest>()
+                val downSyncChain = mutableListOf<OneTimeWorkRequest>()
                 if (configuration.canSyncDataToSimprints()) {
                     eventRepository.createEventScope(
                         EventScopeType.UP_SYNC,
                         upSyncWorkerScopeId,
                     )
 
-                    workerChain += upSyncWorkerBuilder
+                    upSyncChain += upSyncWorkerBuilder
                         .buildUpSyncWorkerChain(
                             uniqueSyncId,
                             upSyncWorkerScopeId,
@@ -110,7 +111,7 @@ class EventSyncMasterWorker @AssistedInject internal constructor(
                         downSyncWorkerScopeId,
                     )
 
-                    workerChain += simprintsDownSyncWorkerBuilder
+                    downSyncChain += simprintsDownSyncWorkerBuilder
                         .buildDownSyncWorkerChain(
                             uniqueSyncId,
                             downSyncWorkerScopeId,
@@ -121,7 +122,7 @@ class EventSyncMasterWorker @AssistedInject internal constructor(
                         downSyncWorkerScopeId,
                     )
 
-                    workerChain += commCareDownSyncWorkerBuilder
+                    downSyncChain += commCareDownSyncWorkerBuilder
                         .buildDownSyncWorkerChain(
                             uniqueSyncId,
                             downSyncWorkerScopeId,
@@ -135,11 +136,10 @@ class EventSyncMasterWorker @AssistedInject internal constructor(
                         upSyncWorkerScopeId,
                     )
 
-                wm
-                    .beginWith(startSyncReporterWorker)
-                    .then(workerChain)
-                    .then(endSyncReporterWorker)
-                    .enqueue()
+                var chain = wm.beginWith(startSyncReporterWorker)
+                if (upSyncChain.isNotEmpty()) chain = chain.then(upSyncChain)
+                if (downSyncChain.isNotEmpty()) chain = chain.then(downSyncChain)
+                chain.then(endSyncReporterWorker).enqueue()
 
                 eventSyncCache.clearProgresses()
 

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorkerTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorkerTest.kt
@@ -58,7 +58,16 @@ internal class EventSyncMasterWorkerTest {
     private val ctx: Context = getApplicationContext()
 
     @MockK
-    lateinit var workContinuation: WorkContinuation
+    lateinit var continuationAfterStart: WorkContinuation
+
+    @MockK
+    lateinit var continuationAfterUp: WorkContinuation
+
+    @MockK
+    lateinit var continuationAfterDown: WorkContinuation
+
+    @MockK
+    lateinit var continuationAfterEnd: WorkContinuation
 
     @MockK
     lateinit var workManager: WorkManager
@@ -126,17 +135,39 @@ internal class EventSyncMasterWorkerTest {
         workManager = spyk(WorkManager.getInstance(ctx))
         mockkObject(WorkManager.Companion)
 
-        every { workContinuation.then(any<OneTimeWorkRequest>()) } returns workContinuation
-        every { workContinuation.then(any<List<OneTimeWorkRequest>>()) } returns workContinuation
-        every { workManager.beginWith(any<OneTimeWorkRequest>()) } returns workContinuation
         every { WorkManager.getInstance(ctx) } returns workManager
 
-        coEvery { simprintsDownSyncWorkerBuilder.buildDownSyncWorkerChain(any(), any()) } returns listOf(
-            simprintsDownSyncWorker,
-        )
-        coEvery { commCareDownSyncWorkerBuilder.buildDownSyncWorkerChain(any(), any()) } returns listOf(
-            commCareDownSyncWorker,
-        )
+        every { workManager.beginWith(startSyncReporterWorker) } returns continuationAfterStart
+
+        every { continuationAfterStart.then(match<List<OneTimeWorkRequest>> { it.contains(upSyncWorker) }) } returns continuationAfterUp
+
+        every {
+            continuationAfterStart.then(
+                match<List<OneTimeWorkRequest>> {
+                    it.contains(simprintsDownSyncWorker) || it.contains(
+                        commCareDownSyncWorker,
+                    )
+                },
+            )
+        } returns continuationAfterDown
+        every {
+            continuationAfterUp.then(
+                match<List<OneTimeWorkRequest>> {
+                    it.contains(simprintsDownSyncWorker) || it.contains(
+                        commCareDownSyncWorker,
+                    )
+                },
+            )
+        } returns continuationAfterDown
+
+        every { continuationAfterStart.then(endSyncReporterWorker) } returns continuationAfterEnd
+        every { continuationAfterUp.then(endSyncReporterWorker) } returns continuationAfterEnd
+        every { continuationAfterDown.then(endSyncReporterWorker) } returns continuationAfterEnd
+
+        every { continuationAfterEnd.enqueue() } returns mockk(relaxed = true)
+
+        coEvery { simprintsDownSyncWorkerBuilder.buildDownSyncWorkerChain(any(), any()) } returns listOf(simprintsDownSyncWorker)
+        coEvery { commCareDownSyncWorkerBuilder.buildDownSyncWorkerChain(any(), any()) } returns listOf(commCareDownSyncWorker)
         coEvery { upSyncWorkerBuilder.buildUpSyncWorkerChain(any(), any()) } returns listOf(upSyncWorker)
         every { eventSyncSubMasterWorkersBuilder.buildStartSyncReporterWorker(any()) } returns startSyncReporterWorker
         every { eventSyncSubMasterWorkersBuilder.buildEndSyncReporterWorker(any(), any(), any()) } returns endSyncReporterWorker
@@ -218,6 +249,13 @@ internal class EventSyncMasterWorkerTest {
         assertUpSyncWorkerPresence(true, uniqueSyncId)
         assertSimprintsDownSyncWorkerPresence(false, uniqueSyncId)
         assertWorkerChainBuild(true, uniqueSyncId)
+
+        verifyOrder {
+            workManager.beginWith(startSyncReporterWorker)
+            continuationAfterStart.then(match<List<OneTimeWorkRequest>> { it.contains(upSyncWorker) })
+            continuationAfterUp.then(endSyncReporterWorker)
+            continuationAfterEnd.enqueue()
+        }
     }
 
     @Test
@@ -245,10 +283,17 @@ internal class EventSyncMasterWorkerTest {
         assertUpSyncWorkerPresence(false, uniqueSyncId)
         assertSimprintsDownSyncWorkerPresence(true, uniqueSyncId)
         assertWorkerChainBuild(true, uniqueSyncId)
+
+        verifyOrder {
+            workManager.beginWith(startSyncReporterWorker)
+            continuationAfterStart.then(match<List<OneTimeWorkRequest>> { it.contains(simprintsDownSyncWorker) })
+            continuationAfterDown.then(endSyncReporterWorker)
+            continuationAfterEnd.enqueue()
+        }
     }
 
     @Test
-    fun `doWork should enqueue the down and up sync worker it can sync to BFSID`() = runTest {
+    fun `doWork should enqueue the down and up sync worker it can sync to BFSID sequentially`() = runTest {
         shouldSyncRun(false)
         canDownSyncFromSimprints(true)
         canUpSync(true)
@@ -270,10 +315,18 @@ internal class EventSyncMasterWorkerTest {
         assertUpSyncWorkerPresence(true, uniqueSyncId)
         assertSimprintsDownSyncWorkerPresence(true, uniqueSyncId)
         assertWorkerChainBuild(true, uniqueSyncId)
+
+        verifyOrder {
+            workManager.beginWith(startSyncReporterWorker)
+            continuationAfterStart.then(match<List<OneTimeWorkRequest>> { it.contains(upSyncWorker) })
+            continuationAfterUp.then(match<List<OneTimeWorkRequest>> { it.contains(simprintsDownSyncWorker) })
+            continuationAfterDown.then(endSyncReporterWorker)
+            continuationAfterEnd.enqueue()
+        }
     }
 
     @Test
-    fun `doWork should enqueue the down sync worker if CommCare sync`() = runTest {
+    fun `doWork should enqueue the down sync worker if CommCare sync sequentially`() = runTest {
         shouldSyncRun(false)
         canDownSyncFromCommCare(true)
         canUpSync(true)
@@ -295,6 +348,14 @@ internal class EventSyncMasterWorkerTest {
         assertUpSyncWorkerPresence(true, uniqueSyncId)
         assertCommCareDownSyncWorkerPresence(true, uniqueSyncId)
         assertWorkerChainBuild(true, uniqueSyncId)
+
+        verifyOrder {
+            workManager.beginWith(startSyncReporterWorker)
+            continuationAfterStart.then(match<List<OneTimeWorkRequest>> { it.contains(upSyncWorker) })
+            continuationAfterUp.then(match<List<OneTimeWorkRequest>> { it.contains(commCareDownSyncWorker) })
+            continuationAfterDown.then(endSyncReporterWorker)
+            continuationAfterEnd.enqueue()
+        }
     }
 
     @Test
@@ -401,18 +462,11 @@ internal class EventSyncMasterWorkerTest {
     ) {
         val times = if (isBuilt) 1 else 0
         verify(exactly = times) {
-            eventSyncSubMasterWorkersBuilder.buildStartSyncReporterWorker(
-                uniqueSyncId,
-            )
+            eventSyncSubMasterWorkersBuilder.buildStartSyncReporterWorker(uniqueSyncId)
         }
         verify(exactly = times) {
-            eventSyncSubMasterWorkersBuilder.buildEndSyncReporterWorker(
-                uniqueSyncId,
-                any(),
-                any(),
-            )
+            eventSyncSubMasterWorkersBuilder.buildEndSyncReporterWorker(uniqueSyncId, any(), any())
         }
-        verify(exactly = times) { workManager.beginWith(any<OneTimeWorkRequest>()) }
     }
 
     private fun assertUpSyncWorkerPresence(
@@ -421,13 +475,6 @@ internal class EventSyncMasterWorkerTest {
     ) {
         val times = if (isPresent) 1 else 0
         coVerify(exactly = times) { upSyncWorkerBuilder.buildUpSyncWorkerChain(uniqueSyncId, any()) }
-        verify(exactly = times) {
-            workContinuation.then(
-                match<List<OneTimeWorkRequest>> {
-                    it.contains(upSyncWorker)
-                },
-            )
-        }
     }
 
     private fun assertSimprintsDownSyncWorkerPresence(
@@ -436,13 +483,6 @@ internal class EventSyncMasterWorkerTest {
     ) {
         val times = if (isPresent) 1 else 0
         coVerify(exactly = times) { simprintsDownSyncWorkerBuilder.buildDownSyncWorkerChain(uniqueSyncId, any()) }
-        verify(exactly = times) {
-            workContinuation.then(
-                match<List<OneTimeWorkRequest>> {
-                    it.contains(simprintsDownSyncWorker)
-                },
-            )
-        }
     }
 
     private fun assertCommCareDownSyncWorkerPresence(
@@ -451,12 +491,5 @@ internal class EventSyncMasterWorkerTest {
     ) {
         val times = if (isPresent) 1 else 0
         coVerify(exactly = times) { commCareDownSyncWorkerBuilder.buildDownSyncWorkerChain(uniqueSyncId, any()) }
-        verify(exactly = times) {
-            workContinuation.then(
-                match<List<OneTimeWorkRequest>> {
-                    it.contains(commCareDownSyncWorker)
-                },
-            )
-        }
     }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1448)
Will be released in: **2026.3.0**

### Notable changes

* I moved the creation of the up-sync and down-sync work chain from parallel to sequential execution. 

### Testing guidance

* It is difficult to test manually, but I added unit tests to verify that the execution happens sequentially.


### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
