### PR TITLE
[MS-1397] OcrConfig is no longer 'lateinit'

### DIFF
--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrFragment.kt
@@ -333,7 +333,7 @@ internal class ExternalCredentialScanOcrFragment : Fragment(R.layout.fragment_ex
 
             // Processing frames as often as we can while camera feedback is displayed to the user
             viewModel.imageProcessingStarted()
-            if (viewModel.isScanningInProgress && viewModel.ocrConfig.useHighRes) {
+            if (viewModel.isScanningInProgress && viewModel.ocrConfig?.useHighRes == true) {
                 // For hi-res OCR we don't need the frame and will capture a new image instead
                 videoFrame.close()
                 captureHighResImageForOcr { highResImage ->

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrViewModel.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrViewModel.kt
@@ -79,7 +79,7 @@ internal class ExternalCredentialScanOcrViewModel @AssistedInject constructor(
             .asLiveData(viewModelScope.coroutineContext)
 
     private lateinit var startTime: Timestamp
-    lateinit var ocrConfig: OcrConfig
+    var ocrConfig: OcrConfig? = null
         private set
     private var lightingConditionsAssessmentConfig: LightingConditionsAssessmentConfig? = null
 
@@ -105,12 +105,13 @@ internal class ExternalCredentialScanOcrViewModel @AssistedInject constructor(
     }
 
     fun startScanning() {
+        val captureConfig = ocrConfig ?: return
         startTime = timeHelper.now()
         updateState {
             ScanOcrState.ScanningInProgress(
                 ocrDocumentType = ocrDocumentType,
                 successfulCaptures = 0,
-                scansRequired = ocrConfig.capturesRequired,
+                scansRequired = captureConfig.capturesRequired,
             )
         }
     }
@@ -144,6 +145,7 @@ internal class ExternalCredentialScanOcrViewModel @AssistedInject constructor(
 
                 if (!isOcrAllowed) return@launch
                 val mfidConfig = configRepository.getProjectConfiguration().multifactorId ?: return@launch
+                val captureConfig = ocrConfig ?: return@launch
                 val scannedMfidDocument =
                     scanMfidDocumentUseCase(bitmap = cropped, documentType = ocrDocumentType, config = mfidConfig) ?: return@launch
                 Simber.d("Detected OCR")
@@ -153,7 +155,7 @@ internal class ExternalCredentialScanOcrViewModel @AssistedInject constructor(
                         ScanOcrState.ScanningInProgress(
                             ocrDocumentType = ocrDocumentType,
                             successfulCaptures = scannedMfidDocuments.size,
-                            scansRequired = ocrConfig.capturesRequired,
+                            scansRequired = captureConfig.capturesRequired,
                         )
                     }
                 }


### PR DESCRIPTION
This removes the potential runtime racing condition

[JIRA ticket](https://simprints.atlassian.net/browse/MS-1397)
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.4.1**

`startScanning()` reads `ocrConfig.capturesRequired`, but `ocrConfig` was initially marked as `lateinit`. The value is set asynchronously in `init { viewModelScope.launch { ... } }`. If the scan starts before the config loading completes, this will throw a runtime exception.

### Notable changes

* Making `ocrConfig` field nullable, and checking for null in places of invocation 

### Additional work checklist

* [x] Effect on other features and security has been considered