### PR TITLE
Re-add release tagging 

### DIFF
--- a/.github/workflows/reusable-upload-to-internal-and-release.yml
+++ b/.github/workflows/reusable-upload-to-internal-and-release.yml
@@ -74,6 +74,9 @@ jobs:
                 with:
                     name: ${{ inputs.mapping-file }}
 
+            -   name: Create release git tag
+                uses: ./.github/actions/set-release-git-tag
+
             -   name: Create draft GitHub release with universal APK
                 env:
                     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
  Uses .github/actions/set-release-git-tag as a step to create and push the release tag 