### PR TITLE
Return subjectActions on ConfirmIdentity if externalCredential was linked

### DIFF
--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/ClientApiViewModel.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/ClientApiViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.simprints.core.livedata.LiveDataEvent
 import com.simprints.core.livedata.LiveDataEventWithContent
 import com.simprints.core.livedata.send
+import com.simprints.core.tools.extentions.isValidGuid
 import com.simprints.core.tools.extentions.toJsonElementMap
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.feature.clientapi.exceptions.InvalidRequestException
@@ -153,6 +154,19 @@ class ClientApiViewModel @Inject internal constructor(
         val currentSessionId = getCurrentSessionId()
         simpleEventReporter.addCompletionCheckEvent(flowCompleted = true)
 
+        val selectedGuid = (action as? ActionRequest.ConfirmIdentityActionRequest)
+            ?.selectedGuid
+            ?.takeIf { it.isValidGuid() }
+        val coSyncEnrolmentRecords = if (
+            confirmResponse.identificationOutcome &&
+            confirmResponse.externalCredential != null &&
+            selectedGuid != null
+        ) {
+            getEnrolmentCreationEventForRecord(action.projectId, selectedGuid)
+        } else {
+            null
+        }
+
         deleteSessionEventsIfNeeded(currentSessionId)
 
         logIntent(action, currentSessionId, "Confirmed: ${confirmResponse.identificationOutcome}")
@@ -163,6 +177,7 @@ class ClientApiViewModel @Inject internal constructor(
                     actionIdentifier = action.actionIdentifier,
                     sessionId = currentSessionId,
                     confirmed = confirmResponse.identificationOutcome,
+                    subjectActions = coSyncEnrolmentRecords,
                     externalCredential = confirmResponse.externalCredential,
                 ),
             ),

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/CommCareResponseMapper.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/CommCareResponseMapper.kt
@@ -45,7 +45,7 @@ internal class CommCareResponseMapper @Inject constructor(
             CommCareConstants.COMMCARE_SID_VERSION to appVersionName,
             CommCareConstants.SIMPRINTS_SESSION_ID to response.sessionId,
             CommCareConstants.BIOMETRICS_COMPLETE_CHECK_KEY to "true",
-        ).toCommCareBundle()
+        ).appendCoSyncData(response.subjectActions).toCommCareBundle()
 
         is ActionResponse.VerifyActionResponse -> bundleOf(
             CommCareConstants.COMMCARE_DEVICE_ID to deviceId,

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapper.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapper.kt
@@ -88,7 +88,8 @@ internal class LibSimprintsResponseMapper @Inject constructor(
                 Constants.SIMPRINTS_APP_VERSION_NAME to appVersionName,
                 Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK to true,
                 Constants.SIMPRINTS_HAS_CREDENTIAL to (response.externalCredential != null),
-            ).appendExternalCredential(response.externalCredential)
+            ).appendCoSyncData(response.subjectActions)
+                .appendExternalCredential(response.externalCredential)
         }
 
         is ActionResponse.VerifyActionResponse -> bundleOf(

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/ClientApiViewModelTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/ClientApiViewModelTest.kt
@@ -201,7 +201,7 @@ internal class ClientApiViewModelTest {
     @Test
     fun `handleConfirmResponse saves correct events`() = runTest {
         viewModel.handleConfirmResponse(
-            mockRequest(),
+            mockConfirmRequest(),
             mockk {
                 every { identificationOutcome } returns true
                 every { externalCredential } returns mockk()
@@ -210,8 +210,60 @@ internal class ClientApiViewModelTest {
 
         coVerify {
             simpleEventReporter.addCompletionCheckEvent(eq(true))
+            getEnrolmentCreationEventForRecord.invoke("projectId", SELECTED_GUID)
             deleteSessionEventsIfNeeded(any())
             persistentLogger.log(any(), any(), any(), any())
+        }
+        verify { resultMapper.invoke(match<ActionResponse> { it is ActionResponse.ConfirmActionResponse }) }
+        viewModel.returnResponse.test().assertHasValue()
+    }
+
+    @Test
+    fun `handleConfirmResponse does not generate cosync when no credential`() = runTest {
+        viewModel.handleConfirmResponse(
+            mockConfirmRequest(),
+            mockk {
+                every { identificationOutcome } returns true
+                every { externalCredential } returns null
+            },
+        )
+
+        coVerify(exactly = 0) {
+            getEnrolmentCreationEventForRecord.invoke(any(), any())
+        }
+        verify { resultMapper.invoke(match<ActionResponse> { it is ActionResponse.ConfirmActionResponse }) }
+        viewModel.returnResponse.test().assertHasValue()
+    }
+
+    @Test
+    fun `handleConfirmResponse does not generate cosync when identification outcome is false`() = runTest {
+        viewModel.handleConfirmResponse(
+            mockConfirmRequest(),
+            mockk {
+                every { identificationOutcome } returns false
+                every { externalCredential } returns mockk()
+            },
+        )
+
+        coVerify(exactly = 0) {
+            getEnrolmentCreationEventForRecord.invoke(any(), any())
+        }
+        verify { resultMapper.invoke(match<ActionResponse> { it is ActionResponse.ConfirmActionResponse }) }
+        viewModel.returnResponse.test().assertHasValue()
+    }
+
+    @Test
+    fun `handleConfirmResponse does not generate cosync when no subject selected`() = runTest {
+        viewModel.handleConfirmResponse(
+            mockConfirmRequest(guid = NONE_SELECTED),
+            mockk {
+                every { identificationOutcome } returns true
+                every { externalCredential } returns mockk()
+            },
+        )
+
+        coVerify(exactly = 0) {
+            getEnrolmentCreationEventForRecord.invoke(any(), any())
         }
         verify { resultMapper.invoke(match<ActionResponse> { it is ActionResponse.ConfirmActionResponse }) }
         viewModel.returnResponse.test().assertHasValue()
@@ -307,5 +359,16 @@ internal class ClientApiViewModelTest {
     private fun mockRequest(): ActionRequest = mockk {
         every { projectId } returns "projectId"
         every { actionIdentifier } returns ActionRequestIdentifier("action", "package", "", 1, 0L)
+    }
+
+    private fun mockConfirmRequest(guid: String = SELECTED_GUID): ActionRequest.ConfirmIdentityActionRequest = mockk {
+        every { projectId } returns "projectId"
+        every { selectedGuid } returns guid
+        every { actionIdentifier } returns ActionRequestIdentifier("action", "package", "", 1, 0L)
+    }
+
+    companion object {
+        private const val SELECTED_GUID = "0b7a26c1-0d4d-4e1b-9c50-1cb3d1e0d1f2"
+        private const val NONE_SELECTED = "NONE_SELECTED"
     }
 }

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/ActionToIntentMapperTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/ActionToIntentMapperTest.kt
@@ -73,6 +73,7 @@ class ActionToIntentMapperTest {
         actionIdentifier = ConfirmIdentityActionFactory.getIdentifier().copy(packageName = packageName),
         sessionId = "sessionId",
         confirmed = true,
+        subjectActions = null,
         externalCredential = null,
     )
 }

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/CommCareResponseMapperTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/CommCareResponseMapperTest.kt
@@ -88,6 +88,7 @@ class CommCareResponseMapperTest {
                 actionIdentifier = ConfirmIdentityActionFactory.getIdentifier(),
                 sessionId = "sessionId",
                 confirmed = true,
+                subjectActions = null,
                 externalCredential = null,
             ),
         ).getBundle(CommCareConstants.COMMCARE_BUNDLE_KEY) ?: bundleOf()
@@ -96,6 +97,21 @@ class CommCareResponseMapperTest {
         assertThat(extras.getString(CommCareConstants.COMMCARE_DEVICE_ID)).isEqualTo("deviceId")
         assertThat(extras.getString(CommCareConstants.COMMCARE_SID_VERSION)).isEqualTo("appVersionName")
         assertThat(extras.getString(CommCareConstants.BIOMETRICS_COMPLETE_CHECK_KEY)).isEqualTo("true")
+    }
+
+    @Test
+    fun `correctly maps confirm response with cosync data`() {
+        val extras = mapper(
+            ActionResponse.ConfirmActionResponse(
+                actionIdentifier = ConfirmIdentityActionFactory.getIdentifier(),
+                sessionId = "sessionId",
+                confirmed = true,
+                subjectActions = "cosyncJson",
+                externalCredential = null,
+            ),
+        ).getBundle(CommCareConstants.COMMCARE_BUNDLE_KEY) ?: bundleOf()
+
+        assertThat(extras.getString(Constants.SIMPRINTS_COSYNC_SUBJECT_ACTIONS)).isEqualTo("cosyncJson")
     }
 
     @Test

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapperTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/LibSimprintsResponseMapperTest.kt
@@ -146,6 +146,7 @@ class LibSimprintsResponseMapperTest {
                 actionIdentifier = ConfirmIdentityActionFactory.getIdentifier(),
                 sessionId = "sessionId",
                 confirmed = true,
+                subjectActions = null,
                 externalCredential = mockk {
                     every { value } returns expectedValue
                     every { type } returns expectedType
@@ -160,6 +161,21 @@ class LibSimprintsResponseMapperTest {
         assertThat(extras.getBoolean(Constants.SIMPRINTS_BIOMETRICS_COMPLETE_CHECK)).isTrue()
         assertThat(extras.getBoolean(Constants.SIMPRINTS_HAS_CREDENTIAL)).isTrue()
         assertThat(extras.getString(Constants.SIMPRINTS_SCANNED_CREDENTIAL)).isEqualTo(expectedJson)
+    }
+
+    @Test
+    fun `correctly maps confirm response with cosync data`() {
+        val extras = mapper(
+            ActionResponse.ConfirmActionResponse(
+                actionIdentifier = ConfirmIdentityActionFactory.getIdentifier(),
+                sessionId = "sessionId",
+                confirmed = true,
+                subjectActions = "cosyncJson",
+                externalCredential = null,
+            ),
+        )
+
+        assertThat(extras.getString(Constants.SIMPRINTS_COSYNC_SUBJECT_ACTIONS)).isEqualTo("cosyncJson")
     }
 
     @Test
@@ -435,6 +451,7 @@ class LibSimprintsResponseMapperTest {
                 actionIdentifier = ConfirmIdentityActionFactory.getIdentifier(),
                 sessionId = "sessionId",
                 confirmed = true,
+                subjectActions = null,
                 externalCredential = null,
             ),
         )

--- a/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/OdkResponseMapperTest.kt
+++ b/feature/client-api/src/test/java/com/simprints/feature/clientapi/mappers/response/OdkResponseMapperTest.kt
@@ -90,6 +90,7 @@ class OdkResponseMapperTest {
                 actionIdentifier = ConfirmIdentityActionFactory.getIdentifier(),
                 sessionId = "sessionId",
                 confirmed = true,
+                subjectActions = null,
                 externalCredential = null,
             ),
         )

--- a/infra/orchestrator-data/src/main/java/com/simprints/infra/orchestration/data/ActionResponse.kt
+++ b/infra/orchestrator-data/src/main/java/com/simprints/infra/orchestration/data/ActionResponse.kt
@@ -33,6 +33,7 @@ sealed class ActionResponse(
         override val actionIdentifier: ActionRequestIdentifier,
         override val sessionId: String,
         val confirmed: Boolean,
+        val subjectActions: String?,
         val externalCredential: AppExternalCredential?,
     ) : ActionResponse(actionIdentifier, sessionId)
 


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1518)
Will be released in: **2026.3.0**

### Notable changes

* If external credential was linked to an enrolment in a Confirm Identity request, return the updated subjectActions in the response so that the data collector can update its copy

### Testing guidance

* In a project that is setup with both BDS  (CoSync) and MFID
* Create an enrolment without a credential (skip it) that is saved in the DC
* Trigger an Identification session and scan a credential
* Send a Confirm Identity callout
* Confirm that subjectActions with the linked credential are present in the response

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
