### PR TITLE
[MS-1484] MFID: QR codes are no longer required to be confirmed. QR code readouts cannot be edited.

### DIFF
--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/search/ExternalCredentialSearchFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/search/ExternalCredentialSearchFragment.kt
@@ -106,11 +106,12 @@ internal class ExternalCredentialSearchFragment : Fragment(R.layout.fragment_ext
         credentialEditText.inputType = viewModel.getKeyBoardInputType()
         credentialEditText.hint = credentialField
         credentialValue.text = currentEditTextValue
-        confirmCredentialCheckbox.isVisible = state.searchState != SearchState.Searching
+        confirmCredentialCheckbox.isVisible = state.isUserConfirmationRequired && state.searchState != SearchState.Searching
         confirmCredentialCheckbox.text = getString(IDR.string.mfid_confirmation_checkbox_text, credentialField)
         confirmCredentialCheckbox.isChecked = state.isConfirmed && !state.isEditingCredential
         confirmCredentialCheckbox.isEnabled = !state.isEditingCredential
 
+        iconEditCredential.isVisible = state.isEditAvailable
         iconEditCredential.setOnClickListener {
             if (isEditingCredential) {
                 viewModel.confirmCredentialUpdate(updatedCredential = credentialEditText.text.toString().asTokenizableRaw())
@@ -209,7 +210,7 @@ internal class ExternalCredentialSearchFragment : Fragment(R.layout.fragment_ext
         val isSearching = state.searchState != SearchState.Searching
         buttonRecapture.isVisible = isSearching
         buttonConfirm.isVisible = isSearching
-        buttonConfirm.isEnabled = state.isConfirmed && !state.isEditingCredential
+        buttonConfirm.isEnabled = !state.isUserConfirmationRequired || (state.isConfirmed && !state.isEditingCredential)
         viewModel.getButtonTextResource(state.searchState, state.flowType)?.run(buttonConfirm::setText)
         buttonConfirm.setOnClickListener {
             viewModel.finish(state)

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/search/model/SearchCredentialState.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/search/model/SearchCredentialState.kt
@@ -3,6 +3,7 @@ package com.simprints.feature.externalcredential.screens.search.model
 import androidx.annotation.Keep
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
 import com.simprints.core.domain.common.FlowType
+import com.simprints.core.domain.externalcredential.ExternalCredentialType
 import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.feature.externalcredential.model.CredentialMatch
 import kotlin.Boolean
@@ -16,19 +17,31 @@ internal data class SearchCredentialState(
     val searchState: SearchState,
     val isConfirmed: Boolean,
     val isEditingCredential: Boolean,
+    val isUserConfirmationRequired: Boolean,
+    val isEditAvailable: Boolean,
 ) {
     companion object {
         fun buildInitial(
             scannedCredentialResult: ScannedCredentialResult,
             flowType: FlowType,
-        ) = SearchCredentialState(
-            scannedCredentialResult = scannedCredentialResult,
-            displayedCredential = scannedCredentialResult.credential,
-            flowType = flowType,
-            searchState = SearchState.Searching,
-            isConfirmed = false,
-            isEditingCredential = false,
-        )
+        ): SearchCredentialState {
+            // [MS-1484] Editing and confirming the readout value should only be available for the OCR readouts (i.e.: Ghana NHIS card)
+            // QR codes are not readable by humans, hence there is no point of asking the user to confirm the readout, nor to edit the readout
+            val isOcrReadout = when (scannedCredentialResult.credentialType) {
+                ExternalCredentialType.NHISCard, ExternalCredentialType.GhanaIdCard -> true
+                ExternalCredentialType.QRCode -> false
+            }
+            return SearchCredentialState(
+                scannedCredentialResult = scannedCredentialResult,
+                displayedCredential = scannedCredentialResult.credential,
+                flowType = flowType,
+                searchState = SearchState.Searching,
+                isConfirmed = false,
+                isEditingCredential = false,
+                isUserConfirmationRequired = isOcrReadout,
+                isEditAvailable = isOcrReadout,
+            )
+        }
     }
 }
 


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1484)
Will be released in: **2026.2.1**

### Notable changes

* Values of the QR code readouts can no longer be edited
* QR code readouts no longer require checkbox confirmation from the user 
<img width="370" height="817" alt="image" src="https://github.com/user-attachments/assets/f4496c8c-2af9-4c2e-9f5e-64b3f4c0a36c" />


The OCR readouts still have the 'edit' icon and the 'confirmation checkbox' in place
<img width="370" height="817" alt="image" src="https://github.com/user-attachments/assets/c97b726c-54e5-4049-83a1-8db30f0d5c26" />



### Testing guidance

* Enable QR codes in the MFID settings
* Scan the QR code
* Make sure that you can recapture and continue
* Make that confirmation checkbox is hidden
* Make that the edit icon is hidden

### Additional work checklist

* [x] Effect on other features and security has been considered