### PR TITLE
MS-1463 Rename "settings" button to "details" in dashboard sync card

### DIFF
--- a/feature/dashboard/src/main/res/layout/fragment_sync_info.xml
+++ b/feature/dashboard/src/main/res/layout/fragment_sync_info.xml
@@ -80,6 +80,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="@string/sync_info_header_settings_button"
+                        android:textColor="@color/simprints_orange"
                         android:gravity="end"
                         android:clickable="true"
                         android:focusable="true"

--- a/infra/resources/src/main/res/values-am-rET/strings.xml
+++ b/infra/resources/src/main/res/values-am-rET/strings.xml
@@ -331,7 +331,7 @@
     <string name="sync_info_title">የማመሳሰል መረጃ</string>
 
     <string name="sync_info_header_title">የማመሳሰል ሁኔታ</string>
-    <string name="sync_info_header_settings_button"><font fgcolor='#FF7C00'><u> ቅንብሮች</u></font></string>
+    <string name="sync_info_header_settings_button"><u> ቅንብሮች</u></string>
 
     <string name="sync_info_re_login_required">ለማመሳሰል እንደገና መግባት አለብህ</string>
 

--- a/infra/resources/src/main/res/values-am/strings.xml
+++ b/infra/resources/src/main/res/values-am/strings.xml
@@ -331,7 +331,7 @@
     <string name="sync_info_title">የማመሳሰል መረጃ</string>
 
     <string name="sync_info_header_title">የማመሳሰል ሁኔታ</string>
-    <string name="sync_info_header_settings_button"><font fgcolor='#FF7C00'><u> ቅንብሮች</u></font></string>
+    <string name="sync_info_header_settings_button"><u> ቅንብሮች</u></string>
 
     <string name="sync_info_re_login_required">ለማመሳሰል እንደገና መግባት አለብህ</string>
 

--- a/infra/resources/src/main/res/values-bn/strings.xml
+++ b/infra/resources/src/main/res/values-bn/strings.xml
@@ -328,7 +328,7 @@
     <string name="sync_info_title">সিঙ্ক তথ্য</string>
 
     <string name="sync_info_header_title">সিঙ্ক স্ট্যাটাস</string>
-    <string name="sync_info_header_settings_button"><font fgcolor='#FF7C00'><u>সেটিংস</u></font></string>
+    <string name="sync_info_header_settings_button"><u>সেটিংস</u></string>
 
     <string name="sync_info_re_login_required">সিঙ্ক করার জন্য আপনাকে আবার লগ ইন করতে হবে</string>
 

--- a/infra/resources/src/main/res/values-fr/strings.xml
+++ b/infra/resources/src/main/res/values-fr/strings.xml
@@ -329,7 +329,7 @@
     <string name="sync_info_title">Informations sur la synchronisation</string>
 
     <string name="sync_info_header_title">Statut de la synchronisation</string>
-    <string name="sync_info_header_settings_button"><font fgcolor='#FF7C00'><u>Réglages</u></font></string>
+    <string name="sync_info_header_settings_button"><u>Réglages</u></string>
 
     <string name="sync_info_re_login_required">Vous devez vous connecter pour synchroniser.</string>
 

--- a/infra/resources/src/main/res/values-hi/strings.xml
+++ b/infra/resources/src/main/res/values-hi/strings.xml
@@ -324,7 +324,7 @@
     <string name="sync_info_title">सिंक जानकारी</string>
 
     <string name="sync_info_header_title">सिंक स्थिति</string>
-    <string name="sync_info_header_settings_button"><font fgcolor='#FF7C00'><u>सेटिंग्स</u></font></string>
+    <string name="sync_info_header_settings_button"><u>सेटिंग्स</u></string>
 
     <string name="sync_info_re_login_required">सिंक करने के लिए आपको पुनः लॉग इन करना होगा</string>
 

--- a/infra/resources/src/main/res/values-om/strings.xml
+++ b/infra/resources/src/main/res/values-om/strings.xml
@@ -271,7 +271,7 @@
     <string name="sync_info_no_modules_message">Maaloo moojuula sinkii gootuu filadhu</string>
     <string name="sync_info_no_modules_button">Moojula</string>
     <string name="sync_info_offline_message">Maaloo gara mijeessaa internetii keetii deebi\'i</string>
-    <string name="sync_info_header_settings_button"><font fgcolor='#FF7C00'><u>Mijeessaa</u></font></string>
+    <string name="sync_info_header_settings_button"><u>Mijeessaa</u></string>
     <string name="sync_info_last_sync">Yeroo dhumaaf siink kan tahe: %1$s</string>
     <string name="sync_info_records_uploaded">Galmeewwan hundi olkaa\'aman</string>
     <string name="sync_info_button_try_again">Irra deebi\'ii yaali</string>

--- a/infra/resources/src/main/res/values/strings.xml
+++ b/infra/resources/src/main/res/values/strings.xml
@@ -326,7 +326,7 @@
     <string name="sync_info_title">Sync Information</string>
 
     <string name="sync_info_header_title">Sync status</string>
-    <string name="sync_info_header_settings_button"><font fgcolor='#FF7C00'><u>Settings</u></font></string>
+    <string name="sync_info_header_settings_button"><u>Details</u></string>
 
     <string name="sync_info_re_login_required">You need to log in again in order to sync</string>
 


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1463)
Will be released in: **2026.3.0**

### Notable changes

* Renamed "Settings" button in the corner of sync status card to "Details" to avoid confusing it with the actual "Settings" option in the menu.
* Also removed the font color tag from that label as it is better set in TextView

### Testing guidance

* Open the dashboard - check out the text

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
