### PR TITLE
MS-1491 Spoof check implementation

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/models/FaceDetection.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/models/FaceDetection.kt
@@ -3,6 +3,7 @@ package com.simprints.face.capture.models
 import android.graphics.Bitmap
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.face.infra.basebiosdk.detection.Face
+import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
 import com.simprints.infra.images.model.SecuredImageRef
 import java.util.UUID
 
@@ -16,6 +17,7 @@ internal data class FaceDetection(
     var isFallback: Boolean = false,
     var id: String = UUID.randomUUID().toString(),
     var detectionEndTime: Timestamp,
+    var spoofCheckResult: SpoofCheckResult? = null,
 ) {
     enum class Status {
         VALID,

--- a/face/capture/src/main/java/com/simprints/face/capture/models/FaceDetection.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/models/FaceDetection.kt
@@ -7,6 +7,7 @@ import com.simprints.infra.images.model.SecuredImageRef
 import java.util.UUID
 
 internal data class FaceDetection(
+    val original: Bitmap,
     val bitmap: Bitmap,
     val face: Face?,
     val status: Status,

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/CropToTargetOverlayAnalyzer.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/CropToTargetOverlayAnalyzer.kt
@@ -11,10 +11,10 @@ internal class CropToTargetOverlayAnalyzer(
     private val previewRect: RectF,
     private val overlayWidth: Int,
     private val overlayHeight: Int,
-    private val onImageCropped: (Bitmap) -> Unit,
+    private val onImageCropped: (original: Bitmap, cropped: Bitmap) -> Unit,
 ) : ImageAnalysis.Analyzer {
     override fun analyze(image: ImageProxy) {
-        val croppedBitmap = image.use {
+        val (originalBitmap, croppedBitmap) = image.use {
             if (previewRect.isEmpty) return
 
             // Adjust overlay size to be fit-center with the image size
@@ -37,7 +37,7 @@ internal class CropToTargetOverlayAnalyzer(
             val cropTop = offsetY + (previewRect.top * scale).toInt()
             val cropHeight = (previewRect.height() * scale).toInt()
 
-            Bitmap.createBitmap(
+            image.toBitmap() to Bitmap.createBitmap(
                 it.toBitmap(),
                 cropLeft,
                 cropTop,
@@ -45,7 +45,7 @@ internal class CropToTargetOverlayAnalyzer(
                 cropHeight,
             )
         }
-        onImageCropped(croppedBitmap)
+        onImageCropped(originalBitmap, croppedBitmap)
     }
 
     private fun getSmallerRatio(

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/CropToTargetOverlayAnalyzer.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/CropToTargetOverlayAnalyzer.kt
@@ -37,8 +37,9 @@ internal class CropToTargetOverlayAnalyzer(
             val cropTop = offsetY + (previewRect.top * scale).toInt()
             val cropHeight = (previewRect.height() * scale).toInt()
 
-            image.toBitmap() to Bitmap.createBitmap(
-                it.toBitmap(),
+            val imageBitmap = it.toBitmap()
+            imageBitmap to Bitmap.createBitmap(
+                imageBitmap,
                 cropLeft,
                 cropTop,
                 cropWidth,

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -181,7 +181,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
             previewRect = RectF(binding.captureOverlay.circleRect), // create a new instance to avoid threading issues
             overlayWidth = binding.captureOverlay.width,
             overlayHeight = binding.captureOverlay.height,
-            onImageCropped = ::analyze,
+            onImageCropped = { original, cropped -> analyze(original, cropped) },
         )
 
         imageAnalyzer.setAnalyzer(cameraExecutor, cropAnalyzer)
@@ -274,9 +274,12 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
         }
     }
 
-    private fun analyze(image: Bitmap) {
+    private fun analyze(
+        original: Bitmap,
+        cropped: Bitmap,
+    ) {
         try {
-            vm.process(croppedBitmap = image)
+            vm.process(originalBitmap = original, croppedBitmap = cropped)
         } catch (t: Throwable) {
             Simber.e("Image analysis crashed", t, tag = FACE_CAPTURE)
             // Image analysis is running in bg thread

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -21,6 +21,7 @@ import androidx.camera.lifecycle.awaitInstance
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.view.isGone
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -263,6 +264,8 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
             when (it) {
                 LiveFeedbackFragmentViewModel.CapturingState.NOT_STARTED -> renderCaptureNotStarted()
                 LiveFeedbackFragmentViewModel.CapturingState.CAPTURING -> renderCapturing()
+                LiveFeedbackFragmentViewModel.CapturingState.VALIDATING -> renderValidating()
+                LiveFeedbackFragmentViewModel.CapturingState.VALIDATION_FAILED -> renderResetAfterValidation()
                 LiveFeedbackFragmentViewModel.CapturingState.FINISHED -> {
                     mainVm.captureFinished(vm.sortedQualifyingCaptures)
                     findNavController().navigateSafely(
@@ -312,6 +315,8 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
             }
 
             captureOverlay.drawSemiTransparentTarget()
+            captureFeedbackTxtExplanation.setTextColor(ContextCompat.getColor(requireContext(), IDR.color.simprints_text_white))
+
             captureFeedbackBtn.isVisible = true
             captureFeedbackPermissionButton.isGone = true
             setManualCaptureButtonClickable(false)
@@ -321,15 +326,37 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
     private fun renderCapturing() {
         binding.apply {
             captureOverlay.drawWhiteTarget()
-            captureFeedbackTxtExplanation.setTextColor(
-                ContextCompat.getColor(requireContext(), IDR.color.simprints_blue_grey),
-            )
+            captureFeedbackTxtExplanation.setTextColor(ContextCompat.getColor(requireContext(), IDR.color.simprints_blue_grey))
 
             captureProgress.isVisible = true
             captureFeedbackBtn.setText(IDR.string.face_capture_prep_begin_button_capturing)
             captureFeedbackBtn.isVisible = true
             captureFeedbackPermissionButton.isGone = true
             setManualCaptureButtonClickable(false)
+        }
+    }
+
+    private fun renderValidating() {
+        binding.apply {
+            captureOverlay.drawWhiteTarget()
+            captureFeedbackTxtExplanation.setTextColor(ContextCompat.getColor(requireContext(), IDR.color.simprints_blue_grey))
+
+            captureProgress.isInvisible = true
+            captureFeedbackBtn.setText(IDR.string.face_capture_title_validating)
+            captureFeedbackBtn.setCheckedWithLeftDrawable(false)
+            setManualCaptureButtonClickable(false)
+
+            captureFeedbackTxtExplanation.isVisible = false
+        }
+    }
+
+    private fun renderResetAfterValidation() {
+        binding.apply {
+            captureProgress.isInvisible = true
+            captureFeedbackBtn.setText(IDR.string.face_capture_title_validating_failed)
+
+            captureFeedbackTxtExplanation.isVisible = true
+            captureFeedbackTxtExplanation.setText(IDR.string.face_capture_error_validating_failed)
         }
     }
 

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -79,6 +79,9 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
     private val defaultCaptureProgressColor: Int
         get() = ContextCompat.getColor(requireContext(), IDR.color.simprints_blue_grey_light)
 
+    private val validationProgressColor: Int
+        get() = ContextCompat.getColor(requireContext(), IDR.color.simprints_orange)
+
     private val launchPermissionRequest = registerForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) { granted ->
@@ -256,6 +259,10 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
     }
 
     private fun bindViewModel() {
+        vm.progressBarValue.observe(viewLifecycleOwner) {
+            binding.captureProgress.value = it
+        }
+
         vm.currentDetection.observe(viewLifecycleOwner) {
             renderCurrentDetection(it)
         }
@@ -293,6 +300,10 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
     }
 
     private fun renderCurrentDetection(faceDetection: FaceDetection) {
+        if (vm.isAutoCapture && vm.capturingState.value != LiveFeedbackFragmentViewModel.CapturingState.CAPTURING) {
+            return
+        }
+
         when (faceDetection.status) {
             FaceDetection.Status.NOFACE -> renderNoFace()
             FaceDetection.Status.OFFYAW -> renderFaceNotStraight()
@@ -310,6 +321,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
             if (vm.isAutoCapture) {
                 captureFeedbackBtn.setText(IDR.string.face_capture_start_capture)
                 captureFeedbackBtn.isChecked = true
+                captureFeedbackBtn.isClickable = true
             } else {
                 captureFeedbackBtn.setText(IDR.string.face_capture_title_previewing)
             }
@@ -319,7 +331,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
 
             captureFeedbackBtn.isVisible = true
             captureFeedbackPermissionButton.isGone = true
-            setManualCaptureButtonClickable(false)
+            captureFeedbackTxtExplanation.isGone = true
         }
     }
 
@@ -327,6 +339,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
         binding.apply {
             captureOverlay.drawWhiteTarget()
             captureFeedbackTxtExplanation.setTextColor(ContextCompat.getColor(requireContext(), IDR.color.simprints_blue_grey))
+            captureFeedbackTxtExplanation.isVisible = true
 
             captureProgress.isVisible = true
             captureFeedbackBtn.setText(IDR.string.face_capture_prep_begin_button_capturing)
@@ -339,9 +352,10 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
     private fun renderValidating() {
         binding.apply {
             captureOverlay.drawWhiteTarget()
-            captureFeedbackTxtExplanation.setTextColor(ContextCompat.getColor(requireContext(), IDR.color.simprints_blue_grey))
 
-            captureProgress.isInvisible = true
+            captureProgress.progressColor = validationProgressColor
+            captureProgress.isVisible = true
+
             captureFeedbackBtn.setText(IDR.string.face_capture_title_validating)
             captureFeedbackBtn.setCheckedWithLeftDrawable(false)
             setManualCaptureButtonClickable(false)
@@ -355,8 +369,9 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
             captureProgress.isInvisible = true
             captureFeedbackBtn.setText(IDR.string.face_capture_title_validating_failed)
 
-            captureFeedbackTxtExplanation.isVisible = true
+            captureFeedbackTxtExplanation.setTextColor(ContextCompat.getColor(requireContext(), IDR.color.simprints_blue_grey))
             captureFeedbackTxtExplanation.setText(IDR.string.face_capture_error_validating_failed)
+            captureFeedbackTxtExplanation.isVisible = true
         }
     }
 
@@ -391,7 +406,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
                 true,
                 ContextCompat.getDrawable(requireContext(), R.drawable.ic_checked_white_18dp),
             )
-            renderProgressBar(false)
+            captureProgress.progressColor = validCaptureProgressColor
         }
     }
 
@@ -404,7 +419,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
 
             captureFeedbackBtn.setCheckedWithLeftDrawable(false)
             setManualCaptureButtonClickable(false)
-            renderProgressBar(false)
+            captureProgress.progressColor = defaultCaptureProgressColor
         }
     }
 
@@ -417,7 +432,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
 
             captureFeedbackBtn.setCheckedWithLeftDrawable(false)
             setManualCaptureButtonClickable(false)
-            renderProgressBar(false)
+            captureProgress.progressColor = defaultCaptureProgressColor
         }
     }
 
@@ -430,7 +445,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
 
             captureFeedbackBtn.setCheckedWithLeftDrawable(false)
             setManualCaptureButtonClickable(false)
-            renderProgressBar(false)
+            captureProgress.progressColor = defaultCaptureProgressColor
         }
     }
 
@@ -443,7 +458,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
 
             captureFeedbackBtn.setCheckedWithLeftDrawable(false)
             setManualCaptureButtonClickable(false)
-            renderProgressBar(false)
+            captureProgress.progressColor = defaultCaptureProgressColor
         }
     }
 
@@ -456,13 +471,8 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
 
             captureFeedbackBtn.setCheckedWithLeftDrawable(false)
             setManualCaptureButtonClickable(false)
-            renderProgressBar(false)
+            captureProgress.progressColor = defaultCaptureProgressColor
         }
-    }
-
-    private fun FragmentLiveFeedbackBinding.renderProgressBar(validCapture: Boolean) {
-        captureProgress.progressColor = if (validCapture) validCaptureProgressColor else defaultCaptureProgressColor
-        captureProgress.value = vm.getNormalizedProgress()
     }
 
     private fun FragmentLiveFeedbackBinding.setManualCaptureButtonClickable(clickable: Boolean) {

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
@@ -131,7 +131,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
         // Skip processing and only update progress bar while spoof check is running
         if (capturingState.value == CapturingState.VALIDATING) {
             progressBarValue.postValue(
-                ((timeHelper.now().ms - validationStartTime).toFloat() / MIN_SPOOF_CHECK_UI_TIME_MS).coerceIn(0f, 1f),
+                ((timeHelper.now().ms - validationStartTime).toFloat() / spoofCheckConfig.validationUiDurationMs).coerceIn(0f, 1f),
             )
             return
         } else if (capturingState.value == CapturingState.VALIDATION_FAILED) {
@@ -270,7 +270,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
         }
 
         // Show the UI for at least a moment for it to register with the user
-        val delay = maxOf(MIN_SPOOF_CHECK_UI_TIME_MS - duration.duration.inWholeMilliseconds, 0)
+        val delay = maxOf(spoofCheckConfig.validationUiDurationMs - duration.duration.inWholeMilliseconds, 0)
         Simber.i("Spoof check performed in ${duration.duration}, waiting for ${delay}ms", tag = FACE_CAPTURE)
         if (delay > 0) delay(delay.milliseconds)
     }
@@ -281,7 +281,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
             // Still track the capture attempt events for analytics and troubleshooting
             sendCaptureEvents(attemptNumber)
         }
-        val delay = maxOf(MIN_SPOOF_CHECK_UI_TIME_MS - duration.duration.inWholeMilliseconds, 0)
+        val delay = maxOf(spoofCheckConfig.validationErrorUiDurationMs - duration.duration.inWholeMilliseconds, 0)
         Simber.i("Captures tracked in ${duration.duration}, waiting for ${delay}ms", tag = FACE_CAPTURE)
         if (delay > 0) delay(delay.milliseconds)
 
@@ -387,7 +387,5 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
     companion object {
         private const val VALID_ROLL_DELTA = 15f
         private const val VALID_YAW_DELTA = 30f
-
-        private const val MIN_SPOOF_CHECK_UI_TIME_MS = 2000
     }
 }

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
@@ -133,8 +133,12 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
             progressBarValue.postValue(
                 ((timeHelper.now().ms - validationStartTime).toFloat() / spoofCheckConfig.validationUiDurationMs).coerceIn(0f, 1f),
             )
+            originalBitmap.recycle()
+            croppedBitmap.recycle()
             return
         } else if (capturingState.value == CapturingState.VALIDATION_FAILED) {
+            originalBitmap.recycle()
+            croppedBitmap.recycle()
             return
         }
 
@@ -298,6 +302,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
         bitmap: Bitmap,
         potentialFace: Face?,
     ): FaceDetection = if (potentialFace == null) {
+        original.recycle()
         bitmap.recycle()
         FaceDetection(
             original = original,

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
@@ -227,8 +227,8 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
                     }
 
                     Simber.i("Spoof check passed: $spoofCheckPassed (check count: $spoofCheckCount)", tag = FACE_CAPTURE)
-                    // Only attempt up to MAX_SPOOF_CHECK_ATTEMPTS times to prevent hard-blocking user
-                    if (spoofCheckCount >= MAX_SPOOF_CHECK_ATTEMPTS || spoofCheckPassed) {
+                    // Only attempt up to configured amount of times to prevent hard-blocking user
+                    if (spoofCheckCount >= spoofCheckConfig.maxAttempts || spoofCheckPassed) {
                         sendEventsAndFinish(attemptNumber)
                     } else {
                         showValidationErrorAndReset()
@@ -377,6 +377,5 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
         private const val VALID_YAW_DELTA = 30f
 
         private const val MIN_SPOOF_CHECK_UI_TIME_MS = 2000
-        private const val MAX_SPOOF_CHECK_ATTEMPTS = 2
     }
 }

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.simprints.core.DispatcherBG
 import com.simprints.core.tools.extentions.area
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.face.capture.models.FaceDetection
@@ -17,20 +18,25 @@ import com.simprints.face.infra.basebiosdk.detection.FaceDetector
 import com.simprints.face.infra.biosdkresolver.ResolveFaceBioSdkUseCase
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.FACE_AUTO_CAPTURE_IMAGING_DURATION_MILLIS_DEFAULT
+import com.simprints.infra.config.store.models.FaceConfiguration
 import com.simprints.infra.config.store.models.FaceConfiguration.SpoofCheckConfiguration
 import com.simprints.infra.config.store.models.ModalitySdkType
 import com.simprints.infra.config.store.models.experimental
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.FACE_CAPTURE
 import com.simprints.infra.logging.Simber
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.measureTimedValue
 
 @HiltViewModel
 internal class LiveFeedbackFragmentViewModel @Inject constructor(
@@ -40,6 +46,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
     private val timeHelper: TimeHelper,
     private val isUsingAutoCaptureUseCase: IsUsingAutoCaptureUseCase,
     private val getSpoofCheckConfiguration: GetSpoofCheckConfigurationUseCase,
+    @param:DispatcherBG private val bgDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     private var attemptNumber: Int = 1
     private var samplesToCapture: Int = 1
@@ -61,6 +68,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
 
     var isAutoCapture: Boolean = false
     var spoofCheckConfig: SpoofCheckConfiguration = SpoofCheckConfiguration.DISABLED
+    var spoofCheckCount: Int = 0
 
     private var captureImagingStartTime: Long = 0
     private var isAutoCaptureHeldOff = true
@@ -118,6 +126,11 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
         originalBitmap: Bitmap,
         croppedBitmap: Bitmap,
     ) {
+        if (capturingState.value == CapturingState.VALIDATING || capturingState.value == CapturingState.VALIDATION_FAILED) {
+            // Skip processing while spoof check is running
+            return
+        }
+
         val captureStartTime = timeHelper.now()
         val potentialFace = faceDetector.analyze(croppedBitmap)
 
@@ -200,15 +213,66 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
     private fun finishCapture(attemptNumber: Int) {
         Simber.i("Finish capture", tag = FACE_CAPTURE)
         viewModelScope.launch {
-            sortedQualifyingCaptures = userCaptures
-                .filter { isAutoCapture || it.hasValidStatus() } // Auto-capture images are pre-qualified
-                .sortedByDescending { it.face?.quality }
-                .ifEmpty { listOfNotNull(fallbackCapture) }
+            if (spoofCheckConfig == SpoofCheckConfiguration.DISABLED) {
+                sendEventsAndFinish(attemptNumber)
+            } else {
+                runSpoofChecksOnCaptures()
 
-            sendCaptureEvents(attemptNumber)
+                if (spoofCheckConfig.mode == FaceConfiguration.SpoofCheckMode.RECORDED) {
+                    sendEventsAndFinish(attemptNumber)
+                } else {
+                    val spoofCheckPassed = userCaptures.map { it.spoofCheckResult }.all {
+                        Simber.i("Spoof check result for capture: $it", tag = FACE_CAPTURE)
+                        it != null && it.skipReason == null && spoofCheckConfig.threshold > it.score
+                    }
 
-            capturingState.postValue(CapturingState.FINISHED)
+                    Simber.i("Spoof check passed: $spoofCheckPassed (check count: $spoofCheckCount)", tag = FACE_CAPTURE)
+                    // Only attempt up to MAX_SPOOF_CHECK_ATTEMPTS times to prevent hard-blocking user
+                    if (spoofCheckCount >= MAX_SPOOF_CHECK_ATTEMPTS || spoofCheckPassed) {
+                        sendEventsAndFinish(attemptNumber)
+                    } else {
+                        showValidationErrorAndReset()
+                    }
+                }
+            }
         }
+    }
+
+    private fun sendEventsAndFinish(attemptNumber: Int) {
+        sortedQualifyingCaptures = userCaptures
+            .filter { isAutoCapture || it.hasValidStatus() } // Auto-capture images are pre-qualified
+            .sortedByDescending { it.face?.quality }
+            .ifEmpty { listOfNotNull(fallbackCapture) }
+
+        sendCaptureEvents(attemptNumber)
+        capturingState.postValue(CapturingState.FINISHED)
+    }
+
+    private suspend fun runSpoofChecksOnCaptures() = withContext(bgDispatcher) {
+        capturingState.postValue(CapturingState.VALIDATING)
+        spoofCheckCount++
+
+        val duration = measureTimedValue {
+            for ((index, bitmap) in userCaptures.map { it.original }.withIndex()) {
+                userCaptures[index].spoofCheckResult = faceDetector.spoofCheck(bitmap)
+            }
+        }
+
+        // Show the UI for at least a moment for it to register with the user
+        val delay = maxOf(MIN_SPOOF_CHECK_UI_TIME_MS - duration.duration.inWholeMilliseconds, 0)
+        Simber.i("Spoof check performed in ${duration.duration}, waiting for ${delay}ms", tag = FACE_CAPTURE)
+        if (delay > 0) delay(delay.milliseconds)
+    }
+
+    private suspend fun showValidationErrorAndReset() {
+        capturingState.postValue(CapturingState.VALIDATION_FAILED)
+        delay(MIN_SPOOF_CHECK_UI_TIME_MS.milliseconds) // Allow for error message to be shown
+
+        // Reset state
+        userCaptures.clear()
+        sortedQualifyingCaptures = emptyList()
+        fallbackCapture = null
+        capturingState.postValue(CapturingState.NOT_STARTED)
     }
 
     private fun getFaceDetectionFromPotentialFace(
@@ -300,10 +364,13 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
         eventReporter.addCaptureEvents(faceDetection, attemptNumber, qualityThreshold, isAutoCapture = isAutoCapture)
     }
 
-    enum class CapturingState { NOT_STARTED, CAPTURING, FINISHED }
+    enum class CapturingState { NOT_STARTED, CAPTURING, VALIDATING, VALIDATION_FAILED, FINISHED }
 
     companion object {
         private const val VALID_ROLL_DELTA = 15f
         private const val VALID_YAW_DELTA = 30f
+
+        private const val MIN_SPOOF_CHECK_UI_TIME_MS = 2000
+        private const val MAX_SPOOF_CHECK_ATTEMPTS = 2
     }
 }

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
@@ -254,7 +254,9 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
 
         val duration = measureTimedValue {
             for ((index, bitmap) in userCaptures.map { it.original }.withIndex()) {
-                userCaptures[index].spoofCheckResult = faceDetector.spoofCheck(bitmap)
+                val result = faceDetector.spoofCheck(bitmap, spoofCheckConfig.maxBitmapSize)
+                Simber.i("Spoof result: $result", tag = FACE_CAPTURE)
+                userCaptures[index].spoofCheckResult = result
             }
         }
 

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
@@ -266,7 +266,13 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
 
     private suspend fun showValidationErrorAndReset() {
         capturingState.postValue(CapturingState.VALIDATION_FAILED)
-        delay(MIN_SPOOF_CHECK_UI_TIME_MS.milliseconds) // Allow for error message to be shown
+        val duration = measureTimedValue {
+            // Still track the capture attempt events for analytics and troubleshooting
+            sendCaptureEvents(attemptNumber)
+        }
+        val delay = maxOf(MIN_SPOOF_CHECK_UI_TIME_MS - duration.duration.inWholeMilliseconds, 0)
+        Simber.i("Captures tracked in ${duration.duration}, waiting for ${delay}ms", tag = FACE_CAPTURE)
+        if (delay > 0) delay(delay.milliseconds)
 
         // Reset state
         userCaptures.clear()

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
@@ -65,12 +65,14 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
     var sortedQualifyingCaptures = listOf<FaceDetection>()
     val currentDetection = MutableLiveData<FaceDetection>()
     val capturingState = MutableLiveData(CapturingState.NOT_STARTED)
+    val progressBarValue = MutableLiveData<Float>()
 
     var isAutoCapture: Boolean = false
     var spoofCheckConfig: SpoofCheckConfiguration = SpoofCheckConfiguration.DISABLED
     var spoofCheckCount: Int = 0
 
     private var captureImagingStartTime: Long = 0
+    private var validationStartTime: Long = 0
     private var isAutoCaptureHeldOff = true
     private var autoCaptureImagingTimeoutJob: Job? = null
     private var autoCaptureImagingDurationMillis: Long = FACE_AUTO_CAPTURE_IMAGING_DURATION_MILLIS_DEFAULT
@@ -126,8 +128,13 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
         originalBitmap: Bitmap,
         croppedBitmap: Bitmap,
     ) {
-        if (capturingState.value == CapturingState.VALIDATING || capturingState.value == CapturingState.VALIDATION_FAILED) {
-            // Skip processing while spoof check is running
+        // Skip processing and only update progress bar while spoof check is running
+        if (capturingState.value == CapturingState.VALIDATING) {
+            progressBarValue.postValue(
+                ((timeHelper.now().ms - validationStartTime).toFloat() / MIN_SPOOF_CHECK_UI_TIME_MS).coerceIn(0f, 1f),
+            )
+            return
+        } else if (capturingState.value == CapturingState.VALIDATION_FAILED) {
             return
         }
 
@@ -153,6 +160,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
         } else {
             currentDetection.postValue(faceDetection)
         }
+        progressBarValue.postValue(getNormalizedCaptureProgress())
 
         when (capturingState.value) {
             CapturingState.NOT_STARTED -> updateFallbackCaptureIfValid(faceDetection)
@@ -174,7 +182,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
         }
     }
 
-    fun getNormalizedProgress(): Float = if (isAutoCapture) {
+    fun getNormalizedCaptureProgress(): Float = if (isAutoCapture) {
         ((timeHelper.now().ms - captureImagingStartTime).toFloat() / autoCaptureImagingDurationMillis).coerceIn(0f, 1f)
     } else {
         userCaptures.size.toFloat() / samplesToCapture
@@ -251,6 +259,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
     private suspend fun runSpoofChecksOnCaptures() = withContext(bgDispatcher) {
         capturingState.postValue(CapturingState.VALIDATING)
         spoofCheckCount++
+        validationStartTime = timeHelper.now().ms
 
         val duration = measureTimedValue {
             for ((index, bitmap) in userCaptures.map { it.original }.withIndex()) {
@@ -277,10 +286,11 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
         if (delay > 0) delay(delay.milliseconds)
 
         // Reset state
+        capturingState.postValue(CapturingState.NOT_STARTED)
+        isAutoCaptureHeldOff = true
         userCaptures.clear()
         sortedQualifyingCaptures = emptyList()
         fallbackCapture = null
-        capturingState.postValue(CapturingState.NOT_STARTED)
     }
 
     private fun getFaceDetectionFromPotentialFace(

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
@@ -9,6 +9,7 @@ import com.simprints.core.tools.time.TimeHelper
 import com.simprints.face.capture.models.FaceDetection
 import com.simprints.face.capture.models.FaceTarget
 import com.simprints.face.capture.models.SymmetricTarget
+import com.simprints.face.capture.usecases.GetSpoofCheckConfigurationUseCase
 import com.simprints.face.capture.usecases.IsUsingAutoCaptureUseCase
 import com.simprints.face.capture.usecases.SimpleCaptureEventReporter
 import com.simprints.face.infra.basebiosdk.detection.Face
@@ -16,6 +17,7 @@ import com.simprints.face.infra.basebiosdk.detection.FaceDetector
 import com.simprints.face.infra.biosdkresolver.ResolveFaceBioSdkUseCase
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.FACE_AUTO_CAPTURE_IMAGING_DURATION_MILLIS_DEFAULT
+import com.simprints.infra.config.store.models.FaceConfiguration.SpoofCheckConfiguration
 import com.simprints.infra.config.store.models.ModalitySdkType
 import com.simprints.infra.config.store.models.experimental
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.FACE_CAPTURE
@@ -37,6 +39,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
     private val eventReporter: SimpleCaptureEventReporter,
     private val timeHelper: TimeHelper,
     private val isUsingAutoCaptureUseCase: IsUsingAutoCaptureUseCase,
+    private val getSpoofCheckConfiguration: GetSpoofCheckConfigurationUseCase,
 ) : ViewModel() {
     private var attemptNumber: Int = 1
     private var samplesToCapture: Int = 1
@@ -57,6 +60,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
     val capturingState = MutableLiveData(CapturingState.NOT_STARTED)
 
     var isAutoCapture: Boolean = false
+    var spoofCheckConfig: SpoofCheckConfiguration = SpoofCheckConfiguration.DISABLED
 
     private var captureImagingStartTime: Long = 0
     private var isAutoCaptureHeldOff = true
@@ -81,6 +85,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
             faceDetector = resolveFaceBioSdk(bioSdk).detector
 
             val config = configRepository.getProjectConfiguration()
+            spoofCheckConfig = getSpoofCheckConfiguration(config, bioSdk)
             qualityThreshold = config.face?.getSdkConfiguration(bioSdk)?.qualityThreshold ?: 0f
             autoCaptureImagingDurationMillis = config.experimental().faceAutoCaptureImagingDurationMillis
         }

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
@@ -384,7 +384,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
         attemptNumber: Int,
     ) {
         if (faceDetection == null) return
-        eventReporter.addCaptureEvents(faceDetection, attemptNumber, qualityThreshold, isAutoCapture = isAutoCapture)
+        eventReporter.addCaptureEvents(faceDetection, attemptNumber, qualityThreshold, spoofCheckConfig, isAutoCapture = isAutoCapture)
     }
 
     enum class CapturingState { NOT_STARTED, CAPTURING, VALIDATING, VALIDATION_FAILED, FINISHED }

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModel.kt
@@ -114,11 +114,14 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
      *
      * @param croppedBitmap is the camera frame
      */
-    fun process(croppedBitmap: Bitmap) {
+    fun process(
+        originalBitmap: Bitmap,
+        croppedBitmap: Bitmap,
+    ) {
         val captureStartTime = timeHelper.now()
         val potentialFace = faceDetector.analyze(croppedBitmap)
 
-        val faceDetection = getFaceDetectionFromPotentialFace(croppedBitmap, potentialFace)
+        val faceDetection = getFaceDetectionFromPotentialFace(originalBitmap, croppedBitmap, potentialFace)
         faceDetection.detectionStartTime = captureStartTime
         faceDetection.detectionEndTime = timeHelper.now()
 
@@ -209,11 +212,13 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
     }
 
     private fun getFaceDetectionFromPotentialFace(
+        original: Bitmap,
         bitmap: Bitmap,
         potentialFace: Face?,
     ): FaceDetection = if (potentialFace == null) {
         bitmap.recycle()
         FaceDetection(
+            original = original,
             bitmap = bitmap,
             face = null,
             status = FaceDetection.Status.NOFACE,
@@ -221,10 +226,11 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
             detectionEndTime = timeHelper.now(),
         )
     } else {
-        getFaceDetection(bitmap, potentialFace)
+        getFaceDetection(original, bitmap, potentialFace)
     }
 
     private fun getFaceDetection(
+        original: Bitmap,
         bitmap: Bitmap,
         potentialFace: Face,
     ): FaceDetection {
@@ -239,6 +245,7 @@ internal class LiveFeedbackFragmentViewModel @Inject constructor(
         }
 
         return FaceDetection(
+            original = original,
             bitmap = bitmap,
             face = potentialFace,
             status = status,

--- a/face/capture/src/main/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCase.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCase.kt
@@ -1,0 +1,34 @@
+package com.simprints.face.capture.usecases
+
+import com.simprints.face.infra.biosdkresolver.RocV3BioSdk
+import com.simprints.infra.config.store.models.FaceConfiguration
+import com.simprints.infra.config.store.models.ModalitySdkType
+import com.simprints.infra.config.store.models.ProjectConfiguration
+import com.simprints.infra.config.store.models.experimental
+import javax.inject.Inject
+
+class GetSpoofCheckConfigurationUseCase @Inject constructor(
+    private val rocV3BioSdk: RocV3BioSdk,
+) {
+    operator fun invoke(
+        projectConfiguration: ProjectConfiguration,
+        bioSdk: ModalitySdkType,
+    ): FaceConfiguration.SpoofCheckConfiguration {
+        // Only available for ROC V3
+        if (bioSdk != ModalitySdkType.RANK_ONE) {
+            return FaceConfiguration.SpoofCheckConfiguration.DISABLED
+        }
+        val faceSdkConfig = projectConfiguration.face?.getSdkConfiguration(bioSdk)
+        if (faceSdkConfig == null || faceSdkConfig.version != rocV3BioSdk.version()) {
+            return FaceConfiguration.SpoofCheckConfiguration.DISABLED
+        }
+
+        // TODO use the Face SDK configuration instead
+        return projectConfiguration.experimental().let {
+            FaceConfiguration.SpoofCheckConfiguration(
+                mode = it.spoofCheckMode,
+                threshold = it.spoofCheckThreshold,
+            )
+        }
+    }
+}

--- a/face/capture/src/main/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCase.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCase.kt
@@ -30,6 +30,8 @@ class GetSpoofCheckConfigurationUseCase @Inject constructor(
                 threshold = it.spoofCheckThreshold,
                 maxAttempts = it.spoofMaxAttempts,
                 maxBitmapSize = it.spoofMaxBitmapSize,
+                validationUiDurationMs = it.spoofMinValidationUiDurationMs,
+                validationErrorUiDurationMs = it.spoofMinValidationErrorUiDurationMs,
             )
         }
     }

--- a/face/capture/src/main/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCase.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCase.kt
@@ -28,6 +28,7 @@ class GetSpoofCheckConfigurationUseCase @Inject constructor(
             FaceConfiguration.SpoofCheckConfiguration(
                 mode = it.spoofCheckMode,
                 threshold = it.spoofCheckThreshold,
+                maxAttempts = it.spoofMaxAttempts,
             )
         }
     }

--- a/face/capture/src/main/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCase.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCase.kt
@@ -29,6 +29,7 @@ class GetSpoofCheckConfigurationUseCase @Inject constructor(
                 mode = it.spoofCheckMode,
                 threshold = it.spoofCheckThreshold,
                 maxAttempts = it.spoofMaxAttempts,
+                maxBitmapSize = it.spoofMaxBitmapSize,
             )
         }
     }

--- a/face/capture/src/main/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporter.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporter.kt
@@ -5,6 +5,7 @@ import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.core.tools.utils.EncodingUtils
 import com.simprints.face.capture.models.FaceDetection
+import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
 import com.simprints.infra.events.event.domain.models.BiometricReferenceCreationEvent
 import com.simprints.infra.events.event.domain.models.FaceCaptureBiometricsEvent
 import com.simprints.infra.events.event.domain.models.FaceCaptureConfirmationEvent
@@ -55,14 +56,14 @@ internal class SimpleCaptureEventReporter @Inject constructor(
         isAutoCapture: Boolean = false,
     ) {
         val faceCaptureEvent = FaceCaptureEvent(
-            faceDetection.detectionStartTime,
-            faceDetection.detectionEndTime,
-            attempt,
-            qualityThreshold,
-            mapDetectionStatusToPayloadResult(faceDetection),
+            startTime = faceDetection.detectionStartTime,
+            endTime = faceDetection.detectionEndTime,
+            attemptNb = attempt,
+            qualityThreshold = qualityThreshold,
+            result = mapDetectionStatusToPayloadResult(faceDetection),
             isAutoCapture = isAutoCapture,
-            faceDetection.isFallback,
-            mapDetectionToCapturePayloadFace(faceDetection),
+            isFallback = faceDetection.isFallback,
+            face = mapDetectionToCapturePayloadFace(faceDetection = faceDetection),
             payloadId = faceDetection.id,
         )
 
@@ -89,8 +90,16 @@ internal class SimpleCaptureEventReporter @Inject constructor(
         FaceDetection.Status.TOOFAR -> FaceCapturePayload.Result.TOO_FAR
     }
 
-    private fun mapDetectionToCapturePayloadFace(faceDetection: FaceDetection) =
-        faceDetection.face?.let { FaceCapturePayload.Face(it.yaw, it.roll, it.quality, it.format) }
+    private fun mapDetectionToCapturePayloadFace(faceDetection: FaceDetection) = faceDetection.face?.let {
+        FaceCapturePayload.Face(
+            yaw = it.yaw,
+            roll = it.roll,
+            quality = it.quality,
+            format = it.format,
+            spoofScore = faceDetection.spoofCheckResult?.score,
+            spoofSkipReason = mapSpoofReason(faceDetection.spoofCheckResult?.skipReason),
+        )
+    }
 
     private fun mapDetectionToCaptureBometricPayloadFace(faceDetection: FaceDetection) = faceDetection.face?.let {
         FaceCaptureBiometricsEvent.FaceCaptureBiometricsPayload.Face(
@@ -101,6 +110,13 @@ internal class SimpleCaptureEventReporter @Inject constructor(
             it.format,
         )
     }!!
+
+    private fun mapSpoofReason(reason: SpoofCheckResult.SkipReason?): FaceCapturePayload.SpoofSkipReason? = when (reason) {
+        SpoofCheckResult.SkipReason.IMAGE_TOO_SMALL -> FaceCapturePayload.SpoofSkipReason.IMAGE_TOO_SMALL
+        SpoofCheckResult.SkipReason.IOD_TOO_SMALL -> FaceCapturePayload.SpoofSkipReason.IOD_TOO_SMALL
+        SpoofCheckResult.SkipReason.IOD_TOO_LARGE -> FaceCapturePayload.SpoofSkipReason.IOD_TOO_LARGE
+        else -> null
+    }
 
     fun addBiometricReferenceCreationEvents(
         referenceId: String,

--- a/face/capture/src/main/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporter.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporter.kt
@@ -6,6 +6,7 @@ import com.simprints.core.tools.time.Timestamp
 import com.simprints.core.tools.utils.EncodingUtils
 import com.simprints.face.capture.models.FaceDetection
 import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
+import com.simprints.infra.config.store.models.FaceConfiguration
 import com.simprints.infra.events.event.domain.models.BiometricReferenceCreationEvent
 import com.simprints.infra.events.event.domain.models.FaceCaptureBiometricsEvent
 import com.simprints.infra.events.event.domain.models.FaceCaptureConfirmationEvent
@@ -53,6 +54,7 @@ internal class SimpleCaptureEventReporter @Inject constructor(
         faceDetection: FaceDetection,
         attempt: Int,
         qualityThreshold: Float,
+        spoofConfig: FaceConfiguration.SpoofCheckConfiguration,
         isAutoCapture: Boolean = false,
     ) {
         val faceCaptureEvent = FaceCaptureEvent(
@@ -60,7 +62,7 @@ internal class SimpleCaptureEventReporter @Inject constructor(
             endTime = faceDetection.detectionEndTime,
             attemptNb = attempt,
             qualityThreshold = qualityThreshold,
-            result = mapDetectionStatusToPayloadResult(faceDetection),
+            result = mapDetectionStatusToPayloadResult(faceDetection, spoofConfig),
             isAutoCapture = isAutoCapture,
             isFallback = faceDetection.isFallback,
             face = mapDetectionToCapturePayloadFace(faceDetection = faceDetection),
@@ -79,15 +81,33 @@ internal class SimpleCaptureEventReporter @Inject constructor(
         }
     }
 
-    private fun mapDetectionStatusToPayloadResult(faceDetection: FaceDetection) = when (faceDetection.status) {
-        FaceDetection.Status.VALID -> FaceCapturePayload.Result.VALID
-        FaceDetection.Status.VALID_CAPTURING -> FaceCapturePayload.Result.VALID
-        FaceDetection.Status.NOFACE -> FaceCapturePayload.Result.INVALID
-        FaceDetection.Status.BAD_QUALITY -> FaceCapturePayload.Result.BAD_QUALITY
-        FaceDetection.Status.OFFYAW -> FaceCapturePayload.Result.OFF_YAW
-        FaceDetection.Status.OFFROLL -> FaceCapturePayload.Result.OFF_ROLL
-        FaceDetection.Status.TOOCLOSE -> FaceCapturePayload.Result.TOO_CLOSE
-        FaceDetection.Status.TOOFAR -> FaceCapturePayload.Result.TOO_FAR
+    private fun mapDetectionStatusToPayloadResult(
+        faceDetection: FaceDetection,
+        spoofConfig: FaceConfiguration.SpoofCheckConfiguration,
+    ) = if (isFaceSpoofed(faceDetection, spoofConfig)) {
+        FaceCapturePayload.Result.SPOOFED
+    } else {
+        when (faceDetection.status) {
+            FaceDetection.Status.VALID -> FaceCapturePayload.Result.VALID
+            FaceDetection.Status.VALID_CAPTURING -> FaceCapturePayload.Result.VALID
+            FaceDetection.Status.NOFACE -> FaceCapturePayload.Result.INVALID
+            FaceDetection.Status.BAD_QUALITY -> FaceCapturePayload.Result.BAD_QUALITY
+            FaceDetection.Status.OFFYAW -> FaceCapturePayload.Result.OFF_YAW
+            FaceDetection.Status.OFFROLL -> FaceCapturePayload.Result.OFF_ROLL
+            FaceDetection.Status.TOOCLOSE -> FaceCapturePayload.Result.TOO_CLOSE
+            FaceDetection.Status.TOOFAR -> FaceCapturePayload.Result.TOO_FAR
+        }
+    }
+
+    private fun isFaceSpoofed(
+        faceDetection: FaceDetection,
+        spoofConfig: FaceConfiguration.SpoofCheckConfiguration,
+    ): Boolean {
+        if (spoofConfig.mode != FaceConfiguration.SpoofCheckMode.ENFORCED) return false
+        val spoofResult = faceDetection.spoofCheckResult ?: return false
+        if (spoofResult.skipReason != null) return false
+
+        return spoofResult.score > spoofConfig.threshold
     }
 
     private fun mapDetectionToCapturePayloadFace(faceDetection: FaceDetection) = faceDetection.face?.let {

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/CropToTargetOverlayAnalyzerTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/CropToTargetOverlayAnalyzerTest.kt
@@ -3,13 +3,10 @@ package com.simprints.face.capture.screens.livefeedback
 import android.graphics.Bitmap
 import android.graphics.RectF
 import androidx.camera.core.ImageProxy
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.common.truth.Truth.assertThat
-import io.mockk.MockKAnnotations
-import io.mockk.every
+import androidx.test.ext.junit.runners.*
+import com.google.common.truth.Truth.*
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.justRun
-import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -36,7 +33,8 @@ internal class CropToTargetOverlayAnalyzerTest {
             previewRect = RectF(200f, 200f, 200f, 200f),
             overlayWidth = 1000,
             overlayHeight = 2000,
-        ) { capturedBitmap = it }
+            onImageCropped = { _, cropped -> capturedBitmap = cropped },
+        )
 
         analyzer.analyze(imageProxy)
 
@@ -53,7 +51,8 @@ internal class CropToTargetOverlayAnalyzerTest {
             previewRect = RectF(200f, 200f, 800f, 800f),
             overlayWidth = 1000,
             overlayHeight = 2000,
-        ) { capturedBitmap = it }
+            onImageCropped = { _, cropped -> capturedBitmap = cropped },
+        )
 
         analyzer.analyze(imageProxy)
 
@@ -73,7 +72,8 @@ internal class CropToTargetOverlayAnalyzerTest {
             previewRect = RectF(200f, 200f, 800f, 800f),
             overlayWidth = 1000,
             overlayHeight = 2000,
-        ) { closedBeforeCallback = closed }
+            onImageCropped = { _, _ -> closedBeforeCallback = closed },
+        )
 
         analyzer.analyze(imageProxy)
 
@@ -88,7 +88,8 @@ internal class CropToTargetOverlayAnalyzerTest {
             previewRect = RectF(700f, 200f, 1300f, 800f),
             overlayWidth = 2000,
             overlayHeight = 1000,
-        ) { capturedBitmap = it }
+            onImageCropped = { _, cropped -> capturedBitmap = cropped },
+        )
 
         analyzer.analyze(imageProxy)
 
@@ -104,7 +105,8 @@ internal class CropToTargetOverlayAnalyzerTest {
             previewRect = RectF(200f, 200f, 800f, 800f),
             overlayWidth = 1000,
             overlayHeight = 2000,
-        ) { capturedBitmap = it }
+            onImageCropped = { _, cropped -> capturedBitmap = cropped },
+        )
 
         analyzer.analyze(imageProxy)
 
@@ -120,7 +122,8 @@ internal class CropToTargetOverlayAnalyzerTest {
             previewRect = RectF(700f, 200f, 1300f, 800f),
             overlayWidth = 2000,
             overlayHeight = 1000,
-        ) { capturedBitmap = it }
+            onImageCropped = { _, cropped -> capturedBitmap = cropped },
+        )
 
         analyzer.analyze(imageProxy)
 

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
@@ -8,12 +8,14 @@ import com.google.common.truth.*
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.face.capture.models.FaceDetection
+import com.simprints.face.capture.usecases.GetSpoofCheckConfigurationUseCase
 import com.simprints.face.capture.usecases.IsUsingAutoCaptureUseCase
 import com.simprints.face.capture.usecases.SimpleCaptureEventReporter
 import com.simprints.face.infra.basebiosdk.detection.Face
 import com.simprints.face.infra.basebiosdk.detection.FaceDetector
 import com.simprints.face.infra.biosdkresolver.ResolveFaceBioSdkUseCase
 import com.simprints.infra.config.store.ConfigRepository
+import com.simprints.infra.config.store.models.FaceConfiguration
 import com.simprints.infra.config.store.models.ModalitySdkType
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import com.simprints.testtools.common.livedata.testObserver
@@ -59,6 +61,8 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
     @MockK
     private lateinit var isUsingAutoCapture: IsUsingAutoCaptureUseCase
 
+    @MockK
+    private lateinit var getSpoofCheckConfiguration: GetSpoofCheckConfigurationUseCase
     private lateinit var viewModel: LiveFeedbackFragmentViewModel
 
     @Before
@@ -73,6 +77,10 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
                 ?.qualityThreshold
         } returns QUALITY_THRESHOLD
         every { isUsingAutoCapture.invoke(any()) } returns true
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns FaceConfiguration.SpoofCheckConfiguration.DISABLED
+        coEvery {
+            configRepository.getProjectConfiguration().custom
+        } returns mapOf("singleQualityFallbackRequired" to JsonPrimitive(false))
 
         every { timeHelper.now() } returnsMany (0..100L).map { Timestamp(it) }
         justRun { previewFrame.recycle() }
@@ -88,6 +96,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
             eventReporter,
             timeHelper,
             isUsingAutoCapture,
+            getSpoofCheckConfiguration,
         )
     }
 

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
@@ -17,6 +17,7 @@ import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
 import com.simprints.face.infra.biosdkresolver.ResolveFaceBioSdkUseCase
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.FaceConfiguration
+import com.simprints.infra.config.store.models.FaceConfiguration.SpoofCheckConfiguration
 import com.simprints.infra.config.store.models.ModalitySdkType
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import com.simprints.testtools.common.livedata.testObserver
@@ -79,7 +80,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
                 ?.qualityThreshold
         } returns QUALITY_THRESHOLD
         every { isUsingAutoCapture.invoke(any()) } returns true
-        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns FaceConfiguration.SpoofCheckConfiguration.DISABLED
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns SpoofCheckConfiguration.DISABLED
         coEvery {
             configRepository.getProjectConfiguration().custom
         } returns mapOf("singleQualityFallbackRequired" to JsonPrimitive(false))
@@ -345,9 +346,9 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
     fun `Auto capture spoof check Recorded finishes regardless of score`() = runTest {
         val validFace = getFace()
         every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
-            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.RECORDED, 0.5f, 2)
+            getDefaultSpoofConfig()
         every { faceDetector.analyze(frame) } returns validFace
-        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
+        coEvery { faceDetector.spoofCheck(any(), any()) } returns SpoofCheckResult(score = 0.9f)
 
         val capturingState = viewModel.capturingState.testObserver()
 
@@ -367,10 +368,9 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
     @Test
     fun `Auto capture spoof check Enforced passed finishes capture`() = runTest {
         val validFace = getFace()
-        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
-            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns getDefaultSpoofConfig(FaceConfiguration.SpoofCheckMode.ENFORCED)
         every { faceDetector.analyze(frame) } returns validFace
-        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.1f)
+        coEvery { faceDetector.spoofCheck(any(), any()) } returns SpoofCheckResult(score = 0.1f)
 
         val capturingState = viewModel.capturingState.testObserver()
 
@@ -390,10 +390,9 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
     @Test
     fun `Auto capture spoof check Enforced failed resets state`() = runTest {
         val validFace = getFace()
-        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
-            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns getDefaultSpoofConfig(FaceConfiguration.SpoofCheckMode.ENFORCED)
         every { faceDetector.analyze(frame) } returns validFace
-        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
+        coEvery { faceDetector.spoofCheck(any(), any()) } returns SpoofCheckResult(score = 0.9f)
 
         val capturingState = viewModel.capturingState.testObserver()
 
@@ -413,10 +412,9 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
     @Test
     fun `Auto capture spoof check Enforced failed max attempts finishes capture`() = runTest {
         val validFace = getFace()
-        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
-            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns getDefaultSpoofConfig(FaceConfiguration.SpoofCheckMode.ENFORCED)
         every { faceDetector.analyze(frame) } returns validFace
-        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
+        coEvery { faceDetector.spoofCheck(any(), any()) } returns SpoofCheckResult(score = 0.9f)
 
         val capturingState = viewModel.capturingState.testObserver()
 
@@ -439,10 +437,9 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
     @Test
     fun `Skip frame processing while validating`() = runTest {
         val validFace = getFace()
-        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
-            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns getDefaultSpoofConfig()
         every { faceDetector.analyze(frame) } returns validFace
-        coEvery { faceDetector.spoofCheck(any()) } answers {
+        coEvery { faceDetector.spoofCheck(any(), any()) } answers {
             viewModel.process(frame, frame)
             SpoofCheckResult(score = 0.9f)
         }
@@ -517,6 +514,15 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         yaw: Float = 0f,
         roll: Float = 0f,
     ) = Face(100, 100, rect, yaw, roll, quality, Random.nextBytes(20), "format")
+
+    private fun getDefaultSpoofConfig(
+        mode: FaceConfiguration.SpoofCheckMode = FaceConfiguration.SpoofCheckMode.RECORDED,
+    ): SpoofCheckConfiguration = SpoofCheckConfiguration(
+        mode = mode,
+        threshold = 0.5f,
+        maxAttempts = 2,
+        maxBitmapSize = 1500,
+    )
 
     companion object {
         private const val QUALITY_THRESHOLD = -1f

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
@@ -264,7 +264,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
             assertThat(it[4]?.status).isEqualTo(FaceDetection.Status.NOFACE)
         }
 
-        coVerify(exactly = 0) { eventReporter.addCaptureEvents(any(), any(), any()) }
+        coVerify(exactly = 0) { eventReporter.addCaptureEvents(any(), any(), any(), any()) }
     }
 
     @Test
@@ -505,7 +505,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         }
 
         coVerify { eventReporter.addFallbackCaptureEvent(any(), any()) }
-        coVerify(exactly = 3) { eventReporter.addCaptureEvents(any(), any(), any(), any()) }
+        coVerify(exactly = 3) { eventReporter.addCaptureEvents(any(), any(), any(), any(), any()) }
     }
 
     private fun getFace(

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
@@ -345,7 +345,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
     fun `Auto capture spoof check Recorded finishes regardless of score`() = runTest {
         val validFace = getFace()
         every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
-            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.RECORDED, 0.5f)
+            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.RECORDED, 0.5f, 2)
         every { faceDetector.analyze(frame) } returns validFace
         coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
 
@@ -368,7 +368,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
     fun `Auto capture spoof check Enforced passed finishes capture`() = runTest {
         val validFace = getFace()
         every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
-            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
         every { faceDetector.analyze(frame) } returns validFace
         coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.1f)
 
@@ -391,7 +391,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
     fun `Auto capture spoof check Enforced failed resets state`() = runTest {
         val validFace = getFace()
         every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
-            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
         every { faceDetector.analyze(frame) } returns validFace
         coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
 
@@ -414,7 +414,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
     fun `Auto capture spoof check Enforced failed max attempts finishes capture`() = runTest {
         val validFace = getFace()
         every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
-            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
         every { faceDetector.analyze(frame) } returns validFace
         coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
 
@@ -440,7 +440,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
     fun `Skip frame processing while validating`() = runTest {
         val validFace = getFace()
         every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
-            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
         every { faceDetector.analyze(frame) } returns validFace
         coEvery { faceDetector.spoofCheck(any()) } answers {
             viewModel.process(frame, frame)

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
@@ -4,7 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.Rect
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.ext.junit.runners.*
-import com.google.common.truth.*
+import com.google.common.truth.Truth.*
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.face.capture.models.FaceDetection
@@ -13,6 +13,7 @@ import com.simprints.face.capture.usecases.IsUsingAutoCaptureUseCase
 import com.simprints.face.capture.usecases.SimpleCaptureEventReporter
 import com.simprints.face.infra.basebiosdk.detection.Face
 import com.simprints.face.infra.basebiosdk.detection.FaceDetector
+import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
 import com.simprints.face.infra.biosdkresolver.ResolveFaceBioSdkUseCase
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.FaceConfiguration
@@ -23,6 +24,7 @@ import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Before
@@ -97,6 +99,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
             timeHelper,
             isUsingAutoCapture,
             getSpoofCheckConfiguration,
+            testCoroutineRule.testCoroutineDispatcher,
         )
     }
 
@@ -110,11 +113,9 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
         viewModel.process(frame, frame)
 
-        Truth
-            .assertThat(currentDetection.observedValues)
+        assertThat(currentDetection.observedValues)
             .isEmpty()
-        Truth
-            .assertThat(capturingState.observedValues.last())
+        assertThat(capturingState.observedValues.last())
             .isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.NOT_STARTED)
     }
 
@@ -130,11 +131,9 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.holdOffAutoCapture()
         viewModel.process(frame, frame)
 
-        Truth
-            .assertThat(currentDetection.observedValues)
+        assertThat(currentDetection.observedValues)
             .isEmpty()
-        Truth
-            .assertThat(capturingState.observedValues.last())
+        assertThat(capturingState.observedValues.last())
             .isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.NOT_STARTED)
     }
 
@@ -149,9 +148,8 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.startCapture()
         viewModel.process(frame, frame)
 
-        Truth.assertThat(currentDetection.observedValues.last()?.hasValidStatus()).isEqualTo(true)
-        Truth
-            .assertThat(capturingState.observedValues.last())
+        assertThat(currentDetection.observedValues.last()?.hasValidStatus()).isEqualTo(true)
+        assertThat(capturingState.observedValues.last())
             .isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.CAPTURING)
     }
 
@@ -168,9 +166,8 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.holdOffAutoCapture()
         viewModel.process(frame, frame)
 
-        Truth.assertThat(currentDetection.observedValues.last()?.hasValidStatus()).isEqualTo(true)
-        Truth
-            .assertThat(capturingState.observedValues.last())
+        assertThat(currentDetection.observedValues.last()?.hasValidStatus()).isEqualTo(true)
+        assertThat(capturingState.observedValues.last())
             .isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.CAPTURING)
     }
 
@@ -189,17 +186,13 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.process(frame, frame)
         viewModel.process(frame, frame)
 
-        Truth
-            .assertThat(currentDetection.observedValues.first()?.status)
+        assertThat(currentDetection.observedValues.first()?.status)
             .isEqualTo(FaceDetection.Status.VALID)
-        Truth
-            .assertThat(capturingState.observedValues.first())
+        assertThat(capturingState.observedValues.first())
             .isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.NOT_STARTED)
-        Truth
-            .assertThat(currentDetection.observedValues.last()?.hasValidStatus())
+        assertThat(currentDetection.observedValues.last()?.hasValidStatus())
             .isEqualTo(true)
-        Truth
-            .assertThat(capturingState.observedValues.last())
+        assertThat(capturingState.observedValues.last())
             .isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.CAPTURING)
     }
 
@@ -214,7 +207,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.process(frame, frame)
 
         val currentDetection = viewModel.currentDetection.testObserver()
-        Truth.assertThat(currentDetection.observedValues.last()?.hasValidStatus()).isEqualTo(true)
+        assertThat(currentDetection.observedValues.last()?.hasValidStatus()).isEqualTo(true)
 
         coVerify { eventReporter.addFallbackCaptureEvent(any(), any()) }
     }
@@ -229,7 +222,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         advanceTimeBy(AUTO_CAPTURE_IMAGING_DURATION_MS + 1)
 
         val currentDetection = viewModel.currentDetection.testObserver()
-        Truth.assertThat(currentDetection.observedValues.last()?.hasValidStatus()).isEqualTo(true)
+        assertThat(currentDetection.observedValues.last()?.hasValidStatus()).isEqualTo(true)
 
         coVerify { eventReporter.addCaptureEvents(any(), any(), any(), any()) }
     }
@@ -263,11 +256,11 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.process(frame, frame)
 
         detections.observedValues.let {
-            Truth.assertThat(it[0]?.status).isEqualTo(FaceDetection.Status.TOOFAR)
-            Truth.assertThat(it[1]?.status).isEqualTo(FaceDetection.Status.TOOCLOSE)
-            Truth.assertThat(it[2]?.status).isEqualTo(FaceDetection.Status.OFFYAW)
-            Truth.assertThat(it[3]?.status).isEqualTo(FaceDetection.Status.OFFROLL)
-            Truth.assertThat(it[4]?.status).isEqualTo(FaceDetection.Status.NOFACE)
+            assertThat(it[0]?.status).isEqualTo(FaceDetection.Status.TOOFAR)
+            assertThat(it[1]?.status).isEqualTo(FaceDetection.Status.TOOCLOSE)
+            assertThat(it[2]?.status).isEqualTo(FaceDetection.Status.OFFYAW)
+            assertThat(it[3]?.status).isEqualTo(FaceDetection.Status.OFFROLL)
+            assertThat(it[4]?.status).isEqualTo(FaceDetection.Status.NOFACE)
         }
 
         coVerify(exactly = 0) { eventReporter.addCaptureEvents(any(), any(), any()) }
@@ -297,8 +290,8 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
 
         detections.observedValues.let {
             // fallback image frame wasn't observed during preparation delay
-            Truth.assertThat(it[0]?.hasValidStatus()).isEqualTo(true)
-            Truth.assertThat(it[1]?.hasValidStatus()).isEqualTo(true)
+            assertThat(it[0]?.hasValidStatus()).isEqualTo(true)
+            assertThat(it[1]?.hasValidStatus()).isEqualTo(true)
         }
     }
 
@@ -316,13 +309,11 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.startCapture()
         viewModel.process(frame, frame)
         advanceTimeBy(AUTO_CAPTURE_IMAGING_DURATION_MS)
-        Truth
-            .assertThat(capturingState.observedValues.last())
+        assertThat(capturingState.observedValues.last())
             .isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.CAPTURING)
 
         advanceTimeBy(1)
-        Truth
-            .assertThat(capturingState.observedValues.last())
+        assertThat(capturingState.observedValues.last())
             .isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.FINISHED)
     }
 
@@ -342,14 +333,128 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.startCapture()
         viewModel.process(frame, frame)
         advanceTimeBy(configDuration / 2)
-        Truth
-            .assertThat(capturingState.observedValues.last())
+        assertThat(capturingState.observedValues.last())
             .isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.CAPTURING)
         // Add 1ms to account for json deserialization delay
         advanceTimeBy((configDuration / 2) + 1)
-        Truth
-            .assertThat(capturingState.observedValues.last())
+        assertThat(capturingState.observedValues.last())
             .isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.FINISHED)
+    }
+
+    @Test
+    fun `Auto capture spoof check Recorded finishes regardless of score`() = runTest {
+        val validFace = getFace()
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
+            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.RECORDED, 0.5f)
+        every { faceDetector.analyze(frame) } returns validFace
+        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
+
+        val capturingState = viewModel.capturingState.testObserver()
+
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.startCapture()
+        viewModel.process(frame, frame)
+
+        advanceUntilIdle()
+
+        assertThat(capturingState.observedValues).contains(LiveFeedbackFragmentViewModel.CapturingState.VALIDATING)
+        assertThat(capturingState.observedValues.last()).isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.FINISHED)
+        assertThat(viewModel.sortedQualifyingCaptures).hasSize(1)
+        assertThat(viewModel.sortedQualifyingCaptures[0].spoofCheckResult?.score).isEqualTo(0.9f)
+    }
+
+    @Test
+    fun `Auto capture spoof check Enforced passed finishes capture`() = runTest {
+        val validFace = getFace()
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
+            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+        every { faceDetector.analyze(frame) } returns validFace
+        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.1f)
+
+        val capturingState = viewModel.capturingState.testObserver()
+
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.startCapture()
+        viewModel.process(frame, frame)
+
+        advanceUntilIdle()
+
+        assertThat(capturingState.observedValues).contains(LiveFeedbackFragmentViewModel.CapturingState.VALIDATING)
+        assertThat(capturingState.observedValues.last()).isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.FINISHED)
+        assertThat(viewModel.sortedQualifyingCaptures).hasSize(1)
+        assertThat(viewModel.sortedQualifyingCaptures[0].spoofCheckResult?.score).isEqualTo(0.1f)
+    }
+
+    @Test
+    fun `Auto capture spoof check Enforced failed resets state`() = runTest {
+        val validFace = getFace()
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
+            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+        every { faceDetector.analyze(frame) } returns validFace
+        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
+
+        val capturingState = viewModel.capturingState.testObserver()
+
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.startCapture()
+        viewModel.process(frame, frame)
+
+        advanceUntilIdle()
+
+        assertThat(capturingState.observedValues).contains(LiveFeedbackFragmentViewModel.CapturingState.VALIDATION_FAILED)
+        assertThat(capturingState.observedValues.last()).isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.NOT_STARTED)
+        assertThat(viewModel.userCaptures).isEmpty()
+        assertThat(viewModel.sortedQualifyingCaptures).isEmpty()
+    }
+
+    @Test
+    fun `Auto capture spoof check Enforced failed max attempts finishes capture`() = runTest {
+        val validFace = getFace()
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
+            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+        every { faceDetector.analyze(frame) } returns validFace
+        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
+
+        val capturingState = viewModel.capturingState.testObserver()
+
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+
+        viewModel.startCapture()
+        viewModel.process(frame, frame)
+        advanceUntilIdle()
+
+        assertThat(capturingState.observedValues.last()).isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.NOT_STARTED)
+
+        viewModel.startCapture()
+        viewModel.process(frame, frame)
+        advanceUntilIdle()
+
+        assertThat(capturingState.observedValues.last()).isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.FINISHED)
+    }
+
+    @Test
+    fun `Skip frame processing while validating`() = runTest {
+        val validFace = getFace()
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
+            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+        every { faceDetector.analyze(frame) } returns validFace
+        coEvery { faceDetector.spoofCheck(any()) } answers {
+            viewModel.process(frame, frame)
+            SpoofCheckResult(score = 0.9f)
+        }
+
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.startCapture()
+        viewModel.process(frame, frame)
+
+        advanceUntilIdle()
+
+        verify(exactly = 1) { faceDetector.analyze(frame) }
     }
 
     @Test
@@ -371,37 +476,35 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
 
         currentDetectionObserver.observedValues.let {
             // 1st frame wasn't observed during preparation delay
-            Truth.assertThat(it[0]?.hasValidStatus()).isEqualTo(true)
-            Truth.assertThat(it[1]?.hasValidStatus()).isEqualTo(true)
+            assertThat(it[0]?.hasValidStatus()).isEqualTo(true)
+            assertThat(it[1]?.hasValidStatus()).isEqualTo(true)
         }
 
         capturingStateObserver.observedValues.let {
-            Truth
-                .assertThat(it[0])
+            assertThat(it[0])
                 .isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.NOT_STARTED)
-            Truth
-                .assertThat(it[1])
+            assertThat(it[1])
                 .isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.CAPTURING)
-            Truth.assertThat(it[2]).isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.FINISHED)
+            assertThat(it[2]).isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.FINISHED)
         }
 
-        Truth.assertThat(viewModel.userCaptures.size).isEqualTo(samplesToKeep)
+        assertThat(viewModel.userCaptures.size).isEqualTo(samplesToKeep)
         viewModel.userCaptures.let {
             with(it[0]) {
-                Truth.assertThat(hasValidStatus()).isEqualTo(true)
-                Truth.assertThat(face).isEqualTo(validFace)
-                Truth.assertThat(isFallback).isEqualTo(false)
+                assertThat(hasValidStatus()).isEqualTo(true)
+                assertThat(face).isEqualTo(validFace)
+                assertThat(isFallback).isEqualTo(false)
             }
 
-            Truth.assertThat(it[1].isFallback).isEqualTo(false)
+            assertThat(it[1].isFallback).isEqualTo(false)
         }
 
         with(viewModel.sortedQualifyingCaptures) {
-            Truth.assertThat(size).isEqualTo(samplesToKeep)
-            Truth.assertThat(get(0).face).isEqualTo(validFace)
-            Truth.assertThat(get(0).isFallback).isEqualTo(false)
-            Truth.assertThat(get(1).face).isEqualTo(validFace)
-            Truth.assertThat(get(1).isFallback).isEqualTo(false)
+            assertThat(size).isEqualTo(samplesToKeep)
+            assertThat(get(0).face).isEqualTo(validFace)
+            assertThat(get(0).isFallback).isEqualTo(false)
+            assertThat(get(1).face).isEqualTo(validFace)
+            assertThat(get(1).isFallback).isEqualTo(false)
         }
 
         coVerify { eventReporter.addFallbackCaptureEvent(any(), any()) }
@@ -413,7 +516,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         quality: Float = 1f,
         yaw: Float = 0f,
         roll: Float = 0f,
-    ) = Face(100, 100, rect, yaw, roll, quality, Random.Default.nextBytes(20), "format")
+    ) = Face(100, 100, rect, yaw, roll, quality, Random.nextBytes(20), "format")
 
     companion object {
         private const val QUALITY_THRESHOLD = -1f

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
@@ -522,6 +522,8 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         threshold = 0.5f,
         maxAttempts = 2,
         maxBitmapSize = 1500,
+        validationUiDurationMs = 1000,
+        validationErrorUiDurationMs = 1000,
     )
 
     companion object {

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackAutoCaptureFragmentViewModelTest.kt
@@ -108,7 +108,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
 
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
 
         Truth
             .assertThat(currentDetection.observedValues)
@@ -128,7 +128,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
         viewModel.startCapture()
         viewModel.holdOffAutoCapture()
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
 
         Truth
             .assertThat(currentDetection.observedValues)
@@ -147,7 +147,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
         viewModel.startCapture()
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
 
         Truth.assertThat(currentDetection.observedValues.last()?.hasValidStatus()).isEqualTo(true)
         Truth
@@ -164,9 +164,9 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
         viewModel.startCapture()
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
         viewModel.holdOffAutoCapture()
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
 
         Truth.assertThat(currentDetection.observedValues.last()?.hasValidStatus()).isEqualTo(true)
         Truth
@@ -186,8 +186,8 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
         viewModel.startCapture()
-        viewModel.process(frame)
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
 
         Truth
             .assertThat(currentDetection.observedValues.first()?.status)
@@ -209,9 +209,9 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
 
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
-        viewModel.process(frame) // a fallback image frame before the preparation delay elapses
+        viewModel.process(frame, frame) // a fallback image frame before the preparation delay elapses
         viewModel.startCapture()
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
 
         val currentDetection = viewModel.currentDetection.testObserver()
         Truth.assertThat(currentDetection.observedValues.last()?.hasValidStatus()).isEqualTo(true)
@@ -225,7 +225,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
 
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
         viewModel.startCapture()
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
         advanceTimeBy(AUTO_CAPTURE_IMAGING_DURATION_MS + 1)
 
         val currentDetection = viewModel.currentDetection.testObserver()
@@ -255,12 +255,12 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 2, 0)
         viewModel.startCapture()
 
-        viewModel.process(frame)
-        viewModel.process(frame)
-        viewModel.process(frame)
-        viewModel.process(frame)
-        viewModel.process(frame)
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
 
         detections.observedValues.let {
             Truth.assertThat(it[0]?.status).isEqualTo(FaceDetection.Status.TOOFAR)
@@ -289,11 +289,11 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
         // fallback image frames before the preparation delay elapses
-        viewModel.process(frame)
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
         viewModel.startCapture()
-        viewModel.process(frame)
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
 
         detections.observedValues.let {
             // fallback image frame wasn't observed during preparation delay
@@ -314,7 +314,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
         viewModel.startCapture()
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
         advanceTimeBy(AUTO_CAPTURE_IMAGING_DURATION_MS)
         Truth
             .assertThat(capturingState.observedValues.last())
@@ -340,7 +340,7 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
         viewModel.startCapture()
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
         advanceTimeBy(configDuration / 2)
         Truth
             .assertThat(capturingState.observedValues.last())
@@ -362,10 +362,10 @@ internal class LiveFeedbackAutoCaptureFragmentViewModelTest {
         val samplesToKeep = 2
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, samplesToKeep, 0)
-        viewModel.process(frame) // won't be observed during the preparation phase
+        viewModel.process(frame, frame) // won't be observed during the preparation phase
         viewModel.startCapture()
         repeat(100) {
-            viewModel.process(frame)
+            viewModel.process(frame, frame)
         }
         advanceTimeBy(AUTO_CAPTURE_IMAGING_DURATION_MS + 1)
 

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
@@ -99,7 +99,7 @@ internal class LiveFeedbackFragmentViewModelTest {
 
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
 
         val currentDetection = viewModel.currentDetection.testObserver()
         assertThat(currentDetection.observedValues.last()?.status).isEqualTo(FaceDetection.Status.VALID)
@@ -113,9 +113,9 @@ internal class LiveFeedbackFragmentViewModelTest {
 
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
         viewModel.startCapture()
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
 
         val currentDetection = viewModel.currentDetection.testObserver()
         assertThat(currentDetection.observedValues.last()?.status).isEqualTo(FaceDetection.Status.VALID_CAPTURING)
@@ -143,12 +143,12 @@ internal class LiveFeedbackFragmentViewModelTest {
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 2, 0)
 
-        viewModel.process(frame)
-        viewModel.process(frame)
-        viewModel.process(frame)
-        viewModel.process(frame)
-        viewModel.process(frame)
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
 
         detections.observedValues.let {
             assertThat(it[0]?.status).isEqualTo(FaceDetection.Status.TOOFAR)
@@ -175,9 +175,9 @@ internal class LiveFeedbackFragmentViewModelTest {
         val detections = viewModel.currentDetection.testObserver()
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
-        viewModel.process(frame)
-        viewModel.process(frame)
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
 
         detections.observedValues.let {
             assertThat(it[0]?.status).isEqualTo(FaceDetection.Status.VALID)
@@ -195,10 +195,10 @@ internal class LiveFeedbackFragmentViewModelTest {
         val capturingStateObserver = viewModel.capturingState.testObserver()
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 2, 0)
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
         viewModel.startCapture()
-        viewModel.process(frame)
-        viewModel.process(frame)
+        viewModel.process(frame, frame)
+        viewModel.process(frame, frame)
 
         currentDetectionObserver.observedValues.let {
             assertThat(it[0]?.status).isEqualTo(FaceDetection.Status.VALID)

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
@@ -350,6 +350,8 @@ internal class LiveFeedbackFragmentViewModelTest {
         threshold = 0.5f,
         maxAttempts = 2,
         maxBitmapSize = 1500,
+        validationUiDurationMs = 1000,
+        validationErrorUiDurationMs = 1000,
     )
 
     companion object {

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
@@ -246,7 +246,7 @@ internal class LiveFeedbackFragmentViewModelTest {
                 any(),
                 any(),
             )
-        } returns FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.RECORDED, 0.5f)
+        } returns FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.RECORDED, 0.5f, 2)
         every { faceDetector.analyze(frame) } returns validFace
         coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
 
@@ -269,7 +269,7 @@ internal class LiveFeedbackFragmentViewModelTest {
     fun `Spoof check Enforced passed finishes capture`() = runTest {
         val validFace: Face = getFace()
         every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
-            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
         every { faceDetector.analyze(frame) } returns validFace
         coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.1f)
 
@@ -296,7 +296,7 @@ internal class LiveFeedbackFragmentViewModelTest {
                 any(),
                 any(),
             )
-        } returns FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+        } returns FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
         every { faceDetector.analyze(frame) } returns validFace
         coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
 
@@ -324,7 +324,7 @@ internal class LiveFeedbackFragmentViewModelTest {
                 any(),
                 any(),
             )
-        } returns FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+        } returns FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
         every { faceDetector.analyze(frame) } returns validFace
         coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
 

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
@@ -124,7 +124,7 @@ internal class LiveFeedbackFragmentViewModelTest {
         val currentDetection = viewModel.currentDetection.testObserver()
         assertThat(currentDetection.observedValues.last()?.status).isEqualTo(FaceDetection.Status.VALID_CAPTURING)
 
-        coVerify { eventReporter.addCaptureEvents(any(), any(), any()) }
+        coVerify { eventReporter.addCaptureEvents(any(), any(), any(), any()) }
     }
 
     @Test
@@ -162,7 +162,7 @@ internal class LiveFeedbackFragmentViewModelTest {
             assertThat(it[4]?.status).isEqualTo(FaceDetection.Status.NOFACE)
         }
 
-        coVerify(exactly = 0) { eventReporter.addCaptureEvents(any(), any(), any()) }
+        coVerify(exactly = 0) { eventReporter.addCaptureEvents(any(), any(), any(), any()) }
     }
 
     @Test
@@ -236,7 +236,7 @@ internal class LiveFeedbackFragmentViewModelTest {
         }
 
         coVerify { eventReporter.addFallbackCaptureEvent(any(), any()) }
-        coVerify(exactly = 3) { eventReporter.addCaptureEvents(any(), any(), any()) }
+        coVerify(exactly = 3) { eventReporter.addCaptureEvents(any(), any(), any(), any()) }
     }
 
     @Test

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
@@ -13,6 +13,7 @@ import com.simprints.face.capture.usecases.IsUsingAutoCaptureUseCase
 import com.simprints.face.capture.usecases.SimpleCaptureEventReporter
 import com.simprints.face.infra.basebiosdk.detection.Face
 import com.simprints.face.infra.basebiosdk.detection.FaceDetector
+import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
 import com.simprints.face.infra.biosdkresolver.ResolveFaceBioSdkUseCase
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.FaceConfiguration
@@ -21,6 +22,7 @@ import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import com.simprints.testtools.common.livedata.testObserver
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -90,6 +92,7 @@ internal class LiveFeedbackFragmentViewModelTest {
             timeHelper,
             isUsingAutoCapture,
             getSpoofCheckConfiguration,
+            testCoroutineRule.testCoroutineDispatcher,
         )
     }
 
@@ -233,6 +236,119 @@ internal class LiveFeedbackFragmentViewModelTest {
 
         coVerify { eventReporter.addFallbackCaptureEvent(any(), any()) }
         coVerify(exactly = 3) { eventReporter.addCaptureEvents(any(), any(), any()) }
+    }
+
+    @Test
+    fun `Spoof check Recorded finishes capture regardless of spoof result`() = runTest {
+        val validFace: Face = getFace()
+        every {
+            getSpoofCheckConfiguration.invoke(
+                any(),
+                any(),
+            )
+        } returns FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.RECORDED, 0.5f)
+        every { faceDetector.analyze(frame) } returns validFace
+        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
+
+        val capturingStateObserver = viewModel.capturingState.testObserver()
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+
+        viewModel.process(frame, frame)
+        viewModel.startCapture()
+        viewModel.process(frame, frame)
+
+        advanceUntilIdle()
+
+        assertThat(capturingStateObserver.observedValues.last()).isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.FINISHED)
+        assertThat(viewModel.sortedQualifyingCaptures.size).isEqualTo(1)
+        assertThat(viewModel.sortedQualifyingCaptures[0].spoofCheckResult?.score).isEqualTo(0.9f)
+    }
+
+    @Test
+    fun `Spoof check Enforced passed finishes capture`() = runTest {
+        val validFace: Face = getFace()
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
+            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+        every { faceDetector.analyze(frame) } returns validFace
+        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.1f)
+
+        val capturingStateObserver = viewModel.capturingState.testObserver()
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+
+        viewModel.process(frame, frame)
+        viewModel.startCapture()
+        viewModel.process(frame, frame)
+
+        advanceUntilIdle()
+
+        assertThat(capturingStateObserver.observedValues.last()).isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.FINISHED)
+        assertThat(viewModel.sortedQualifyingCaptures.size).isEqualTo(1)
+        assertThat(viewModel.sortedQualifyingCaptures[0].spoofCheckResult?.score).isEqualTo(0.1f)
+    }
+
+    @Test
+    fun `Spoof check Enforced failed resets state`() = runTest {
+        val validFace: Face = getFace()
+        every {
+            getSpoofCheckConfiguration.invoke(
+                any(),
+                any(),
+            )
+        } returns FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+        every { faceDetector.analyze(frame) } returns validFace
+        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
+
+        val capturingStateObserver = viewModel.capturingState.testObserver()
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+
+        viewModel.process(frame, frame)
+        viewModel.startCapture()
+        viewModel.process(frame, frame)
+
+        advanceUntilIdle()
+
+        assertThat(capturingStateObserver.observedValues).contains(LiveFeedbackFragmentViewModel.CapturingState.VALIDATION_FAILED)
+        assertThat(capturingStateObserver.observedValues.last()).isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.NOT_STARTED)
+        assertThat(viewModel.sortedQualifyingCaptures.size).isEqualTo(0)
+        assertThat(viewModel.userCaptures.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `Spoof check Enforced failed max times finishes capture`() = runTest {
+        val validFace: Face = getFace()
+        every {
+            getSpoofCheckConfiguration.invoke(
+                any(),
+                any(),
+            )
+        } returns FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f)
+        every { faceDetector.analyze(frame) } returns validFace
+        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
+
+        val capturingStateObserver = viewModel.capturingState.testObserver()
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+
+        // Attempt 1
+        viewModel.process(frame, frame)
+        viewModel.startCapture()
+        viewModel.process(frame, frame)
+
+        advanceUntilIdle()
+
+        assertThat(capturingStateObserver.observedValues.last()).isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.NOT_STARTED)
+
+        // Attempt 2
+        viewModel.process(frame, frame)
+        viewModel.startCapture()
+        viewModel.process(frame, frame)
+
+        advanceUntilIdle()
+
+        assertThat(capturingStateObserver.observedValues.last()).isEqualTo(LiveFeedbackFragmentViewModel.CapturingState.FINISHED)
     }
 
     private fun getFace(

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
@@ -17,6 +17,7 @@ import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
 import com.simprints.face.infra.biosdkresolver.ResolveFaceBioSdkUseCase
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.FaceConfiguration
+import com.simprints.infra.config.store.models.FaceConfiguration.SpoofCheckConfiguration
 import com.simprints.infra.config.store.models.ModalitySdkType
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import com.simprints.testtools.common.livedata.testObserver
@@ -241,14 +242,9 @@ internal class LiveFeedbackFragmentViewModelTest {
     @Test
     fun `Spoof check Recorded finishes capture regardless of spoof result`() = runTest {
         val validFace: Face = getFace()
-        every {
-            getSpoofCheckConfiguration.invoke(
-                any(),
-                any(),
-            )
-        } returns FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.RECORDED, 0.5f, 2)
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns getDefaultSpoofConfig()
         every { faceDetector.analyze(frame) } returns validFace
-        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
+        coEvery { faceDetector.spoofCheck(any(), any()) } returns SpoofCheckResult(score = 0.9f)
 
         val capturingStateObserver = viewModel.capturingState.testObserver()
         viewModel.initAutoCapture()
@@ -268,10 +264,9 @@ internal class LiveFeedbackFragmentViewModelTest {
     @Test
     fun `Spoof check Enforced passed finishes capture`() = runTest {
         val validFace: Face = getFace()
-        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns
-            FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns getDefaultSpoofConfig(FaceConfiguration.SpoofCheckMode.ENFORCED)
         every { faceDetector.analyze(frame) } returns validFace
-        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.1f)
+        coEvery { faceDetector.spoofCheck(any(), any()) } returns SpoofCheckResult(score = 0.1f)
 
         val capturingStateObserver = viewModel.capturingState.testObserver()
         viewModel.initAutoCapture()
@@ -291,14 +286,9 @@ internal class LiveFeedbackFragmentViewModelTest {
     @Test
     fun `Spoof check Enforced failed resets state`() = runTest {
         val validFace: Face = getFace()
-        every {
-            getSpoofCheckConfiguration.invoke(
-                any(),
-                any(),
-            )
-        } returns FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns getDefaultSpoofConfig(FaceConfiguration.SpoofCheckMode.ENFORCED)
         every { faceDetector.analyze(frame) } returns validFace
-        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
+        coEvery { faceDetector.spoofCheck(any(), any()) } returns SpoofCheckResult(score = 0.9f)
 
         val capturingStateObserver = viewModel.capturingState.testObserver()
         viewModel.initAutoCapture()
@@ -319,14 +309,9 @@ internal class LiveFeedbackFragmentViewModelTest {
     @Test
     fun `Spoof check Enforced failed max times finishes capture`() = runTest {
         val validFace: Face = getFace()
-        every {
-            getSpoofCheckConfiguration.invoke(
-                any(),
-                any(),
-            )
-        } returns FaceConfiguration.SpoofCheckConfiguration(FaceConfiguration.SpoofCheckMode.ENFORCED, 0.5f, 2)
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns getDefaultSpoofConfig(FaceConfiguration.SpoofCheckMode.ENFORCED)
         every { faceDetector.analyze(frame) } returns validFace
-        coEvery { faceDetector.spoofCheck(any()) } returns SpoofCheckResult(score = 0.9f)
+        coEvery { faceDetector.spoofCheck(any(), any()) } returns SpoofCheckResult(score = 0.9f)
 
         val capturingStateObserver = viewModel.capturingState.testObserver()
         viewModel.initAutoCapture()
@@ -357,6 +342,15 @@ internal class LiveFeedbackFragmentViewModelTest {
         yaw: Float = 0f,
         roll: Float = 0f,
     ) = Face(100, 100, rect, yaw, roll, quality, Random.nextBytes(20), "format")
+
+    private fun getDefaultSpoofConfig(
+        mode: FaceConfiguration.SpoofCheckMode = FaceConfiguration.SpoofCheckMode.RECORDED,
+    ): SpoofCheckConfiguration = SpoofCheckConfiguration(
+        mode = mode,
+        threshold = 0.5f,
+        maxAttempts = 2,
+        maxBitmapSize = 1500,
+    )
 
     companion object {
         private const val QUALITY_THRESHOLD = -1f

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragmentViewModelTest.kt
@@ -8,12 +8,14 @@ import com.google.common.truth.Truth.*
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.face.capture.models.FaceDetection
+import com.simprints.face.capture.usecases.GetSpoofCheckConfigurationUseCase
 import com.simprints.face.capture.usecases.IsUsingAutoCaptureUseCase
 import com.simprints.face.capture.usecases.SimpleCaptureEventReporter
 import com.simprints.face.infra.basebiosdk.detection.Face
 import com.simprints.face.infra.basebiosdk.detection.FaceDetector
 import com.simprints.face.infra.biosdkresolver.ResolveFaceBioSdkUseCase
 import com.simprints.infra.config.store.ConfigRepository
+import com.simprints.infra.config.store.models.FaceConfiguration
 import com.simprints.infra.config.store.models.ModalitySdkType
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
 import com.simprints.testtools.common.livedata.testObserver
@@ -54,6 +56,9 @@ internal class LiveFeedbackFragmentViewModelTest {
 
     @MockK
     private lateinit var isUsingAutoCapture: IsUsingAutoCaptureUseCase
+
+    @MockK
+    private lateinit var getSpoofCheckConfiguration: GetSpoofCheckConfigurationUseCase
     private lateinit var viewModel: LiveFeedbackFragmentViewModel
 
     @Before
@@ -68,6 +73,8 @@ internal class LiveFeedbackFragmentViewModelTest {
                 ?.qualityThreshold
         } returns QUALITY_THRESHOLD
         every { isUsingAutoCapture.invoke(any()) } returns false
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns FaceConfiguration.SpoofCheckConfiguration.DISABLED
+
         every { timeHelper.now() } returnsMany (0..100L).map { Timestamp(it) }
         justRun { previewFrame.recycle() }
         val resolveFaceBioSdkUseCase = mockk<ResolveFaceBioSdkUseCase> {
@@ -82,6 +89,7 @@ internal class LiveFeedbackFragmentViewModelTest {
             eventReporter,
             timeHelper,
             isUsingAutoCapture,
+            getSpoofCheckConfiguration,
         )
     }
 

--- a/face/capture/src/test/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCaseTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCaseTest.kt
@@ -1,0 +1,80 @@
+package com.simprints.face.capture.usecases
+
+import com.google.common.truth.Truth.*
+import com.simprints.face.infra.biosdkresolver.RocV3BioSdk
+import com.simprints.infra.config.store.models.FaceConfiguration
+import com.simprints.infra.config.store.models.FaceConfiguration.SpoofCheckConfiguration
+import com.simprints.infra.config.store.models.ModalitySdkType
+import com.simprints.infra.config.store.models.ProjectConfiguration
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Before
+import org.junit.Test
+
+class GetSpoofCheckConfigurationUseCaseTest {
+    @MockK
+    private lateinit var projectConfiguration: ProjectConfiguration
+
+    @MockK
+    private lateinit var faceConfiguration: FaceConfiguration
+
+    @MockK
+    private lateinit var faceSdkConfiguration: FaceConfiguration.FaceSdkConfiguration
+
+    @MockK
+    private lateinit var rocV3BioSdk: RocV3BioSdk
+
+    private lateinit var useCase: GetSpoofCheckConfigurationUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        every { rocV3BioSdk.version() } returns "3.1"
+
+        useCase = GetSpoofCheckConfigurationUseCase(rocV3BioSdk)
+    }
+
+    @Test
+    fun `Returns disabled when face is null`() {
+        every { projectConfiguration.face } returns null
+        val result = useCase(projectConfiguration, ModalitySdkType.RANK_ONE)
+
+        assertThat(result).isEqualTo(SpoofCheckConfiguration.DISABLED)
+    }
+
+    @Test
+    fun `Returns disabled when face sdk config is not ROC`() {
+        val result = useCase(projectConfiguration, ModalitySdkType.SIM_FACE)
+
+        assertThat(result).isEqualTo(SpoofCheckConfiguration.DISABLED)
+    }
+
+    @Test
+    fun `Returns disabled when face sdk config is not ROC V3`() {
+        every { projectConfiguration.face } returns faceConfiguration
+        every { faceConfiguration.getSdkConfiguration(any()) } returns faceSdkConfiguration
+        every { faceSdkConfiguration.version } returns "1.0"
+
+        val result = useCase(projectConfiguration, ModalitySdkType.RANK_ONE)
+
+        assertThat(result).isEqualTo(SpoofCheckConfiguration.DISABLED)
+    }
+
+    @Test
+    fun `Returns config when ROC V3 is used`() {
+        every { projectConfiguration.face } returns faceConfiguration
+        every { faceConfiguration.getSdkConfiguration(any()) } returns faceSdkConfiguration
+        every { faceSdkConfiguration.version } returns "3.1"
+        every { projectConfiguration.custom } returns mapOf(
+            "spoofCheckMode" to JsonPrimitive("ENFORCED"),
+            "spoofCheckThreshold" to JsonPrimitive(0.75f),
+        )
+
+        val result = useCase(projectConfiguration, ModalitySdkType.RANK_ONE)
+
+        assertThat(result.mode).isEqualTo(FaceConfiguration.SpoofCheckMode.ENFORCED)
+        assertThat(result.threshold).isEqualTo(0.75f)
+    }
+}

--- a/face/capture/src/test/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCaseTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCaseTest.kt
@@ -70,11 +70,15 @@ class GetSpoofCheckConfigurationUseCaseTest {
         every { projectConfiguration.custom } returns mapOf(
             "spoofCheckMode" to JsonPrimitive("ENFORCED"),
             "spoofCheckThreshold" to JsonPrimitive(0.75f),
+            "spoofMaxAttempts" to JsonPrimitive(3),
+            "spoofMaxBitmapSize" to JsonPrimitive(1000),
         )
 
         val result = useCase(projectConfiguration, ModalitySdkType.RANK_ONE)
 
         assertThat(result.mode).isEqualTo(FaceConfiguration.SpoofCheckMode.ENFORCED)
         assertThat(result.threshold).isEqualTo(0.75f)
+        assertThat(result.maxAttempts).isEqualTo(3)
+        assertThat(result.maxBitmapSize).isEqualTo(1000)
     }
 }

--- a/face/capture/src/test/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporterTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporterTest.kt
@@ -1,7 +1,7 @@
 package com.simprints.face.capture.usecases
 
 import android.graphics.Rect
-import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.*
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.core.tools.utils.EncodingUtils
@@ -16,11 +16,8 @@ import com.simprints.infra.events.event.domain.models.FaceFallbackCaptureEvent
 import com.simprints.infra.events.event.domain.models.FaceOnboardingCompleteEvent
 import com.simprints.infra.events.session.SessionEventRepository
 import com.simprints.testtools.common.coroutines.TestCoroutineRule
-import io.mockk.MockKAnnotations
-import io.mockk.coVerify
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -200,8 +197,17 @@ class SimpleCaptureEventReporterTest {
         }
     }
 
-    private fun getDetection(status: FaceDetection.Status) =
-        FaceDetection(mockk(), getFace(), status, mockk(), Timestamp(1L), false, "id", Timestamp(1L))
+    private fun getDetection(status: FaceDetection.Status) = FaceDetection(
+        mockk(),
+        mockk(),
+        getFace(),
+        status,
+        mockk(),
+        Timestamp(1L),
+        false,
+        "id",
+        Timestamp(1L),
+    )
 
     private fun getFace() = Face(
         100,

--- a/face/capture/src/test/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporterTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporterTest.kt
@@ -9,6 +9,8 @@ import com.simprints.face.capture.models.FaceDetection
 import com.simprints.face.infra.basebiosdk.detection.Face
 import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
 import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult.SkipReason
+import com.simprints.infra.config.store.models.FaceConfiguration
+import com.simprints.infra.config.store.models.FaceConfiguration.SpoofCheckConfiguration
 import com.simprints.infra.events.event.domain.models.BiometricReferenceCreationEvent
 import com.simprints.infra.events.event.domain.models.BiometricReferenceCreationEvent.BiometricReferenceCreationPayload
 import com.simprints.infra.events.event.domain.models.FaceCaptureBiometricsEvent
@@ -111,7 +113,7 @@ class SimpleCaptureEventReporterTest {
 
     @Test
     fun `Adds capture and biometric event for valid detection`() = runTest {
-        reporter.addCaptureEvents(getDetection(FaceDetection.Status.VALID), 1, 0.5f)
+        reporter.addCaptureEvents(getDetection(FaceDetection.Status.VALID), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
 
         coVerify {
             eventRepository.addOrUpdateEvent(
@@ -129,7 +131,7 @@ class SimpleCaptureEventReporterTest {
 
     @Test
     fun `Adds capture and biometric event for valid_capturing detection`() = runTest {
-        reporter.addCaptureEvents(getDetection(FaceDetection.Status.VALID_CAPTURING), 1, 0.5f)
+        reporter.addCaptureEvents(getDetection(FaceDetection.Status.VALID_CAPTURING), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
 
         coVerify {
             eventRepository.addOrUpdateEvent(
@@ -147,33 +149,85 @@ class SimpleCaptureEventReporterTest {
 
     @Test
     fun `Adds capture and no biometric event for invalid detections`() = runTest {
-        reporter.addCaptureEvents(getDetection(FaceDetection.Status.NOFACE), 1, 0.5f)
-        reporter.addCaptureEvents(getDetection(FaceDetection.Status.OFFYAW), 1, 0.5f)
-        reporter.addCaptureEvents(getDetection(FaceDetection.Status.OFFROLL), 1, 0.5f)
-        reporter.addCaptureEvents(getDetection(FaceDetection.Status.TOOCLOSE), 1, 0.5f)
-        reporter.addCaptureEvents(getDetection(FaceDetection.Status.TOOFAR), 1, 0.5f)
-        reporter.addCaptureEvents(getDetection(FaceDetection.Status.BAD_QUALITY), 1, 0.5f)
+        reporter.addCaptureEvents(getDetection(FaceDetection.Status.NOFACE), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
+        reporter.addCaptureEvents(getDetection(FaceDetection.Status.OFFYAW), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
+        reporter.addCaptureEvents(getDetection(FaceDetection.Status.OFFROLL), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
+        reporter.addCaptureEvents(getDetection(FaceDetection.Status.TOOCLOSE), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
+        reporter.addCaptureEvents(getDetection(FaceDetection.Status.TOOFAR), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
+        reporter.addCaptureEvents(getDetection(FaceDetection.Status.BAD_QUALITY), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
 
         coVerify(exactly = 6) {
+            eventRepository.addOrUpdateEvent(withArg { assertThat(it).isInstanceOf(FaceCaptureEvent::class.java) })
+        }
+        coVerify(exactly = 0) {
+            eventRepository.addOrUpdateEvent(withArg { assertThat(it).isInstanceOf(FaceCaptureBiometricsEvent::class.java) })
+        }
+    }
+
+    @Test
+    fun `Correctly marks only spoofed detections when enabled spoof check`() = runTest {
+        // Should not be marked as SPOOFED
+        reporter.addCaptureEvents(
+            getDetection(FaceDetection.Status.VALID).copy(spoofCheckResult = SpoofCheckResult(0f, skipReason = SkipReason.IOD_TOO_SMALL)),
+            1,
+            0.5f,
+            getEnforcedSpoofConfig(),
+        )
+        reporter.addCaptureEvents(
+            getDetection(FaceDetection.Status.VALID).copy(spoofCheckResult = SpoofCheckResult(0.5f)),
+            1,
+            0.5f,
+            getEnforcedSpoofConfig().copy(mode = FaceConfiguration.SpoofCheckMode.RECORDED),
+        )
+        reporter.addCaptureEvents(
+            getDetection(FaceDetection.Status.VALID).copy(spoofCheckResult = SpoofCheckResult(0.1f)),
+            1,
+            0.5f,
+            getEnforcedSpoofConfig(),
+        )
+        reporter.addCaptureEvents(
+            getDetection(FaceDetection.Status.VALID).copy(spoofCheckResult = null),
+            1,
+            0.5f,
+            getEnforcedSpoofConfig(),
+        )
+        // Should be marked as SPOOFED
+        reporter.addCaptureEvents(
+            getDetection(FaceDetection.Status.VALID).copy(spoofCheckResult = SpoofCheckResult(0.9f)),
+            1,
+            0.5f,
+            getEnforcedSpoofConfig(),
+        )
+
+        coVerify(exactly = 4) {
             eventRepository.addOrUpdateEvent(
-                withArg {
-                    assertThat(it).isInstanceOf(FaceCaptureEvent::class.java)
+                match<FaceCaptureEvent> {
+                    it.payload.result == FaceCaptureEvent.FaceCapturePayload.Result.VALID
                 },
             )
         }
-        coVerify(exactly = 0) {
+        coVerify(exactly = 1) {
             eventRepository.addOrUpdateEvent(
-                withArg {
-                    assertThat(it).isInstanceOf(FaceCaptureBiometricsEvent::class.java)
+                match<FaceCaptureEvent> {
+                    it.payload.result == FaceCaptureEvent.FaceCapturePayload.Result.SPOOFED
                 },
             )
         }
     }
 
+    private fun getEnforcedSpoofConfig(): SpoofCheckConfiguration = SpoofCheckConfiguration(
+        mode = FaceConfiguration.SpoofCheckMode.ENFORCED,
+        maxAttempts = 0,
+        maxBitmapSize = 0,
+        validationUiDurationMs = 0,
+        validationErrorUiDurationMs = 0,
+        threshold = 0.3f,
+    )
+
     @Test
     fun `Adds capture event with correct auto-capture flag`() = runTest {
         listOf(true, false).forEach { isAutoCapture ->
-            reporter.addCaptureEvents(getDetection(FaceDetection.Status.VALID), 1, 0.5f, isAutoCapture)
+            reporter.addCaptureEvents(getDetection(FaceDetection.Status.VALID), 1, 0.5f, SpoofCheckConfiguration.DISABLED, isAutoCapture)
             coVerify {
                 eventRepository.addOrUpdateEvent(
                     withArg {
@@ -201,13 +255,13 @@ class SimpleCaptureEventReporterTest {
 
     @Test
     fun `Correctly maps spoof skip reasons`() = runTest {
-        reporter.addCaptureEvents(getSpoofedDetection(SkipReason.NOT_AVAILABLE), 1, 0.5f)
+        reporter.addCaptureEvents(getSpoofedDetection(SkipReason.NOT_AVAILABLE), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
         // to null,
-        reporter.addCaptureEvents(getSpoofedDetection(SkipReason.IOD_TOO_SMALL), 1, 0.5f)
+        reporter.addCaptureEvents(getSpoofedDetection(SkipReason.IOD_TOO_SMALL), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
         // to FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IMAGE_TOO_SMALL,
-        reporter.addCaptureEvents(getSpoofedDetection(SkipReason.IOD_TOO_LARGE), 1, 0.5f)
+        reporter.addCaptureEvents(getSpoofedDetection(SkipReason.IOD_TOO_LARGE), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
         // to FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IOD_TOO_LARGE,
-        reporter.addCaptureEvents(getSpoofedDetection(SkipReason.IMAGE_TOO_SMALL), 1, 0.5f)
+        reporter.addCaptureEvents(getSpoofedDetection(SkipReason.IMAGE_TOO_SMALL), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
         // to FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IMAGE_TOO_SMALL,
 
         coVerify(exactly = 1) {

--- a/face/capture/src/test/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporterTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporterTest.kt
@@ -7,6 +7,8 @@ import com.simprints.core.tools.time.Timestamp
 import com.simprints.core.tools.utils.EncodingUtils
 import com.simprints.face.capture.models.FaceDetection
 import com.simprints.face.infra.basebiosdk.detection.Face
+import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
+import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult.SkipReason
 import com.simprints.infra.events.event.domain.models.BiometricReferenceCreationEvent
 import com.simprints.infra.events.event.domain.models.BiometricReferenceCreationEvent.BiometricReferenceCreationPayload
 import com.simprints.infra.events.event.domain.models.FaceCaptureBiometricsEvent
@@ -195,6 +197,47 @@ class SimpleCaptureEventReporterTest {
                 },
             )
         }
+    }
+
+    @Test
+    fun `Correctly maps spoof skip reasons`() = runTest {
+        reporter.addCaptureEvents(getSpoofedDetection(SkipReason.NOT_AVAILABLE), 1, 0.5f)
+        // to null,
+        reporter.addCaptureEvents(getSpoofedDetection(SkipReason.IOD_TOO_SMALL), 1, 0.5f)
+        // to FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IMAGE_TOO_SMALL,
+        reporter.addCaptureEvents(getSpoofedDetection(SkipReason.IOD_TOO_LARGE), 1, 0.5f)
+        // to FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IOD_TOO_LARGE,
+        reporter.addCaptureEvents(getSpoofedDetection(SkipReason.IMAGE_TOO_SMALL), 1, 0.5f)
+        // to FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IMAGE_TOO_SMALL,
+
+        coVerify(exactly = 1) {
+            eventRepository.addOrUpdateEvent(
+                match<FaceCaptureEvent> {
+                    it.payload.face?.spoofSkipReason == FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IMAGE_TOO_SMALL
+                },
+            )
+        }
+        coVerify(exactly = 1) {
+            eventRepository.addOrUpdateEvent(
+                match<FaceCaptureEvent> {
+                    it.payload.face?.spoofSkipReason == FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IOD_TOO_SMALL
+                },
+            )
+        }
+        coVerify(exactly = 1) {
+            eventRepository.addOrUpdateEvent(
+                match<FaceCaptureEvent> {
+                    it.payload.face?.spoofSkipReason == FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IOD_TOO_LARGE
+                },
+            )
+        }
+        coVerify(exactly = 1) {
+            eventRepository.addOrUpdateEvent(match { it is FaceCaptureEvent && it.payload.face?.spoofSkipReason == null })
+        }
+    }
+
+    private fun getSpoofedDetection(reason: SkipReason) = getDetection(FaceDetection.Status.VALID).also {
+        it.spoofCheckResult = SpoofCheckResult(0f, reason)
     }
 
     private fun getDetection(status: FaceDetection.Status) = FaceDetection(

--- a/face/infra/base-bio-sdk/src/main/java/com/simprints/face/infra/basebiosdk/detection/FaceDetector.kt
+++ b/face/infra/base-bio-sdk/src/main/java/com/simprints/face/infra/basebiosdk/detection/FaceDetector.kt
@@ -2,7 +2,7 @@ package com.simprints.face.infra.basebiosdk.detection
 
 import android.graphics.Bitmap
 
-fun interface FaceDetector {
+interface FaceDetector {
     /**
      * Analyze an ARGB_8888 bitmap and return the detected face data
      *
@@ -10,4 +10,12 @@ fun interface FaceDetector {
      * @return Face object or null if no face is detected
      */
     fun analyze(bitmap: Bitmap): Face?
+
+    /**
+     * Perform a spoof check on an ARGB_8888 bitmap
+     *
+     * @param bitmap original captured image (ARGB_8888)
+     * @return Either a spoof score (lower is better) or a reason why the check was skipped
+     */
+    fun spoofCheck(bitmap: Bitmap): SpoofCheckResult
 }

--- a/face/infra/base-bio-sdk/src/main/java/com/simprints/face/infra/basebiosdk/detection/FaceDetector.kt
+++ b/face/infra/base-bio-sdk/src/main/java/com/simprints/face/infra/basebiosdk/detection/FaceDetector.kt
@@ -17,5 +17,8 @@ interface FaceDetector {
      * @param bitmap original captured image (ARGB_8888)
      * @return Either a spoof score (lower is better) or a reason why the check was skipped
      */
-    fun spoofCheck(bitmap: Bitmap): SpoofCheckResult
+    fun spoofCheck(
+        bitmap: Bitmap,
+        configuredMaxSize: Int,
+    ): SpoofCheckResult
 }

--- a/face/infra/base-bio-sdk/src/main/java/com/simprints/face/infra/basebiosdk/detection/SpoofCheckResult.kt
+++ b/face/infra/base-bio-sdk/src/main/java/com/simprints/face/infra/basebiosdk/detection/SpoofCheckResult.kt
@@ -1,0 +1,13 @@
+package com.simprints.face.infra.basebiosdk.detection
+
+data class SpoofCheckResult(
+    val score: Float,
+    val skipReason: SkipReason? = null,
+) {
+    enum class SkipReason {
+        NOT_AVAILABLE,
+        IMAGE_TOO_SMALL,
+        IOD_TOO_SMALL,
+        IOD_TOO_LARGE,
+    }
+}

--- a/face/infra/roc-v1/src/main/java/com/simprints/face/infra/rocv1/detection/RocV1Detector.kt
+++ b/face/infra/roc-v1/src/main/java/com/simprints/face/infra/rocv1/detection/RocV1Detector.kt
@@ -5,6 +5,7 @@ import android.graphics.Rect
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
 import com.simprints.face.infra.basebiosdk.detection.Face
 import com.simprints.face.infra.basebiosdk.detection.FaceDetector
+import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
 import io.rankone.rocsdk.embedded.SWIGTYPE_p_float
 import io.rankone.rocsdk.embedded.SWIGTYPE_p_unsigned_char
 import io.rankone.rocsdk.embedded.roc
@@ -45,6 +46,8 @@ class RocV1Detector @Inject constructor() : FaceDetector {
             roc.delete_float(quality)
         }
     }
+
+    override fun spoofCheck(bitmap: Bitmap) = SpoofCheckResult(0f, SpoofCheckResult.SkipReason.NOT_AVAILABLE)
 
     override fun analyze(bitmap: Bitmap): Face? {
         val rocColorImage = roc_image()

--- a/face/infra/roc-v1/src/main/java/com/simprints/face/infra/rocv1/detection/RocV1Detector.kt
+++ b/face/infra/roc-v1/src/main/java/com/simprints/face/infra/rocv1/detection/RocV1Detector.kt
@@ -47,7 +47,10 @@ class RocV1Detector @Inject constructor() : FaceDetector {
         }
     }
 
-    override fun spoofCheck(bitmap: Bitmap) = SpoofCheckResult(0f, SpoofCheckResult.SkipReason.NOT_AVAILABLE)
+    override fun spoofCheck(
+        bitmap: Bitmap,
+        configuredMaxSize: Int,
+    ) = SpoofCheckResult(0f, SpoofCheckResult.SkipReason.NOT_AVAILABLE)
 
     override fun analyze(bitmap: Bitmap): Face? {
         val rocColorImage = roc_image()

--- a/face/infra/roc-v3/src/main/java/com/simprints/face/infra/rocv3/detection/RocV3Detector.kt
+++ b/face/infra/roc-v3/src/main/java/com/simprints/face/infra/rocv3/detection/RocV3Detector.kt
@@ -7,10 +7,12 @@ import ai.roc.rocsdk.embedded.roc_image
 import ai.roc.rocsdk.embedded.roc_landmark
 import android.graphics.Bitmap
 import android.graphics.Rect
+import androidx.core.graphics.scale
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
 import com.simprints.face.infra.basebiosdk.detection.Face
 import com.simprints.face.infra.basebiosdk.detection.FaceDetector
 import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
+import com.simprints.infra.logging.Simber
 import java.nio.ByteBuffer
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -65,14 +67,14 @@ class RocV3Detector @Inject constructor() : FaceDetector {
             val yawValue = roc3.float_value(yaw)
             val qualityValue = roc3.float_value(quality)
             Face(
-                width,
-                height,
-                detection.boundingRect(),
-                yawValue,
-                detection.rotation,
-                qualityValue,
-                roc3.cdata(roc3.roc_cast(template), roc3.ROC_FACE_FAST_FV_SIZE.toInt()),
-                RANK_ONE_TEMPLATE_FORMAT_3_1,
+                sourceWidth = width,
+                sourceHeight = height,
+                absoluteBoundingBox = detection.boundingRect(),
+                yaw = yawValue,
+                roll = detection.rotation,
+                quality = qualityValue,
+                template = roc3.cdata(roc3.roc_cast(template), roc3.ROC_FACE_FAST_FV_SIZE.toInt()),
+                format = RANK_ONE_TEMPLATE_FORMAT_3_1,
             )
         } else {
             null
@@ -175,20 +177,30 @@ class RocV3Detector @Inject constructor() : FaceDetector {
     }
 
     // TODO verify results
-    override fun spoofCheck(bitmap: Bitmap): SpoofCheckResult {
+    override fun spoofCheck(
+        bitmap: Bitmap,
+        configuredMaxSize: Int,
+    ): SpoofCheckResult {
         if (minOf(bitmap.width, bitmap.height) < SPOOF_MIN_SIZE) {
             // As per documentation - smallest dimension must be at least 720px
             return SpoofCheckResult(0f, SpoofCheckResult.SkipReason.IMAGE_TOO_SMALL)
         }
 
+        val maxSize = configuredMaxSize
+        val scaledBitmap = if (bitmap.width > maxSize) {
+            bitmap.scale(maxSize, (bitmap.height * maxSize.toFloat() / bitmap.width).toInt(), false)
+        } else {
+            bitmap
+        }
+
         val rocColorImage = roc_image()
         val rocGrayImage = roc_image()
-        val byteBuffer = bitmap.toByteBuffer()
+        val byteBuffer = scaledBitmap.toByteBuffer()
         roc3.roc_from_rgba(
             byteBuffer.array(),
-            bitmap.width.toLong(),
-            bitmap.height.toLong(),
-            bitmap.rowBytes.toLong(),
+            scaledBitmap.width.toLong(),
+            scaledBitmap.height.toLong(),
+            scaledBitmap.rowBytes.toLong(),
             rocColorImage,
         )
         roc3.roc_bgr2gray(rocColorImage, rocGrayImage)
@@ -268,6 +280,11 @@ class RocV3Detector @Inject constructor() : FaceDetector {
         roc3.roc_free_image(rocColorImage)
         detection.delete()
         byteBuffer.clear()
+
+        Simber.i(
+            "!!! width: ${scaledBitmap.width}, IOD: $iod, quality: ${roc3.float_value(quality)}, finalScore: $finalScore",
+            tag = "FACE_CAPTURE",
+        )
 
         return when {
             !faceDetected -> SpoofCheckResult(finalScore, SpoofCheckResult.SkipReason.NOT_AVAILABLE)

--- a/face/infra/roc-v3/src/main/java/com/simprints/face/infra/rocv3/detection/RocV3Detector.kt
+++ b/face/infra/roc-v3/src/main/java/com/simprints/face/infra/rocv3/detection/RocV3Detector.kt
@@ -184,8 +184,10 @@ class RocV3Detector @Inject constructor() : FaceDetector {
             return SpoofCheckResult(0f, SpoofCheckResult.SkipReason.IMAGE_TOO_SMALL)
         }
 
-        val scaledBitmap = if (bitmap.width > configuredMaxSize) {
-            bitmap.scale(configuredMaxSize, (bitmap.height * configuredMaxSize.toFloat() / bitmap.width).toInt(), false)
+        // Scaling image down to lower the chance that IOD is outside of requirements. The check also runs faster on smaller images.
+        val scaledBitmap = if (maxOf(bitmap.width, bitmap.height) > configuredMaxSize) {
+            val scale = configuredMaxSize.toFloat() / maxOf(bitmap.width, bitmap.height).toFloat()
+            bitmap.scale((bitmap.width * scale).toInt(), (bitmap.height * scale).toInt(), false)
         } else {
             bitmap
         }

--- a/face/infra/roc-v3/src/main/java/com/simprints/face/infra/rocv3/detection/RocV3Detector.kt
+++ b/face/infra/roc-v3/src/main/java/com/simprints/face/infra/rocv3/detection/RocV3Detector.kt
@@ -10,9 +10,11 @@ import android.graphics.Rect
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
 import com.simprints.face.infra.basebiosdk.detection.Face
 import com.simprints.face.infra.basebiosdk.detection.FaceDetector
+import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
 import java.nio.ByteBuffer
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.abs
 import ai.roc.rocsdk.embedded.roc as roc3
 
 @ExcludedFromGeneratedTestCoverageReports(
@@ -172,11 +174,118 @@ class RocV3Detector @Inject constructor() : FaceDetector {
         return byteBuffer
     }
 
+    // TODO verify results
+    override fun spoofCheck(bitmap: Bitmap): SpoofCheckResult {
+        if (minOf(bitmap.width, bitmap.height) < SPOOF_MIN_SIZE) {
+            // As per documentation - smallest dimension must be at least 720px
+            return SpoofCheckResult(0f, SpoofCheckResult.SkipReason.IMAGE_TOO_SMALL)
+        }
+
+        val rocColorImage = roc_image()
+        val rocGrayImage = roc_image()
+        val byteBuffer = bitmap.toByteBuffer()
+        roc3.roc_from_rgba(
+            byteBuffer.array(),
+            bitmap.width.toLong(),
+            bitmap.height.toLong(),
+            bitmap.rowBytes.toLong(),
+            rocColorImage,
+        )
+        roc3.roc_bgr2gray(rocColorImage, rocGrayImage)
+
+        val detection = roc_detection()
+        val faceDetected = isFaceDetected(rocColorImage, detection)
+
+        var iod = 0f
+        var finalScore = 0f
+
+        val quality = roc3.new_float() // TODO remove later
+
+        if (faceDetected) {
+            val rightEye = roc_landmark()
+            val leftEye = roc_landmark()
+            val chin = roc_landmark()
+
+            val landmarks = roc3.new_roc_landmark_array(roc3.roc_num_landmarks_for_pose(detection.pose))
+            roc3.roc_embedded_landmark_face(
+                rocGrayImage,
+                detection,
+                landmarks,
+                rightEye,
+                leftEye,
+                chin,
+                null,
+                null,
+            )
+            roc3.delete_roc_landmark_array(landmarks)
+
+            iod = abs(leftEye.x - rightEye.x)
+
+            // As per documentation - Inter-ocular distance must be in 100-320px range
+            if (iod in SPOOF_MIN_IOD..SPOOF_MAX_IOD) {
+                val embeddingSpoof = roc3.new_float()
+                val livenessSpoof = roc3.new_float()
+
+                roc3.roc_embedded_represent_face(
+                    rocColorImage,
+                    detection,
+                    rightEye,
+                    leftEye,
+                    chin,
+                    null,
+                    quality,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    embeddingSpoof,
+                )
+                val embeddingScore = roc3.float_value(embeddingSpoof)
+                roc3.delete_float(embeddingSpoof)
+
+                roc3.roc_embedded_liveness(
+                    rocGrayImage,
+                    rightEye,
+                    leftEye,
+                    chin,
+                    livenessSpoof,
+                )
+                val livenessScore = roc3.float_value(livenessSpoof)
+                roc3.delete_float(livenessSpoof)
+
+                // As per documentation - weighted average of 2 call scores with 75% weight for direct liveness result
+                finalScore = ((3 * livenessScore) + embeddingScore) / 4f
+            }
+            leftEye.delete()
+            rightEye.delete()
+            chin.delete()
+        }
+        roc3.roc_free_image(rocGrayImage)
+        roc3.roc_free_image(rocColorImage)
+        detection.delete()
+        byteBuffer.clear()
+
+        return when {
+            !faceDetected -> SpoofCheckResult(finalScore, SpoofCheckResult.SkipReason.NOT_AVAILABLE)
+            iod < SPOOF_MIN_IOD -> SpoofCheckResult(finalScore, SpoofCheckResult.SkipReason.IOD_TOO_SMALL)
+            iod > SPOOF_MAX_IOD -> SpoofCheckResult(finalScore, SpoofCheckResult.SkipReason.IOD_TOO_LARGE)
+            else -> SpoofCheckResult(finalScore)
+        }
+    }
+
     companion object {
         const val RANK_ONE_TEMPLATE_FORMAT_3_1 = "RANK_ONE_3_1"
         const val MAX_FACE_DETECTION = 1
         const val FALSE_DETECTION_RATE = 0.1f
         const val RELATIVE_MIN_SIZE = 0.2f
         const val ABSOLUTE_MIN_SIZE = 36L
+
+        private const val SPOOF_MIN_SIZE = 720
+        private const val SPOOF_MIN_IOD = 100f
+        private const val SPOOF_MAX_IOD = 320f
     }
 }

--- a/face/infra/roc-v3/src/main/java/com/simprints/face/infra/rocv3/detection/RocV3Detector.kt
+++ b/face/infra/roc-v3/src/main/java/com/simprints/face/infra/rocv3/detection/RocV3Detector.kt
@@ -12,7 +12,6 @@ import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
 import com.simprints.face.infra.basebiosdk.detection.Face
 import com.simprints.face.infra.basebiosdk.detection.FaceDetector
 import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
-import com.simprints.infra.logging.Simber
 import java.nio.ByteBuffer
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -176,7 +175,6 @@ class RocV3Detector @Inject constructor() : FaceDetector {
         return byteBuffer
     }
 
-    // TODO verify results
     override fun spoofCheck(
         bitmap: Bitmap,
         configuredMaxSize: Int,
@@ -186,9 +184,8 @@ class RocV3Detector @Inject constructor() : FaceDetector {
             return SpoofCheckResult(0f, SpoofCheckResult.SkipReason.IMAGE_TOO_SMALL)
         }
 
-        val maxSize = configuredMaxSize
-        val scaledBitmap = if (bitmap.width > maxSize) {
-            bitmap.scale(maxSize, (bitmap.height * maxSize.toFloat() / bitmap.width).toInt(), false)
+        val scaledBitmap = if (bitmap.width > configuredMaxSize) {
+            bitmap.scale(configuredMaxSize, (bitmap.height * configuredMaxSize.toFloat() / bitmap.width).toInt(), false)
         } else {
             bitmap
         }
@@ -210,8 +207,6 @@ class RocV3Detector @Inject constructor() : FaceDetector {
 
         var iod = 0f
         var finalScore = 0f
-
-        val quality = roc3.new_float() // TODO remove later
 
         if (faceDetected) {
             val rightEye = roc_landmark()
@@ -245,7 +240,7 @@ class RocV3Detector @Inject constructor() : FaceDetector {
                     leftEye,
                     chin,
                     null,
-                    quality,
+                    null,
                     null,
                     null,
                     null,
@@ -280,11 +275,6 @@ class RocV3Detector @Inject constructor() : FaceDetector {
         roc3.roc_free_image(rocColorImage)
         detection.delete()
         byteBuffer.clear()
-
-        Simber.i(
-            "!!! width: ${scaledBitmap.width}, IOD: $iod, quality: ${roc3.float_value(quality)}, finalScore: $finalScore",
-            tag = "FACE_CAPTURE",
-        )
 
         return when {
             !faceDetected -> SpoofCheckResult(finalScore, SpoofCheckResult.SkipReason.NOT_AVAILABLE)

--- a/face/infra/simface/src/main/java/com/simprints/face/infra/simface/detection/SimFaceDetector.kt
+++ b/face/infra/simface/src/main/java/com/simprints/face/infra/simface/detection/SimFaceDetector.kt
@@ -33,7 +33,10 @@ class SimFaceDetector @Inject constructor(
         )
     }
 
-    override fun spoofCheck(bitmap: Bitmap) = SpoofCheckResult(0f, SpoofCheckResult.SkipReason.NOT_AVAILABLE)
+    override fun spoofCheck(
+        bitmap: Bitmap,
+        configuredMaxSize: Int,
+    ) = SpoofCheckResult(0f, SpoofCheckResult.SkipReason.NOT_AVAILABLE)
 
     companion object {
         private const val BAD_FACE_THRESHOLD = 0.1

--- a/face/infra/simface/src/main/java/com/simprints/face/infra/simface/detection/SimFaceDetector.kt
+++ b/face/infra/simface/src/main/java/com/simprints/face/infra/simface/detection/SimFaceDetector.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import com.simprints.biometrics.simface.SimFace
 import com.simprints.face.infra.basebiosdk.detection.Face
 import com.simprints.face.infra.basebiosdk.detection.FaceDetector
+import com.simprints.face.infra.basebiosdk.detection.SpoofCheckResult
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
@@ -31,6 +32,8 @@ class SimFaceDetector @Inject constructor(
             format = simFace.getTemplateVersion(),
         )
     }
+
+    override fun spoofCheck(bitmap: Bitmap) = SpoofCheckResult(0f, SpoofCheckResult.SkipReason.NOT_AVAILABLE)
 
     companion object {
         private const val BAD_FACE_THRESHOLD = 0.1

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
@@ -1,7 +1,10 @@
 package com.simprints.infra.config.store.models
 
+import com.simprints.infra.config.store.models.FaceConfiguration.SpoofCheckMode
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.floatOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
@@ -173,6 +176,23 @@ data class ExperimentalProjectConfiguration(
             ?.booleanOrNull
             .let { it == true }
 
+    // TODO Temporary flags until configuration is added to FaceSdkConfiguration
+    val spoofCheckMode: SpoofCheckMode
+        get() = customConfig
+            ?.get(SPOOF_CHECK_MODE)
+            ?.jsonPrimitive
+            ?.contentOrNull
+            ?.let { SpoofCheckMode.fromString(it) }
+            ?: SpoofCheckMode.DISABLED
+
+    // TODO Temporary flags until configuration is added to FaceSdkConfiguration
+    val spoofCheckThreshold: Float
+        get() = customConfig
+            ?.get(SPOOF_CHECK_THRESHOLD)
+            ?.jsonPrimitive
+            ?.floatOrNull
+            ?: SPOOF_CHECK_THRESHOLD_DEFAULT
+
     companion object {
         internal const val DISABLE_SUBJECT_POOL_VALIDATION = "disableSubjectPoolValidation"
         internal const val FACE_AUTO_CAPTURE_IMAGING_DURATION_MILLIS = "faceAutoCaptureImagingDurationMillis"
@@ -233,5 +253,9 @@ data class ExperimentalProjectConfiguration(
 
         const val MFID_DEFAULT_SKIP_REASON = "mfidDefaultSkipReason"
         const val MFID_SKIP_REASONS_HIDE_HAS_NUMBER = "mfidSkipReasonsHideHasNumber"
+
+        const val SPOOF_CHECK_MODE = "spoofCheckMode"
+        const val SPOOF_CHECK_THRESHOLD = "spoofCheckThreshold"
+        const val SPOOF_CHECK_THRESHOLD_DEFAULT = 0.33f
     }
 }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
@@ -191,6 +191,7 @@ data class ExperimentalProjectConfiguration(
             ?.get(SPOOF_CHECK_THRESHOLD)
             ?.jsonPrimitive
             ?.floatOrNull
+            ?.coerceIn(0f, 1f)
             ?: SPOOF_CHECK_THRESHOLD_DEFAULT
 
     // TODO Temporary flags until configuration is added to FaceSdkConfiguration
@@ -199,7 +200,17 @@ data class ExperimentalProjectConfiguration(
             ?.get(SPOOF_CHECK_MAX_ATTEMPTS)
             ?.jsonPrimitive
             ?.intOrNull
+            ?.coerceAtLeast(1)
             ?: SPOOF_CHECK_MAX_ATTEMPTS_DEFAULT
+
+    // TODO Temporary flags until configuration is added to FaceSdkConfiguration
+    val spoofMaxBitmapSize: Int
+        get() = customConfig
+            ?.get(SPOOF_CHECK_MAX_BITMAP_SIZE)
+            ?.jsonPrimitive
+            ?.intOrNull
+            ?.coerceAtLeast(SPOOF_CHECK_MAX_BITMAP_SIZE_MINIMUM)
+            ?: SPOOF_CHECK_MAX_BITMAP_SIZE_DEFAULT
 
     companion object {
         internal const val DISABLE_SUBJECT_POOL_VALIDATION = "disableSubjectPoolValidation"
@@ -269,5 +280,9 @@ data class ExperimentalProjectConfiguration(
 
         const val SPOOF_CHECK_MAX_ATTEMPTS = "spoofMaxAttempts"
         const val SPOOF_CHECK_MAX_ATTEMPTS_DEFAULT = 2
+
+        const val SPOOF_CHECK_MAX_BITMAP_SIZE = "spoofMaxBitmapSize"
+        const val SPOOF_CHECK_MAX_BITMAP_SIZE_MINIMUM = 720
+        const val SPOOF_CHECK_MAX_BITMAP_SIZE_DEFAULT = 1500
     }
 }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
@@ -212,6 +212,24 @@ data class ExperimentalProjectConfiguration(
             ?.coerceAtLeast(SPOOF_CHECK_MAX_BITMAP_SIZE_MINIMUM)
             ?: SPOOF_CHECK_MAX_BITMAP_SIZE_DEFAULT
 
+    // TODO Temporary flags until configuration is added to FaceSdkConfiguration
+    val spoofMinValidationUiDurationMs: Int
+        get() = customConfig
+            ?.get(SPOOF_CHECK_MIN_VALIDATION_UI_DURATION_MS)
+            ?.jsonPrimitive
+            ?.intOrNull
+            ?.coerceAtLeast(0)
+            ?: SPOOF_CHECK_MIN_VALIDATION_UI_DURATION_MS_DEFAULT
+
+    // TODO Temporary flags until configuration is added to FaceSdkConfiguration
+    val spoofMinValidationErrorUiDurationMs: Int
+        get() = customConfig
+            ?.get(SPOOF_CHECK_MIN_VALIDATION_ERROR_UI_DURATION_MS)
+            ?.jsonPrimitive
+            ?.intOrNull
+            ?.coerceAtLeast(0)
+            ?: SPOOF_CHECK_MIN_VALIDATION_ERROR_UI_DURATION_MS_DEFAULT
+
     companion object {
         internal const val DISABLE_SUBJECT_POOL_VALIDATION = "disableSubjectPoolValidation"
         internal const val FACE_AUTO_CAPTURE_IMAGING_DURATION_MILLIS = "faceAutoCaptureImagingDurationMillis"
@@ -284,5 +302,10 @@ data class ExperimentalProjectConfiguration(
         const val SPOOF_CHECK_MAX_BITMAP_SIZE = "spoofMaxBitmapSize"
         const val SPOOF_CHECK_MAX_BITMAP_SIZE_MINIMUM = 720
         const val SPOOF_CHECK_MAX_BITMAP_SIZE_DEFAULT = 1500
+
+        const val SPOOF_CHECK_MIN_VALIDATION_UI_DURATION_MS = "spoofMinValidationUiDurationMs"
+        const val SPOOF_CHECK_MIN_VALIDATION_UI_DURATION_MS_DEFAULT = 2000
+        const val SPOOF_CHECK_MIN_VALIDATION_ERROR_UI_DURATION_MS = "spoofMinValidationErrorUiDurationMs"
+        const val SPOOF_CHECK_MIN_VALIDATION_ERROR_UI_DURATION_MS_DEFAULT = 2000
     }
 }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
@@ -193,6 +193,14 @@ data class ExperimentalProjectConfiguration(
             ?.floatOrNull
             ?: SPOOF_CHECK_THRESHOLD_DEFAULT
 
+    // TODO Temporary flags until configuration is added to FaceSdkConfiguration
+    val spoofMaxAttempts: Int
+        get() = customConfig
+            ?.get(SPOOF_CHECK_MAX_ATTEMPTS)
+            ?.jsonPrimitive
+            ?.intOrNull
+            ?: SPOOF_CHECK_MAX_ATTEMPTS_DEFAULT
+
     companion object {
         internal const val DISABLE_SUBJECT_POOL_VALIDATION = "disableSubjectPoolValidation"
         internal const val FACE_AUTO_CAPTURE_IMAGING_DURATION_MILLIS = "faceAutoCaptureImagingDurationMillis"
@@ -256,6 +264,10 @@ data class ExperimentalProjectConfiguration(
 
         const val SPOOF_CHECK_MODE = "spoofCheckMode"
         const val SPOOF_CHECK_THRESHOLD = "spoofCheckThreshold"
+
         const val SPOOF_CHECK_THRESHOLD_DEFAULT = 0.33f
+
+        const val SPOOF_CHECK_MAX_ATTEMPTS = "spoofMaxAttempts"
+        const val SPOOF_CHECK_MAX_ATTEMPTS_DEFAULT = 2
     }
 }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/FaceConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/FaceConfiguration.kt
@@ -39,6 +39,8 @@ data class FaceConfiguration(
         val threshold: Float,
         val maxAttempts: Int,
         val maxBitmapSize: Int,
+        val validationUiDurationMs: Int,
+        val validationErrorUiDurationMs: Int,
     ) {
         companion object {
             val DISABLED = SpoofCheckConfiguration(
@@ -46,6 +48,8 @@ data class FaceConfiguration(
                 threshold = 0f,
                 maxAttempts = 0,
                 maxBitmapSize = 0,
+                validationUiDurationMs = 0,
+                validationErrorUiDurationMs = 0,
             )
         }
     }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/FaceConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/FaceConfiguration.kt
@@ -37,11 +37,13 @@ data class FaceConfiguration(
     data class SpoofCheckConfiguration(
         val mode: SpoofCheckMode,
         val threshold: Float,
+        val maxAttempts: Int,
     ) {
         companion object {
             val DISABLED = SpoofCheckConfiguration(
                 mode = SpoofCheckMode.DISABLED,
                 threshold = 0f,
+                maxAttempts = 0,
             )
         }
     }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/FaceConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/FaceConfiguration.kt
@@ -38,12 +38,14 @@ data class FaceConfiguration(
         val mode: SpoofCheckMode,
         val threshold: Float,
         val maxAttempts: Int,
+        val maxBitmapSize: Int,
     ) {
         companion object {
             val DISABLED = SpoofCheckConfiguration(
                 mode = SpoofCheckMode.DISABLED,
                 threshold = 0f,
                 maxAttempts = 0,
+                maxBitmapSize = 0,
             )
         }
     }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/FaceConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/FaceConfiguration.kt
@@ -32,4 +32,33 @@ data class FaceConfiguration(
 
         fun shouldSaveImage() = this != NEVER
     }
+
+    // TODO Will be a field in FaceSdkConfiguration later
+    data class SpoofCheckConfiguration(
+        val mode: SpoofCheckMode,
+        val threshold: Float,
+    ) {
+        companion object {
+            val DISABLED = SpoofCheckConfiguration(
+                mode = SpoofCheckMode.DISABLED,
+                threshold = 0f,
+            )
+        }
+    }
+
+    enum class SpoofCheckMode {
+        DISABLED,
+        ENFORCED,
+        RECORDED,
+        ;
+
+        companion object {
+            // TODO Later it will be enforced by API.
+            fun fromString(mode: String): SpoofCheckMode = when (mode.uppercase()) {
+                "ENFORCED" -> ENFORCED
+                "RECORDED" -> RECORDED
+                else -> DISABLED
+            }
+        }
+    }
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
@@ -393,9 +393,22 @@ internal class ExperimentalProjectConfigurationTest {
             mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MAX_ATTEMPTS to JsonPrimitive(null)) to 2,
             mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MAX_ATTEMPTS to JsonPrimitive("string")) to 2,
             mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MAX_ATTEMPTS to JsonPrimitive(1)) to 1,
-            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MAX_ATTEMPTS to JsonPrimitive(0f)) to 0,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MAX_ATTEMPTS to JsonPrimitive(0f)) to 2,
         ).forEach { (config, result) ->
             assertThat(ExperimentalProjectConfiguration(config).spoofMaxAttempts).isEqualTo(result)
+        }
+    }
+
+    @Test
+    fun `spoof check max bitmap size value parsed correctly`() {
+        mapOf(
+            emptyMap<String, JsonElement>() to 1500,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MAX_BITMAP_SIZE to JsonPrimitive(null)) to 1500,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MAX_BITMAP_SIZE to JsonPrimitive("string")) to 1500,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MAX_BITMAP_SIZE to JsonPrimitive(100)) to 720,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MAX_BITMAP_SIZE to JsonPrimitive(0f)) to 1500,
+        ).forEach { (config, result) ->
+            assertThat(ExperimentalProjectConfiguration(config).spoofMaxBitmapSize).isEqualTo(result)
         }
     }
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
@@ -411,4 +411,30 @@ internal class ExperimentalProjectConfigurationTest {
             assertThat(ExperimentalProjectConfiguration(config).spoofMaxBitmapSize).isEqualTo(result)
         }
     }
+
+    @Test
+    fun `spoof check spoof ui duration parsed correctly`() {
+        mapOf(
+            emptyMap<String, JsonElement>() to 2000,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MIN_VALIDATION_UI_DURATION_MS to JsonPrimitive(null)) to 2000,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MIN_VALIDATION_UI_DURATION_MS to JsonPrimitive("string")) to 2000,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MIN_VALIDATION_UI_DURATION_MS to JsonPrimitive(100)) to 100,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MIN_VALIDATION_UI_DURATION_MS to JsonPrimitive(0f)) to 2000,
+        ).forEach { (config, result) ->
+            assertThat(ExperimentalProjectConfiguration(config).spoofMinValidationUiDurationMs).isEqualTo(result)
+        }
+    }
+
+    @Test
+    fun `spoof check spoof error ui duration parsed correctly`() {
+        mapOf(
+            emptyMap<String, JsonElement>() to 2000,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MIN_VALIDATION_ERROR_UI_DURATION_MS to JsonPrimitive(null)) to 2000,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MIN_VALIDATION_ERROR_UI_DURATION_MS to JsonPrimitive("string")) to 2000,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MIN_VALIDATION_ERROR_UI_DURATION_MS to JsonPrimitive(100)) to 100,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MIN_VALIDATION_ERROR_UI_DURATION_MS to JsonPrimitive(0f)) to 2000,
+        ).forEach { (config, result) ->
+            assertThat(ExperimentalProjectConfiguration(config).spoofMinValidationErrorUiDurationMs).isEqualTo(result)
+        }
+    }
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
@@ -385,4 +385,17 @@ internal class ExperimentalProjectConfigurationTest {
             assertThat(ExperimentalProjectConfiguration(config).spoofCheckThreshold).isEqualTo(result)
         }
     }
+
+    @Test
+    fun `spoof check max attempts value parsed correctly`() {
+        mapOf(
+            emptyMap<String, JsonElement>() to 2,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MAX_ATTEMPTS to JsonPrimitive(null)) to 2,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MAX_ATTEMPTS to JsonPrimitive("string")) to 2,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MAX_ATTEMPTS to JsonPrimitive(1)) to 1,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MAX_ATTEMPTS to JsonPrimitive(0f)) to 0,
+        ).forEach { (config, result) ->
+            assertThat(ExperimentalProjectConfiguration(config).spoofMaxAttempts).isEqualTo(result)
+        }
+    }
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
@@ -37,6 +37,7 @@ import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.RECORDS_DB_MIGRATION_FROM_REALM_TO_ROOM_DEFAULT_MAX_RETRIES
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.RECORDS_DB_MIGRATION_FROM_REALM_TO_ROOM_ENABLED
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.RECORDS_DB_MIGRATION_FROM_REALM_TO_ROOM_MAX_RETRIES
+import com.simprints.infra.config.store.models.FaceConfiguration.SpoofCheckMode
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Test
@@ -356,6 +357,32 @@ internal class ExperimentalProjectConfigurationTest {
             mapOf(ExperimentalProjectConfiguration.MFID_SKIP_REASONS_HIDE_HAS_NUMBER to JsonPrimitive(true)) to true,
         ).forEach { (config, result) ->
             assertThat(ExperimentalProjectConfiguration(config).mfidSkipReasonsHideHasNumber).isEqualTo(result)
+        }
+    }
+
+    @Test
+    fun `spoof check mode value parsed correctly`() {
+        mapOf(
+            emptyMap<String, JsonElement>() to SpoofCheckMode.DISABLED,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MODE to JsonPrimitive(null)) to SpoofCheckMode.DISABLED,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MODE to JsonPrimitive("string")) to SpoofCheckMode.DISABLED,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MODE to JsonPrimitive("ENFORCED")) to SpoofCheckMode.ENFORCED,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_MODE to JsonPrimitive("RECORDED")) to SpoofCheckMode.RECORDED,
+        ).forEach { (config, result) ->
+            assertThat(ExperimentalProjectConfiguration(config).spoofCheckMode).isEqualTo(result)
+        }
+    }
+
+    @Test
+    fun `spoof check threshold value parsed correctly`() {
+        mapOf(
+            emptyMap<String, JsonElement>() to 0.33f,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_THRESHOLD to JsonPrimitive(null)) to 0.33f,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_THRESHOLD to JsonPrimitive("string")) to 0.33f,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_THRESHOLD to JsonPrimitive(1)) to 1f,
+            mapOf(ExperimentalProjectConfiguration.SPOOF_CHECK_THRESHOLD to JsonPrimitive(0f)) to 0f,
+        ).forEach { (config, result) ->
+            assertThat(ExperimentalProjectConfiguration(config).spoofCheckThreshold).isEqualTo(result)
         }
     }
 }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiFaceCapturePayload.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiFaceCapturePayload.kt
@@ -3,6 +3,7 @@ package com.simprints.infra.eventsync.event.remote.models
 import androidx.annotation.Keep
 import com.simprints.infra.config.store.models.TokenKeyType
 import com.simprints.infra.events.event.domain.models.FaceCaptureEvent.FaceCapturePayload
+import com.simprints.infra.events.event.domain.models.FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason
 import com.simprints.infra.eventsync.event.remote.models.ApiFaceCapturePayload.ApiFace
 import com.simprints.infra.eventsync.event.remote.models.ApiFaceCapturePayload.ApiResult.BAD_QUALITY
 import com.simprints.infra.eventsync.event.remote.models.ApiFaceCapturePayload.ApiResult.INVALID
@@ -43,6 +44,8 @@ internal data class ApiFaceCapturePayload(
         var roll: Float,
         val quality: Float,
         val format: String,
+        val spoofScore: Float? = null,
+        val spoofSkipReason: ApiSpoofSkipReason? = null,
     )
 
     @Keep
@@ -57,10 +60,25 @@ internal data class ApiFaceCapturePayload(
         TOO_FAR,
     }
 
+    @Keep
+    @Serializable
+    enum class ApiSpoofSkipReason {
+        IMAGE_TOO_SMALL,
+        IOD_TOO_SMALL,
+        IOD_TOO_LARGE,
+    }
+
     override fun getTokenizedFieldJsonPath(tokenKeyType: TokenKeyType): String? = null // this payload doesn't have tokenizable fields
 }
 
-internal fun FaceCapturePayload.Face.fromDomainToApi() = ApiFace(yaw, roll, quality, format)
+internal fun FaceCapturePayload.Face.fromDomainToApi() = ApiFace(
+    yaw = yaw,
+    roll = roll,
+    quality = quality,
+    format = format,
+    spoofScore = spoofScore,
+    spoofSkipReason = spoofSkipReason?.fromDomainToApi(),
+)
 
 internal fun FaceCapturePayload.Result.fromDomainToApi() = when (this) {
     FaceCapturePayload.Result.VALID -> VALID
@@ -70,4 +88,10 @@ internal fun FaceCapturePayload.Result.fromDomainToApi() = when (this) {
     FaceCapturePayload.Result.OFF_ROLL -> OFF_ROLL
     FaceCapturePayload.Result.TOO_CLOSE -> TOO_CLOSE
     FaceCapturePayload.Result.TOO_FAR -> TOO_FAR
+}
+
+internal fun SpoofSkipReason.fromDomainToApi() = when (this) {
+    SpoofSkipReason.IMAGE_TOO_SMALL -> ApiFaceCapturePayload.ApiSpoofSkipReason.IMAGE_TOO_SMALL
+    SpoofSkipReason.IOD_TOO_SMALL -> ApiFaceCapturePayload.ApiSpoofSkipReason.IOD_TOO_SMALL
+    SpoofSkipReason.IOD_TOO_LARGE -> ApiFaceCapturePayload.ApiSpoofSkipReason.IOD_TOO_LARGE
 }

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiFaceCapturePayload.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiFaceCapturePayload.kt
@@ -9,6 +9,7 @@ import com.simprints.infra.eventsync.event.remote.models.ApiFaceCapturePayload.A
 import com.simprints.infra.eventsync.event.remote.models.ApiFaceCapturePayload.ApiResult.INVALID
 import com.simprints.infra.eventsync.event.remote.models.ApiFaceCapturePayload.ApiResult.OFF_ROLL
 import com.simprints.infra.eventsync.event.remote.models.ApiFaceCapturePayload.ApiResult.OFF_YAW
+import com.simprints.infra.eventsync.event.remote.models.ApiFaceCapturePayload.ApiResult.SPOOFED
 import com.simprints.infra.eventsync.event.remote.models.ApiFaceCapturePayload.ApiResult.TOO_CLOSE
 import com.simprints.infra.eventsync.event.remote.models.ApiFaceCapturePayload.ApiResult.TOO_FAR
 import com.simprints.infra.eventsync.event.remote.models.ApiFaceCapturePayload.ApiResult.VALID
@@ -58,6 +59,7 @@ internal data class ApiFaceCapturePayload(
         OFF_ROLL,
         TOO_CLOSE,
         TOO_FAR,
+        SPOOFED,
     }
 
     @Keep
@@ -88,6 +90,7 @@ internal fun FaceCapturePayload.Result.fromDomainToApi() = when (this) {
     FaceCapturePayload.Result.OFF_ROLL -> OFF_ROLL
     FaceCapturePayload.Result.TOO_CLOSE -> TOO_CLOSE
     FaceCapturePayload.Result.TOO_FAR -> TOO_FAR
+    FaceCapturePayload.Result.SPOOFED -> SPOOFED
 }
 
 internal fun SpoofSkipReason.fromDomainToApi() = when (this) {

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/EventValidationUtils.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/EventValidationUtils.kt
@@ -653,7 +653,9 @@ fun validateFaceCaptureEventApiModel(json: JSONObject) {
             assertThat(getDouble("roll")).isNotNull()
             assertThat(getDouble("quality")).isNotNull()
             assertThat(getString("format")).isIn(listOf("RANK_ONE_1_23"))
-            assertThat(length()).isEqualTo(4)
+            assertThat(getDouble("spoofScore")).isNotNull()
+            assertThat(getString("spoofSkipReason")).isNotNull()
+            assertThat(length()).isEqualTo(6)
         }
 
         assertThat(length()).isEqualTo(8)

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/face/ApiFaceCapturePayloadTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/face/ApiFaceCapturePayloadTest.kt
@@ -1,6 +1,6 @@
 package com.simprints.infra.eventsync.event.remote.models.face
 
-import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.*
 import com.simprints.core.tools.utils.randomUUID
 import com.simprints.infra.events.event.domain.models.FaceCaptureEvent
 import com.simprints.infra.events.sampledata.FACE_TEMPLATE_FORMAT
@@ -17,6 +17,7 @@ class ApiFaceCapturePayloadTest {
             roll = 2.3f,
             quality = 12f,
             format = FACE_TEMPLATE_FORMAT,
+            spoofScore = 0.5f,
         )
         val payload = ApiFaceCapturePayload(
             id = randomUUID(),
@@ -41,52 +42,25 @@ class ApiFaceCapturePayloadTest {
     }
 
     @Test
-    fun `should map VALID correctly`() {
-        val result = FaceCaptureEvent.FaceCapturePayload.Result.VALID
-            .fromDomainToApi()
-        assertThat(result).isInstanceOf(ApiFaceCapturePayload.ApiResult.VALID::class.java)
+    fun `should map all face capture results correctly`() {
+        mapOf(
+            FaceCaptureEvent.FaceCapturePayload.Result.VALID to ApiFaceCapturePayload.ApiResult.VALID,
+            FaceCaptureEvent.FaceCapturePayload.Result.INVALID to ApiFaceCapturePayload.ApiResult.INVALID,
+            FaceCaptureEvent.FaceCapturePayload.Result.OFF_YAW to ApiFaceCapturePayload.ApiResult.OFF_YAW,
+            FaceCaptureEvent.FaceCapturePayload.Result.OFF_ROLL to ApiFaceCapturePayload.ApiResult.OFF_ROLL,
+            FaceCaptureEvent.FaceCapturePayload.Result.TOO_CLOSE to ApiFaceCapturePayload.ApiResult.TOO_CLOSE,
+            FaceCaptureEvent.FaceCapturePayload.Result.TOO_FAR to ApiFaceCapturePayload.ApiResult.TOO_FAR,
+            FaceCaptureEvent.FaceCapturePayload.Result.BAD_QUALITY to ApiFaceCapturePayload.ApiResult.BAD_QUALITY,
+        ).forEach { (mappedResult, expected) -> assertThat(mappedResult.fromDomainToApi()).isEqualTo(expected) }
     }
 
     @Test
-    fun `should map INVALID correctly`() {
-        val result = FaceCaptureEvent.FaceCapturePayload.Result.INVALID
-            .fromDomainToApi()
-        assertThat(result).isInstanceOf(ApiFaceCapturePayload.ApiResult.INVALID::class.java)
-    }
-
-    @Test
-    fun `should map OFF YAW correctly`() {
-        val result = FaceCaptureEvent.FaceCapturePayload.Result.OFF_YAW
-            .fromDomainToApi()
-        assertThat(result).isInstanceOf(ApiFaceCapturePayload.ApiResult.OFF_YAW::class.java)
-    }
-
-    @Test
-    fun `should map OFF ROLL correctly`() {
-        val result = FaceCaptureEvent.FaceCapturePayload.Result.OFF_ROLL
-            .fromDomainToApi()
-        assertThat(result).isInstanceOf(ApiFaceCapturePayload.ApiResult.OFF_ROLL::class.java)
-    }
-
-    @Test
-    fun `should map TOO CLOSE correctly`() {
-        val result = FaceCaptureEvent.FaceCapturePayload.Result.TOO_CLOSE
-            .fromDomainToApi()
-        assertThat(result).isInstanceOf(ApiFaceCapturePayload.ApiResult.TOO_CLOSE::class.java)
-    }
-
-    @Test
-    fun `should map TOO FAR correctly`() {
-        val result = FaceCaptureEvent.FaceCapturePayload.Result.TOO_FAR
-            .fromDomainToApi()
-        assertThat(result).isInstanceOf(ApiFaceCapturePayload.ApiResult.TOO_FAR::class.java)
-    }
-
-    @Test
-    fun `should map BAD QUALITY correctly`() {
-        val result = FaceCaptureEvent.FaceCapturePayload.Result.BAD_QUALITY
-            .fromDomainToApi()
-        assertThat(result).isInstanceOf(ApiFaceCapturePayload.ApiResult.BAD_QUALITY::class.java)
+    fun `should map all face spoof skip reasons correctly`() {
+        mapOf(
+            FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IMAGE_TOO_SMALL to ApiFaceCapturePayload.ApiSpoofSkipReason.IMAGE_TOO_SMALL,
+            FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IOD_TOO_LARGE to ApiFaceCapturePayload.ApiSpoofSkipReason.IOD_TOO_LARGE,
+            FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IOD_TOO_SMALL to ApiFaceCapturePayload.ApiSpoofSkipReason.IOD_TOO_SMALL,
+        ).forEach { (mappedResult, expected) -> assertThat(mappedResult.fromDomainToApi()).isEqualTo(expected) }
     }
 
     @Test
@@ -97,11 +71,15 @@ class ApiFaceCapturePayloadTest {
                 roll = 1.0f,
                 quality = 3.0f,
                 format = FACE_TEMPLATE_FORMAT,
+                spoofScore = 0.5f,
+                spoofSkipReason = FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IOD_TOO_SMALL,
             ).fromDomainToApi()
         assertThat(face).isInstanceOf(ApiFaceCapturePayload.ApiFace::class.java)
         assertThat(face.format).isEqualTo(FACE_TEMPLATE_FORMAT)
         assertThat(face.yaw).isEqualTo(2.0f)
         assertThat(face.roll).isEqualTo(1.0f)
         assertThat(face.quality).isEqualTo(3.0f)
+        assertThat(face.spoofScore).isEqualTo(0.5f)
+        assertThat(face.spoofSkipReason).isEqualTo(ApiFaceCapturePayload.ApiSpoofSkipReason.IOD_TOO_SMALL)
     }
 }

--- a/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
+++ b/infra/events/src/debug/java/com/simprints/infra/events/sampledata/EventFactoryUtils.kt
@@ -313,7 +313,14 @@ fun createFaceCaptureEvent() = FaceCaptureEvent(
     result = FaceCaptureEvent.FaceCapturePayload.Result.VALID,
     isAutoCapture = false,
     isFallback = true,
-    face = FaceCaptureEvent.FaceCapturePayload.Face(0F, 1F, 2F, FACE_TEMPLATE_FORMAT),
+    face = FaceCaptureEvent.FaceCapturePayload.Face(
+        yaw = 0F,
+        roll = 1F,
+        quality = 2F,
+        format = FACE_TEMPLATE_FORMAT,
+        spoofScore = 0.5f,
+        spoofSkipReason = FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IMAGE_TOO_SMALL,
+    ),
 )
 
 fun createFaceFallbackCaptureEvent() = FaceFallbackCaptureEvent(

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/FaceCaptureEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/FaceCaptureEvent.kt
@@ -64,7 +64,7 @@ data class FaceCaptureEvent(
     ) : EventPayload() {
         override fun toSafeString(): String =
             "result: $result, attempt nr: $attemptNb, auto-capture: $isAutoCapture, fallback: $isFallback, " +
-                "quality: ${face?.quality},  format: ${face?.format}"
+                "quality: ${face?.quality},  format: ${face?.format}, spoof score: ${face?.spoofScore}"
 
         @Keep
         @Serializable
@@ -73,6 +73,8 @@ data class FaceCaptureEvent(
             var roll: Float,
             val quality: Float,
             val format: String,
+            val spoofScore: Float? = null,
+            val spoofSkipReason: SpoofSkipReason? = null,
         )
 
         @Keep
@@ -85,6 +87,14 @@ data class FaceCaptureEvent(
             OFF_ROLL,
             TOO_CLOSE,
             TOO_FAR,
+        }
+
+        @Keep
+        @Serializable
+        enum class SpoofSkipReason {
+            IMAGE_TOO_SMALL,
+            IOD_TOO_SMALL,
+            IOD_TOO_LARGE,
         }
     }
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/FaceCaptureEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/FaceCaptureEvent.kt
@@ -87,6 +87,7 @@ data class FaceCaptureEvent(
             OFF_ROLL,
             TOO_CLOSE,
             TOO_FAR,
+            SPOOFED,
         }
 
         @Keep

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureEventTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/face/FaceCaptureEventTest.kt
@@ -1,7 +1,7 @@
 package com.simprints.infra.events.event.domain.models.face
 
 import androidx.annotation.Keep
-import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.*
 import com.simprints.infra.events.event.domain.models.EventType
 import com.simprints.infra.events.event.domain.models.FaceCaptureEvent
 import com.simprints.infra.events.sampledata.FACE_TEMPLATE_FORMAT
@@ -12,16 +12,23 @@ import org.junit.Test
 class FaceCaptureEventTest {
     @Test
     fun create_FaceCaptureEvent() {
-        val faceArg = FaceCaptureEvent.FaceCapturePayload.Face(0F, 1F, 2F, FACE_TEMPLATE_FORMAT)
+        val faceArg = FaceCaptureEvent.FaceCapturePayload.Face(
+            yaw = 0F,
+            roll = 1F,
+            quality = 2F,
+            format = FACE_TEMPLATE_FORMAT,
+            spoofScore = 0.5f,
+            spoofSkipReason = FaceCaptureEvent.FaceCapturePayload.SpoofSkipReason.IMAGE_TOO_SMALL,
+        )
         val event = FaceCaptureEvent(
-            SampleDefaults.CREATED_AT,
-            SampleDefaults.ENDED_AT,
-            0,
-            1F,
-            FaceCaptureEvent.FaceCapturePayload.Result.VALID,
-            false,
-            true,
-            faceArg,
+            startTime = SampleDefaults.CREATED_AT,
+            endTime = SampleDefaults.ENDED_AT,
+            attemptNb = 0,
+            qualityThreshold = 1F,
+            result = FaceCaptureEvent.FaceCapturePayload.Result.VALID,
+            isAutoCapture = false,
+            isFallback = true,
+            face = faceArg,
         )
 
         assertThat(event.id).isNotNull()

--- a/infra/resources/src/main/res/values/strings.xml
+++ b/infra/resources/src/main/res/values/strings.xml
@@ -190,6 +190,9 @@
     <string name="face_capture_error_too_close">Move back</string>
     <string name="face_capture_title_look_straight">Not looking straight</string>
     <string name="face_capture_error_look_straight">Make sure the person is looking straight at the camera</string>
+    <string name="face_capture_title_validating">Verifying your scan</string>
+    <string name="face_capture_title_validating_failed">Unable to verify</string>
+    <string name="face_capture_error_validating_failed">Please recapture and ensure a real person is in front of the camera</string>
     <string name="face_capture_begin_button">Tap to capture</string>
     <string name="face_capture_prep_begin_button_capturing">Capturing…</string>
     <string name="face_capture_permission_denied">Please grant the camera permission</string>


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1491)
Will be released in: **2026.3.0**

[Design document](https://docs.google.com/document/d/1yOKwQL2V4Tv84HzFiWOoYEz0xAjk-Q9K-yUk1LCvX4w/edit?tab=t.0)

### Notable changes

* Added spoof checks when using ROC v3 face SDK (other SDKs have no-op stubs). Spoof check return the "probability that provided image is being spoofed" and must not be over the configured threshold. If any of the images are over the threshold and the mode is configured to be "ENFORCED", the capture is reset up to configured amount of times. 

https://github.com/user-attachments/assets/d6361e46-193e-443c-a570-0f37509ce725

* In "RECORDED" mode the spoof check is performed and results are stored, but the flow is not reset in case of failed check.

#### Custom config 

Will be added to the documentation before merging this PR.

```
"spoofCheckMode": "ENFORCED",  // Or "DISABLED", or "RECORDED"
"spoofCheckThreshold": 0.33,  // Probability cutoff in (0; 1) range
"spoofMaxAttempts": 2,  // How many attempts are users forced to do until all images pass
"spoofMaxBitmapSize": 1500,  // Largest image size to scale down to before check to ensure IOD is within range
"spoofMinValidationUiDurationMs": 2000,  // At least how long the processing is shown
"spoofMinValidationErrorUiDurationMs": 2000,  // At least how long error is shown
```

### Testing guidance

* Configure a project with face modality, ROC v3 and 2-5 samples to capture.
* Add the custom configuration `"spoofCheckMode": "ENFORCED"` and try to run identification flows:
  * with printed/screen faces - it should force re-capture;
  * with real faces - it should proceed without re-capture.
* Add the custom configuration `"spoofCheckMode": "RECORDED"` and try to run identification flows:
  * it should proceed without re-capture on any face;
  * spoof score is recorded in the session events (either in troubleshooting screen or network data).
* Currently the logging is a bit verbose to help with debugging, it will be cleared before merging the PR.



### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
