### PR TITLE
[MS-1449] Ensure CommCare down sync worker respects the isDownSyncAllowed flag

### DIFF
--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorker.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorker.kt
@@ -99,33 +99,35 @@ class EventSyncMasterWorker @AssistedInject internal constructor(
                 }
 
                 val isDownSyncAllowedInWorker = inputData.getBoolean(IS_DOWN_SYNC_ALLOWED, true)
-                if (configuration.isSimprintsEventDownSyncAllowed() && isDownSyncAllowedInWorker) {
-                    // TODO: Remove after all users have updated to 2025.3.0
-                    // In versions before 2025.3.0 a bug prevented single subject down-sync scopes from being closed and uploaded.
-                    // Attempting to close any such scopes and recover at least some of the data.
-                    eventRepository.closeAllOpenScopes(EventScopeType.DOWN_SYNC, null)
+                if (isDownSyncAllowedInWorker) {
+                    if (configuration.isSimprintsEventDownSyncAllowed()) {
+                        // TODO: Remove after all users have updated to 2025.3.0
+                        // In versions before 2025.3.0 a bug prevented single subject down-sync scopes from being closed and uploaded.
+                        // Attempting to close any such scopes and recover at least some of the data.
+                        eventRepository.closeAllOpenScopes(EventScopeType.DOWN_SYNC, null)
 
-                    eventRepository.createEventScope(
-                        EventScopeType.DOWN_SYNC,
-                        downSyncWorkerScopeId,
-                    )
-
-                    workerChain += simprintsDownSyncWorkerBuilder
-                        .buildDownSyncWorkerChain(
-                            uniqueSyncId,
+                        eventRepository.createEventScope(
+                            EventScopeType.DOWN_SYNC,
                             downSyncWorkerScopeId,
-                        ).also { Simber.d("Scheduled ${it.size} Simprints down workers", tag = tag) }
-                } else if (configuration.isCommCareEventDownSyncAllowed()) {
-                    eventRepository.createEventScope(
-                        EventScopeType.DOWN_SYNC,
-                        downSyncWorkerScopeId,
-                    )
+                        )
 
-                    workerChain += commCareDownSyncWorkerBuilder
-                        .buildDownSyncWorkerChain(
-                            uniqueSyncId,
+                        workerChain += simprintsDownSyncWorkerBuilder
+                            .buildDownSyncWorkerChain(
+                                uniqueSyncId,
+                                downSyncWorkerScopeId,
+                            ).also { Simber.d("Scheduled ${it.size} Simprints down workers", tag = tag) }
+                    } else if (configuration.isCommCareEventDownSyncAllowed()) {
+                        eventRepository.createEventScope(
+                            EventScopeType.DOWN_SYNC,
                             downSyncWorkerScopeId,
-                        ).also { Simber.d("Scheduled ${it.size} CommCare down workers", tag = tag) }
+                        )
+
+                        workerChain += commCareDownSyncWorkerBuilder
+                            .buildDownSyncWorkerChain(
+                                uniqueSyncId,
+                                downSyncWorkerScopeId,
+                            ).also { Simber.d("Scheduled ${it.size} CommCare down workers", tag = tag) }
+                    }
                 }
 
                 val endSyncReporterWorker =

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorkerTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/master/EventSyncMasterWorkerTest.kt
@@ -298,6 +298,32 @@ internal class EventSyncMasterWorkerTest {
     }
 
     @Test
+    fun `doWork should not enqueue CommCare down sync worker when isDownSyncAllowed is false`() = runTest {
+        val workerWithDownSyncDisabled = buildMasterWorker(isDownSyncAllowed = false)
+        shouldSyncRun(false)
+        canDownSyncFromCommCare(true)
+        canUpSync(true)
+
+        val uniqueSyncId = workerWithDownSyncDisabled.uniqueSyncId
+        val result = workerWithDownSyncDisabled.doWork()
+
+        assertThat(result).isEqualTo(
+            ListenableWorker.Result.success(
+                workDataOf(
+                    EventSyncMasterWorker.OUTPUT_LAST_SYNC_ID to uniqueSyncId,
+                ),
+            ),
+        )
+
+        coVerify(exactly = 1) { eventSyncCache.clearProgresses() }
+        coVerify(exactly = 1) { eventRepository.createEventScope(EventScopeType.UP_SYNC, any()) }
+        coVerify(exactly = 0) { eventRepository.createEventScope(EventScopeType.DOWN_SYNC, any()) }
+
+        assertUpSyncWorkerPresence(true, uniqueSyncId)
+        assertCommCareDownSyncWorkerPresence(false, uniqueSyncId)
+    }
+
+    @Test
     fun `doWork should not enqueue the workers is one is already running`() = runTest {
         shouldSyncRun(true)
         canDownSyncFromSimprints(true)
@@ -458,5 +484,27 @@ internal class EventSyncMasterWorkerTest {
                 },
             )
         }
+    }
+
+    private fun buildMasterWorker(isDownSyncAllowed: Boolean): EventSyncMasterWorker = spyk(
+        EventSyncMasterWorker(
+            appContext = ctx,
+            params = mockk(relaxed = true) {
+                every { tags } returns setOf(MASTER_SYNC_SCHEDULER_PERIODIC_TIME)
+                every { inputData.getBoolean(EventSyncMasterWorker.IS_DOWN_SYNC_ALLOWED, true) } returns isDownSyncAllowed
+            },
+            simprintsDownSyncWorkerBuilder = simprintsDownSyncWorkerBuilder,
+            commCareDownSyncWorkerBuilder = commCareDownSyncWorkerBuilder,
+            upSyncWorkerBuilder = upSyncWorkerBuilder,
+            configRepository = configRepository,
+            eventSyncCache = eventSyncCache,
+            eventSyncSubMasterWorkersBuilder = eventSyncSubMasterWorkersBuilder,
+            timeHelper = timeHelper,
+            dispatcher = testCoroutineRule.testCoroutineDispatcher,
+            securityManager = securityManager,
+            eventRepository = eventRepository,
+        ),
+    ).also {
+        coEvery { it["showProgressNotification"]() } returns Unit
     }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1449)
Will be released in: **2026.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **very old**

* In EventSyncMasterWorker, the isDownSyncAllowed input flag was correctly guarding Simprints downsync, but the else if branch for CommCare downsync ignored it entirely — so CommCare would always downsync regardless of whether it was allowed (e.g., during logout)

### Notable changes

*  Added && isDownSyncAllowedInWorker to the CommCare condition in EventSyncMasterWorker                                                                                                                 
                                                            

### Testing guidance

* fllow the steps in the jira bug ticket.

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
