### PR TITLE
Update universal APK download ID key to `generatedUniversalApk`

### DIFF
--- a/.github/scripts/download-universal-apk.py
+++ b/.github/scripts/download-universal-apk.py
@@ -41,8 +41,9 @@ def find_universal_apk_download_id(service, package_name: str, version_code: int
     ).execute()
 
     for apk in result.get("generatedApks", []):
-        if apk.get("universalApk"):
-            return apk["downloadId"]
+        universal = apk.get("generatedUniversalApk")
+        if universal:
+            return universal["downloadId"]
     return None
 
 


### PR DESCRIPTION
The generatedapks.list API response nests the download ID under generatedUniversalApk.downloadId, but the script was checking the non-existent universalApk field, causing the function to always return None and loop until timeout. 