### PR TITLE
[MS-1466] QR code scanning area is now bigger during the MFID workflow

### DIFF
--- a/feature/external-credential/src/main/res/layout-land/fragment_external_credential_scan_qr.xml
+++ b/feature/external-credential/src/main/res/layout-land/fragment_external_credential_scan_qr.xml
@@ -22,54 +22,56 @@
         app:targetViewId="@+id/qrScannerArea"
         tools:visibility="visible" />
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/qrInstructionsText"
+        style="@style/Text.Headline5.White"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="vertical"
+        android:layout_margin="@dimen/padding_default"
+        app:layout_constraintBottom_toTopOf="@+id/qrScannerArea"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:text="Place QR code in window" />
+
+    <com.simprints.infra.view.imagecapture.CaptureTargetView
+        android:id="@+id/qrScannerArea"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:cornerRadius="16dp"
+        app:layout_constraintBottom_toTopOf="@+id/buttonScan"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_percent="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:shape="rect"
+        app:strokeColor="@color/simprints_blue"
+        app:strokeWidth="4dp" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/qrPreviewCard"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="16dp"
+        android:visibility="gone"
+        app:cardBackgroundColor="@color/simprints_blue"
+        app:cardUseCompatPadding="true"
         app:layout_constraintBottom_toTopOf="@+id/buttonScan"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@+id/qrScannerArea"
+        tools:visibility="visible">
 
         <TextView
-            android:id="@+id/qrInstructionsText"
-            style="@style/Text.Headline5.White"
+            android:id="@+id/qrPreviewText"
+            style="@style/Text.Body1.White"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/padding_default"
-            tools:text="Place QR code in window" />
-
-        <com.simprints.infra.view.imagecapture.CaptureTargetView
-            android:id="@+id/qrScannerArea"
-            android:layout_width="200dp"
-            android:layout_height="200dp"
-            app:shape="rect"
-            app:strokeColor="@color/simprints_blue"
-            app:strokeWidth="4dp"
-            app:cornerRadius="16dp"/>
-
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/qrPreviewCard"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="16dp"
-            android:layout_marginTop="16dp"
-            android:visibility="gone"
-            app:cardBackgroundColor="@color/simprints_blue"
-            app:cardUseCompatPadding="true"
-            tools:visibility="visible">
-
-            <TextView
-                android:id="@+id/qrPreviewText"
-                android:gravity="center"
-                style="@style/Text.Body1.White"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_margin="8dp"
-                tools:text="QR_CODE" />
-        </com.google.android.material.card.MaterialCardView>
-    </LinearLayout>
+            android:layout_margin="8dp"
+            android:gravity="center"
+            tools:text="QR_CODE" />
+    </com.google.android.material.card.MaterialCardView>
 
     <Button
         android:id="@+id/buttonScan"

--- a/feature/external-credential/src/main/res/layout-sw600dp-land/fragment_external_credential_scan_qr.xml
+++ b/feature/external-credential/src/main/res/layout-sw600dp-land/fragment_external_credential_scan_qr.xml
@@ -24,27 +24,29 @@
 
     <TextView
         android:id="@+id/qrInstructionsText"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/qrScannerArea"
-        tools:text="Place QR code in window"
         style="@style/Text.Headline5.White"
-        android:layout_margin="@dimen/padding_default"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/padding_default"
+        app:layout_constraintBottom_toTopOf="@+id/qrScannerArea"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:text="Place QR code in window" />
 
     <com.simprints.infra.view.imagecapture.CaptureTargetView
         android:id="@+id/qrScannerArea"
-        android:layout_width="200dp"
-        android:layout_height="200dp"
-        app:shape="rect"
-        app:strokeColor="@color/simprints_blue"
-        app:strokeWidth="4dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:cornerRadius="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_percent="0.6"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:shape="rect"
+        app:strokeColor="@color/simprints_blue"
+        app:strokeWidth="4dp" />
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/qrPreviewCard"
@@ -55,6 +57,7 @@
         android:visibility="gone"
         app:cardBackgroundColor="@color/simprints_blue"
         app:cardUseCompatPadding="true"
+        app:layout_constraintBottom_toTopOf="@+id/buttonScan"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/qrScannerArea"

--- a/feature/external-credential/src/main/res/layout/fragment_external_credential_scan_qr.xml
+++ b/feature/external-credential/src/main/res/layout/fragment_external_credential_scan_qr.xml
@@ -35,12 +35,14 @@
 
     <com.simprints.infra.view.imagecapture.CaptureTargetView
         android:id="@+id/qrScannerArea"
-        android:layout_width="200dp"
-        android:layout_height="200dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:shape="rect"
         app:strokeColor="@color/simprints_blue"
         app:strokeWidth="4dp"
         app:cornerRadius="16dp"
+        app:layout_constraintWidth_percent="0.5"
+        app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1466)
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2025.4.0**

* The QR scanning area was too small on tablets

### Notable changes

* The QR scanner area in MFID workflow is now 50% of width in portrait orientation, and 50% height in landscape orientation
<img width="720" height="480" alt="image" src="https://github.com/user-attachments/assets/42308172-68ea-4438-86ff-437760ab3fc9" />

### Testing guidance

* Open MFID QR scanner and see the increased size of the scanning area