### PR TITLE
[MS-1470] Scanning noew checks that there are not enough captures before updating the scanning progress state

### DIFF
--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrViewModel.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrViewModel.kt
@@ -147,7 +147,8 @@ internal class ExternalCredentialScanOcrViewModel @AssistedInject constructor(
                 val scannedMfidDocument =
                     scanMfidDocumentUseCase(bitmap = cropped, documentType = ocrDocumentType, config = mfidConfig) ?: return@launch
                 Simber.d("Detected OCR")
-                if (isScanningInProgress) {
+                val notEnoughCaptures = scannedMfidDocuments.size < ocrConfig.capturesRequired
+                if (isScanningInProgress && notEnoughCaptures) {
                     scannedMfidDocuments += scannedMfidDocument
                     updateState {
                         ScanOcrState.ScanningInProgress(

--- a/feature/external-credential/src/test/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrViewModelTest.kt
+++ b/feature/external-credential/src/test/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrViewModelTest.kt
@@ -326,6 +326,53 @@ internal class ExternalCredentialScanOcrViewModelTest {
     }
 
     @Test
+    fun `processImage does not add documents or update state once required captures are reached`() = runTest {
+        val mockScannedDocument = mockk<ScannedMfidDocument>()
+        val mockNormalizedBitmap = mockk<Bitmap>()
+        val mockCroppedBitmap = mockk<Bitmap>()
+
+        coEvery { normalizeBitmapToPreviewUseCase(bitmap, cropConfig) } returns mockNormalizedBitmap
+        coEvery { cropDocumentFromPreviewUseCase(mockNormalizedBitmap, any()) } returns mockCroppedBitmap
+        coEvery { scanMfidDocumentUseCase(mockCroppedBitmap, documentType, any()) } returns mockScannedDocument
+
+        val observer = viewModel.scanOcrStateLiveData.test()
+        viewModel.startScanning()
+
+        val capturesRequired = (observer.value() as ScanOcrState.ScanningInProgress).scansRequired
+        repeat(capturesRequired) { viewModel.processImage(bitmap, cropConfig) }
+
+        val stateAtCapacity = observer.value() as ScanOcrState.ScanningInProgress
+        assertThat(stateAtCapacity.successfulCaptures).isEqualTo(capturesRequired)
+
+        viewModel.processImage(bitmap, cropConfig)
+
+        assertThat(observer.value()).isEqualTo(stateAtCapacity)
+    }
+
+    @Test
+    fun `processImage emits ScanningInProgress with enough captures exactly once`() = runTest {
+        val mockScannedDocument = mockk<ScannedMfidDocument>()
+        val mockNormalizedBitmap = mockk<Bitmap>()
+        val mockCroppedBitmap = mockk<Bitmap>()
+
+        coEvery { normalizeBitmapToPreviewUseCase(bitmap, cropConfig) } returns mockNormalizedBitmap
+        coEvery { cropDocumentFromPreviewUseCase(mockNormalizedBitmap, any()) } returns mockCroppedBitmap
+        coEvery { scanMfidDocumentUseCase(mockCroppedBitmap, documentType, any()) } returns mockScannedDocument
+
+        val observer = viewModel.scanOcrStateLiveData.test()
+        viewModel.startScanning()
+
+        val capturesRequired = (observer.value() as ScanOcrState.ScanningInProgress).scansRequired
+        repeat(capturesRequired + 2) { viewModel.processImage(bitmap, cropConfig) }
+
+        val completionTriggers = observer
+            .valueHistory()
+            .filterIsInstance<ScanOcrState.ScanningInProgress>()
+            .count { it.successfulCaptures >= it.scansRequired }
+        assertThat(completionTriggers).isEqualTo(1)
+    }
+
+    @Test
     fun `processImage does not append documents or update state after scanning is complete`() = runTest {
         val mockScannedDocument = mockk<ScannedMfidDocument>()
         val mockScannedCredentialResult = mockk<ScannedCredentialResult>()


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1470)
Will be released in: **2026.2.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.2.0**

Sometimes the OCR completion function was called twice due to race condition. We haven't captured this behaviour earlier due to low chance of having the race condition in the first place, but now this is addressed.

### Notable changes

ViewModel now checks if the amount of scans hasn't been reached to avoid calling the completion workflow more than once.

### Testing guidance

Run the standard OCR tests for the NHIS and GhanaID cards multiple times, and verify that there are no runtime crashes.

### Additional work checklist

* [x] Effect on other features and security has been considered