### PR TITLE
[MS-1485] MFID, "Skip reason" screen rework. Its visibility and contents can be controlled with custom config

### DIFF
--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/controller/ExternalCredentialControllerFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/controller/ExternalCredentialControllerFragment.kt
@@ -77,10 +77,6 @@ internal class ExternalCredentialControllerFragment : Fragment(R.layout.fragment
     private fun initListeners() {
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             when (internalNavController?.currentDestination?.id) {
-                R.id.externalCredentialSearch -> {
-                    internalNavController?.navigate(R.id.externalCredentialSkip)
-                }
-
                 R.id.externalCredentialSkip, R.id.externalCredentialScanQr, R.id.externalCredentialScanOcr -> {
                     internalNavController?.popBackStack()
                 }

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/controller/ExternalCredentialViewModel.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/controller/ExternalCredentialViewModel.kt
@@ -14,6 +14,7 @@ import com.simprints.feature.externalcredential.ExternalCredentialSearchResult
 import com.simprints.feature.externalcredential.model.ExternalCredentialParams
 import com.simprints.feature.externalcredential.usecase.ExternalCredentialEventTrackerUseCase
 import com.simprints.infra.config.store.ConfigRepository
+import com.simprints.infra.config.store.models.experimental
 import com.simprints.infra.events.event.domain.models.ExternalCredentialSelectionEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -28,6 +29,10 @@ internal class ExternalCredentialViewModel @Inject internal constructor(
 ) : ViewModel() {
     private var isInitialized = false
     lateinit var params: ExternalCredentialParams
+        private set
+    var defaultSkipReason: String? = null
+        private set
+    var skipReasonsHideHasNumber: Boolean = false
         private set
     val finishEvent: LiveData<LiveDataEventWithContent<ExternalCredentialSearchResult>>
         get() = _finishEvent
@@ -58,8 +63,11 @@ internal class ExternalCredentialViewModel @Inject internal constructor(
 
         viewModelScope.launch {
             val config = configRepository.getProjectConfiguration()
+            val experimental = config.experimental()
             val allowedExternalCredentials = config.multifactorId?.allowedExternalCredentials.orEmpty()
             _externalCredentialTypes.postValue(allowedExternalCredentials)
+            defaultSkipReason = experimental.mfidDefaultSkipReason
+            skipReasonsHideHasNumber = experimental.mfidSkipReasonsHideHasNumber
         }
     }
 
@@ -79,6 +87,16 @@ internal class ExternalCredentialViewModel @Inject internal constructor(
 
     fun skipOtherReasonChanged(otherText: String?) {
         selectedSkipOtherText = otherText?.ifBlank { null }
+    }
+
+    fun bypassSkipScreen() {
+        selectedSkipOtherText = defaultSkipReason
+        finish(
+            ExternalCredentialSearchResult.Skipped(
+                flowType = params.flowType,
+                skipReason = ExternalCredentialSelectionEvent.SkipReason.OTHER,
+            ),
+        )
     }
 
     private fun updateState(state: (ExternalCredentialState) -> ExternalCredentialState) {

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/search/ExternalCredentialSearchFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/search/ExternalCredentialSearchFragment.kt
@@ -83,9 +83,9 @@ internal class ExternalCredentialSearchFragment : Fragment(R.layout.fragment_ext
         }
     }
 
-    override fun onDestroy() {
+    override fun onDestroyView() {
         dismissDialog()
-        super.onDestroy()
+        super.onDestroyView()
     }
 
     override fun onPause() {

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/search/ExternalCredentialSearchFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/search/ExternalCredentialSearchFragment.kt
@@ -1,11 +1,13 @@
 package com.simprints.feature.externalcredential.screens.search
 
+import android.app.Dialog
 import android.content.Context
 import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.text.TextWatcher
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import androidx.activity.addCallback
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
@@ -30,6 +32,7 @@ import com.simprints.feature.externalcredential.screens.scanocr.usecase.ZoomOnto
 import com.simprints.feature.externalcredential.screens.search.model.ScannedCredentialResult
 import com.simprints.feature.externalcredential.screens.search.model.SearchCredentialState
 import com.simprints.feature.externalcredential.screens.search.model.SearchState
+import com.simprints.feature.externalcredential.view.SkipScanConfirmationDialog
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MULTI_FACTOR_ID
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.uibase.navigation.navigateSafely
@@ -62,6 +65,7 @@ internal class ExternalCredentialSearchFragment : Fragment(R.layout.fragment_ext
     @Inject
     lateinit var zoomOntoCredentialUseCase: ZoomOntoCredentialUseCase
     private var credentialTextWatcher: TextWatcher? = null
+    private var dialog: Dialog? = null
 
     override fun onViewCreated(
         view: View,
@@ -70,11 +74,28 @@ internal class ExternalCredentialSearchFragment : Fragment(R.layout.fragment_ext
         super.onViewCreated(view, savedInstanceState)
         applySystemBarInsets(view)
         initObservers()
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            if (mainViewModel.defaultSkipReason != null) {
+                showSkipConfirmationDialog()
+            } else {
+                findNavController().navigate(R.id.externalCredentialSkip)
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        dismissDialog()
+        super.onDestroy()
     }
 
     override fun onPause() {
         hideKeyboard()
         super.onPause()
+    }
+
+    private fun dismissDialog() {
+        dialog?.dismiss()
+        dialog = null
     }
 
     private fun initObservers() {
@@ -258,6 +279,19 @@ internal class ExternalCredentialSearchFragment : Fragment(R.layout.fragment_ext
         if (!isEditingCredential) {
             hideKeyboard()
         }
+    }
+
+    private fun showSkipConfirmationDialog() {
+        dismissDialog()
+        dialog = SkipScanConfirmationDialog(
+            context = requireContext(),
+            credentialTypes = mainViewModel.externalCredentialTypes.value.orEmpty(),
+            onConfirm = {
+                dismissDialog()
+                mainViewModel.bypassSkipScreen()
+            },
+            onCancel = ::dismissDialog,
+        ).also { it.show() }
     }
 
     private fun hideKeyboard() {

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/select/ExternalCredentialSelectFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/select/ExternalCredentialSelectFragment.kt
@@ -44,9 +44,9 @@ internal class ExternalCredentialSelectFragment : Fragment(R.layout.fragment_ext
         observeChanges()
     }
 
-    override fun onDestroy() {
+    override fun onDestroyView() {
         dismissDialog()
-        super.onDestroy()
+        super.onDestroyView()
     }
 
     private fun dismissDialog() {

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/select/ExternalCredentialSelectFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/select/ExternalCredentialSelectFragment.kt
@@ -3,16 +3,11 @@ package com.simprints.feature.externalcredential.screens.select
 import android.app.Dialog
 import android.os.Bundle
 import android.view.View
-import android.widget.Button
-import android.widget.TextView
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.google.android.material.bottomsheet.BottomSheetBehavior
-import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.simprints.core.domain.externalcredential.ExternalCredentialType
 import com.simprints.feature.externalcredential.R
 import com.simprints.feature.externalcredential.databinding.FragmentExternalCredentialSelectBinding
@@ -22,6 +17,7 @@ import com.simprints.feature.externalcredential.screens.controller.ExternalCrede
 import com.simprints.feature.externalcredential.screens.scanocr.model.OcrDocumentType
 import com.simprints.feature.externalcredential.screens.scanocr.model.asOcrDocumentType
 import com.simprints.feature.externalcredential.screens.select.view.ExternalCredentialTypeAdapter
+import com.simprints.feature.externalcredential.view.SkipScanConfirmationDialog
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
 import com.simprints.infra.logging.Simber
 import com.simprints.infra.uibase.navigation.navigateSafely
@@ -60,17 +56,23 @@ internal class ExternalCredentialSelectFragment : Fragment(R.layout.fragment_ext
 
     private fun initListeners(types: List<ExternalCredentialType>) {
         binding.skipScanning.setOnClickListener {
-            displaySkipScanningConfirmationDialog(
+            dismissDialog()
+            dialog = SkipScanConfirmationDialog(
+                context = requireContext(),
                 credentialTypes = types,
                 onConfirm = {
                     dismissDialog()
-                    findNavController().navigateSafely(
-                        this,
-                        ExternalCredentialSelectFragmentDirections.actionExternalCredentialSelectFragmentToExternalCredentialSkip(),
-                    )
+                    if (mainViewModel.defaultSkipReason != null) {
+                        mainViewModel.bypassSkipScreen()
+                    } else {
+                        findNavController().navigateSafely(
+                            this,
+                            ExternalCredentialSelectFragmentDirections.actionExternalCredentialSelectFragmentToExternalCredentialSkip(),
+                        )
+                    }
                 },
                 onCancel = ::dismissDialog,
-            )
+            ).also { it.show() }
         }
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             binding.skipScanning.performClick()
@@ -125,39 +127,6 @@ internal class ExternalCredentialSelectFragment : Fragment(R.layout.fragment_ext
             this,
             ExternalCredentialSelectFragmentDirections.actionExternalCredentialSelectFragmentToExternalCredentialScanQr(),
         )
-    }
-
-    private fun displaySkipScanningConfirmationDialog(
-        credentialTypes: List<ExternalCredentialType>,
-        onConfirm: () -> Unit,
-        onCancel: () -> Unit,
-    ) {
-        dismissDialog()
-        dialog = BottomSheetDialog(requireContext()).also {
-            val view = layoutInflater
-                .inflate(R.layout.dialog_skip_scan_confirm, null)
-                .also { view ->
-                    val bodyText = view.findViewById<TextView>(R.id.skipDialogBodyText)
-                    val cancelButton = view.findViewById<Button>(R.id.buttonCancel)
-                    val confirmButton = view.findViewById<Button>(R.id.buttonSkip)
-
-                    bodyText.text = resources.getQuantityCredentialString(
-                        id = IDR.string.mfid_skip_scan_dialog_body,
-                        credentialTypes = credentialTypes,
-                        specificCredentialRes = resources.getCredentialTypeRes(credentialTypes.firstOrNull()),
-                        multipleCredentialsRes = IDR.string.mfid_type_any_document,
-                    )
-
-                    confirmButton.setOnClickListener { onConfirm() }
-                    cancelButton.setOnClickListener { onCancel() }
-                }
-            it.setContentView(view)
-            it.setCancelable(true)
-            it.behavior.state = BottomSheetBehavior.STATE_EXPANDED
-            it.behavior.isDraggable = false
-        }
-
-        dialog?.show()
     }
 
     private fun startOcr(ocrDocumentType: OcrDocumentType) {

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/skip/ExternalCredentialSkipFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/skip/ExternalCredentialSkipFragment.kt
@@ -41,6 +41,7 @@ class ExternalCredentialSkipFragment : Fragment(R.layout.fragment_external_crede
     }
 
     private fun initViews(credentialTypes: List<ExternalCredentialType>) = with(binding) {
+        skipReasonHasNumberNoId.isVisible = !mainViewModel.skipReasonsHideHasNumber
         if (credentialTypes.size == 1) {
             val credentialText = resources.getCredentialTypeString(credentialTypes.first())
             mapOf(

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/view/SkipScanConfirmationDialog.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/view/SkipScanConfirmationDialog.kt
@@ -1,0 +1,38 @@
+package com.simprints.feature.externalcredential.view
+
+import android.content.Context
+import android.view.LayoutInflater
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
+import com.simprints.core.domain.externalcredential.ExternalCredentialType
+import com.simprints.feature.externalcredential.databinding.DialogSkipScanConfirmBinding
+import com.simprints.feature.externalcredential.ext.getCredentialTypeRes
+import com.simprints.feature.externalcredential.ext.getQuantityCredentialString
+import com.simprints.infra.resources.R as IDR
+
+@ExcludedFromGeneratedTestCoverageReports("UI class")
+class SkipScanConfirmationDialog(
+    context: Context,
+    credentialTypes: List<ExternalCredentialType>,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+) : BottomSheetDialog(context) {
+    private val binding = DialogSkipScanConfirmBinding.inflate(LayoutInflater.from(context))
+
+    init {
+        setContentView(binding.root)
+        setCancelable(true)
+        behavior.state = BottomSheetBehavior.STATE_EXPANDED
+        behavior.isDraggable = false
+
+        binding.skipDialogBodyText.text = context.resources.getQuantityCredentialString(
+            id = IDR.string.mfid_skip_scan_dialog_body,
+            credentialTypes = credentialTypes,
+            specificCredentialRes = context.resources.getCredentialTypeRes(credentialTypes.firstOrNull()),
+            multipleCredentialsRes = IDR.string.mfid_type_any_document,
+        )
+        binding.buttonSkip.setOnClickListener { onConfirm() }
+        binding.buttonCancel.setOnClickListener { onCancel() }
+    }
+}

--- a/feature/external-credential/src/test/java/com/simprints/feature/externalcredential/screens/controller/ExternalCredentialViewModelTest.kt
+++ b/feature/external-credential/src/test/java/com/simprints/feature/externalcredential/screens/controller/ExternalCredentialViewModelTest.kt
@@ -14,11 +14,13 @@ import com.simprints.feature.externalcredential.model.ExternalCredentialParams
 import com.simprints.feature.externalcredential.screens.search.model.ScannedCredentialResult
 import com.simprints.feature.externalcredential.usecase.ExternalCredentialEventTrackerUseCase
 import com.simprints.infra.config.store.ConfigRepository
+import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration
 import com.simprints.infra.events.event.domain.models.ExternalCredentialSelectionEvent
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -258,6 +260,56 @@ internal class ExternalCredentialViewModelTest {
     }
 
     @Test
+    fun `bypassSkipScreen saves skipped event with OTHER reason and config string as skipOther`() = runTest {
+        val viewModel = setupViewModel(
+            allowedCredentials = listOf(ExternalCredentialType.QRCode),
+            customConfig = mapOf(ExperimentalProjectConfiguration.MFID_DEFAULT_SKIP_REASON to JsonPrimitive("project_reason")),
+        )
+        viewModel.selectionStarted()
+        viewModel.init(createParams(subjectId = "subjectId", flowType = FlowType.IDENTIFY))
+
+        viewModel.bypassSkipScreen()
+
+        coVerify {
+            eventsTracker.saveSkippedEvent(
+                any(),
+                skipReason = ExternalCredentialSelectionEvent.SkipReason.OTHER,
+                skipOther = "project_reason",
+            )
+        }
+        assertThat(
+            viewModel.finishEvent
+                .test()
+                .value()
+                .getContentIfNotHandled(),
+        ).isEqualTo(
+            ExternalCredentialSearchResult.Skipped(
+                flowType = FlowType.IDENTIFY,
+                skipReason = ExternalCredentialSelectionEvent.SkipReason.OTHER,
+            ),
+        )
+    }
+
+    @Test
+    fun `init block reads defaultSkipReason from config`() = runTest {
+        val reason = "reason"
+        val viewModel = setupViewModel(
+            allowedCredentials = emptyList(),
+            customConfig = mapOf(ExperimentalProjectConfiguration.MFID_DEFAULT_SKIP_REASON to JsonPrimitive(reason)),
+        )
+        assertThat(viewModel.defaultSkipReason).isEqualTo(reason)
+    }
+
+    @Test
+    fun `init block reads skipReasonsHideHasNumber flag from config`() = runTest {
+        val viewModel = setupViewModel(
+            allowedCredentials = emptyList(),
+            customConfig = mapOf(ExperimentalProjectConfiguration.MFID_SKIP_REASONS_HIDE_HAS_NUMBER to JsonPrimitive(true)),
+        )
+        assertThat(viewModel.skipReasonsHideHasNumber).isTrue()
+    }
+
+    @Test
     fun `init block loads allowed external credentials from config`() = runTest {
         val allowedCredentials = listOf(
             ExternalCredentialType.NHISCard,
@@ -275,11 +327,15 @@ internal class ExternalCredentialViewModelTest {
         assertThat(observer.value()).isEmpty()
     }
 
-    private fun setupViewModel(allowedCredentials: List<ExternalCredentialType>): ExternalCredentialViewModel {
+    private fun setupViewModel(
+        allowedCredentials: List<ExternalCredentialType>,
+        customConfig: Map<String, kotlinx.serialization.json.JsonElement>? = null,
+    ): ExternalCredentialViewModel {
         coEvery { configRepository.getProjectConfiguration() } returns mockk {
             every { multifactorId } returns mockk {
                 every { allowedExternalCredentials } returns allowedCredentials
             }
+            every { custom } returns customConfig
         }
         return ExternalCredentialViewModel(
             configRepository = configRepository,

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
@@ -2,6 +2,7 @@ package com.simprints.infra.config.store.models
 
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
@@ -179,6 +180,20 @@ data class ExperimentalProjectConfiguration(
             ?.booleanOrNull
             .let { it == true }
 
+    val mfidDefaultSkipReason: String?
+        get() = customConfig
+            ?.get(MFID_DEFAULT_SKIP_REASON)
+            ?.jsonPrimitive
+            ?.contentOrNull
+            ?.takeIf { it.isNotEmpty() }
+
+    val mfidSkipReasonsHideHasNumber: Boolean
+        get() = customConfig
+            ?.get(MFID_SKIP_REASONS_HIDE_HAS_NUMBER)
+            ?.jsonPrimitive
+            ?.booleanOrNull
+            .let { it == true }
+
     companion object {
         internal const val ENABLE_ID_POOL_VALIDATION = "validateIdentificationPool"
         internal const val SINGLE_GOOD_QUALITY_FALLBACK_REQUIRED = "singleQualityFallbackRequired"
@@ -240,5 +255,8 @@ data class ExperimentalProjectConfiguration(
         const val MINIMUM_FREE_SPACE_MB_DEFAULT = 1024 // 1GB
 
         const val USE_BALANCED_LOCATION_ACCURACY = "useBalancedLocationAccuracy"
+
+        const val MFID_DEFAULT_SKIP_REASON = "mfidDefaultSkipReason"
+        const val MFID_SKIP_REASONS_HIDE_HAS_NUMBER = "mfidSkipReasonsHideHasNumber"
     }
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
@@ -388,16 +388,14 @@ internal class ExperimentalProjectConfigurationTest {
         assertThat(ExperimentalProjectConfiguration(emptyMap()).mfidDefaultSkipReason).isNull()
         assertThat(
             ExperimentalProjectConfiguration(
-                mapOf(ExperimentalProjectConfiguration.MFID_DEFAULT_SKIP_REASON to JsonPrimitive(true)),
+                mapOf(ExperimentalProjectConfiguration.MFID_DEFAULT_SKIP_REASON to JsonPrimitive("")),
             ).mfidDefaultSkipReason,
         ).isNull()
         assertThat(
             ExperimentalProjectConfiguration(
                 mapOf(ExperimentalProjectConfiguration.MFID_DEFAULT_SKIP_REASON to JsonPrimitive("project_reason")),
             ).mfidDefaultSkipReason,
-        ).isEqualTo(
-            "project_reason",
-        )
+        ).isEqualTo("project_reason")
     }
 
     @Test

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
@@ -382,4 +382,33 @@ internal class ExperimentalProjectConfigurationTest {
             assertThat(ExperimentalProjectConfiguration(config).useBalancedLocationAccuracy).isEqualTo(result)
         }
     }
+
+    @Test
+    fun `check mfid default skip reason parsed correctly`() {
+        assertThat(ExperimentalProjectConfiguration(emptyMap()).mfidDefaultSkipReason).isNull()
+        assertThat(
+            ExperimentalProjectConfiguration(
+                mapOf(ExperimentalProjectConfiguration.MFID_DEFAULT_SKIP_REASON to JsonPrimitive(true)),
+            ).mfidDefaultSkipReason,
+        ).isNull()
+        assertThat(
+            ExperimentalProjectConfiguration(
+                mapOf(ExperimentalProjectConfiguration.MFID_DEFAULT_SKIP_REASON to JsonPrimitive("project_reason")),
+            ).mfidDefaultSkipReason,
+        ).isEqualTo(
+            "project_reason",
+        )
+    }
+
+    @Test
+    fun `check mfid skip reasons hide has number flag parsed correctly`() {
+        mapOf(
+            emptyMap<String, JsonElement>() to false,
+            mapOf(ExperimentalProjectConfiguration.MFID_SKIP_REASONS_HIDE_HAS_NUMBER to JsonPrimitive(1)) to false,
+            mapOf(ExperimentalProjectConfiguration.MFID_SKIP_REASONS_HIDE_HAS_NUMBER to JsonPrimitive(false)) to false,
+            mapOf(ExperimentalProjectConfiguration.MFID_SKIP_REASONS_HIDE_HAS_NUMBER to JsonPrimitive(true)) to true,
+        ).forEach { (config, result) ->
+            assertThat(ExperimentalProjectConfiguration(config).mfidSkipReasonsHideHasNumber).isEqualTo(result)
+        }
+    }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1485)
Will be released in: **2026.2.1**

### Notable changes
#### 1. Controlling visibility of GG2-specific MFID skip reason with the `mfidSkipReasonsHideHasNumber` flag
`mfidSkipReasonsHideHasNumber` is a boolean flag with `false` as default value. When set to `true`, [HAS_NUMBER_NO_ID](https://github.com/Simprints/Android-Simprints-ID/blob/843564af18c1e1b208f32f27c0d0e02e7dce5027/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ExternalCredentialSelectionEvent.kt#L85) (_"Has number, no document (Booklet)"_) reason is hidden. The remaining 7 reasons are shown.

_mfidSkipReasonsHideHasNumber = true_
<img width="210" height="450" alt="skip-screen-hide-gg2" src="https://github.com/user-attachments/assets/8a88f935-7b94-4dad-b8c4-d188e6bde03b" />

_mfidSkipReasonsHideHasNumber = false_
<img width="210" height="450" alt="image" src="https://github.com/user-attachments/assets/313cdeb2-96bb-4936-97f4-c1bb49bfb2a7" />

#### 2. "Skip Reason" screen can be bypassed with the `mfidDefaultSkipReason` string 
This flag specifies the default MFID skip reason. If not empty, the "Skip Reason" screen is bypassed within the MFID flow, and [ExternalCredentialSelectionEvent](https://github.com/Simprints/Android-Simprints-ID/blob/main/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ExternalCredentialSelectionEvent.kt) is saved with `skipReason = “OTHER”` and `skipOther=flag-value`

- Video, Current MFID skip default behaviour: [`mfidDefaultSkipReason=null`](https://github.com/user-attachments/assets/7ca49314-af12-43c9-ac28-4ebd5eb22122). 

- Video, "Skip Screen" is bypassed from the credential selection screen: [`mfidDefaultSkipReason="Test MFID Default Skip Reason"`](https://github.com/user-attachments/assets/95698007-4afb-489e-bb0f-c661d2b60613)

- Video, "Skip Screen" is bypassed from the credential search results screen: [`_mfidDefaultSkipReason="Test MFID Default Skip Reason"`](https://github.com/user-attachments/assets/2587db2a-8044-4486-971b-676ad3dddba3)

In both cases the [ExternalCredentialSelectionEvent](https://github.com/Simprints/Android-Simprints-ID/blob/main/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/ExternalCredentialSelectionEvent.kt) is saved with `skipReason = “OTHER”` and `skipOther=Test MFID Default Skip Reason`.
<img width="361" height="392" alt="image" src="https://github.com/user-attachments/assets/5a0e1f47-cd06-4bb7-a7d2-0eac7cd5bb9f" />

### Testing guidance

Test the behaviour of the "Skip Reason" screen using these flags in your custom project configuration:
```
{"mfidDefaultSkipReason":"anything","mfidSkipReasonsHideHasNumber":true}
```

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
