### PR TITLE
Fix 'extentions' package typo

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -32,9 +32,9 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.simprints.core.domain.permission.PermissionStatus
-import com.simprints.core.tools.extentions.hasCameraFlash
-import com.simprints.core.tools.extentions.hasPermission
-import com.simprints.core.tools.extentions.permissionFromResult
+import com.simprints.core.tools.extensions.hasCameraFlash
+import com.simprints.core.tools.extensions.hasPermission
+import com.simprints.core.tools.extensions.permissionFromResult
 import com.simprints.face.capture.R
 import com.simprints.face.capture.databinding.FragmentLiveFeedbackBinding
 import com.simprints.face.capture.models.FaceDetection

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModel.kt
@@ -4,7 +4,7 @@ import android.graphics.Bitmap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.simprints.core.DispatcherBG
-import com.simprints.core.tools.extentions.area
+import com.simprints.core.tools.extensions.area
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.face.capture.models.FaceDetection
 import com.simprints.face.capture.models.FaceTarget

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/views/CameraTargetOverlay.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/views/CameraTargetOverlay.kt
@@ -10,7 +10,7 @@ import android.graphics.RectF
 import android.util.AttributeSet
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.content.res.ResourcesCompat
-import com.simprints.core.tools.extentions.dpToPx
+import com.simprints.core.tools.extensions.dpToPx
 import com.simprints.face.capture.R
 import com.simprints.infra.uibase.annotations.ExcludedFromGeneratedTestCoverageReports
 import kotlin.math.max

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/views/DashedCircularProgress.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/views/DashedCircularProgress.kt
@@ -6,7 +6,7 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.util.AttributeSet
 import android.widget.FrameLayout
-import com.simprints.core.tools.extentions.dpToPx
+import com.simprints.core.tools.extensions.dpToPx
 import com.simprints.face.capture.R
 import com.simprints.infra.uibase.annotations.ExcludedFromGeneratedTestCoverageReports
 

--- a/face/capture/src/main/java/com/simprints/face/capture/usecases/BitmapToByteArrayUseCase.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/usecases/BitmapToByteArrayUseCase.kt
@@ -2,7 +2,7 @@ package com.simprints.face.capture.usecases
 
 import android.content.Context
 import android.graphics.Bitmap
-import com.simprints.core.tools.extentions.dpToPx
+import com.simprints.core.tools.extensions.dpToPx
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.ByteArrayOutputStream
 import javax.inject.Inject

--- a/feature/client-api/src/main/java/com/simprints/feature/clientapi/ClientApiViewModel.kt
+++ b/feature/client-api/src/main/java/com/simprints/feature/clientapi/ClientApiViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.simprints.core.livedata.LiveDataEvent
 import com.simprints.core.livedata.LiveDataEventWithContent
 import com.simprints.core.livedata.send
-import com.simprints.core.tools.extentions.toJsonElementMap
+import com.simprints.core.tools.extensions.toJsonElementMap
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.utils.isValidGuid
 import com.simprints.feature.clientapi.exceptions.InvalidRequestException

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/ModuleSelectionFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/moduleselection/ModuleSelectionFragment.kt
@@ -18,7 +18,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.simprints.core.tools.extentions.hideKeyboard
+import com.simprints.core.tools.extensions.hideKeyboard
 import com.simprints.feature.dashboard.R
 import com.simprints.feature.dashboard.databinding.FragmentSyncModuleSelectionBinding
 import com.simprints.feature.dashboard.settings.password.SettingsPasswordDialogFragment

--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCase.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCase.kt
@@ -2,7 +2,7 @@ package com.simprints.feature.dashboard.settings.syncinfo.usecase
 
 import com.simprints.core.DispatcherBG
 import com.simprints.core.lifecycle.AppForegroundStateTracker
-import com.simprints.core.tools.extentions.onChange
+import com.simprints.core.tools.extensions.onChange
 import com.simprints.core.tools.time.Ticker
 import com.simprints.feature.dashboard.settings.syncinfo.SyncInfo
 import com.simprints.feature.dashboard.settings.syncinfo.SyncInfoSectionModules

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoViewModelTest.kt
@@ -116,7 +116,7 @@ class SyncInfoViewModelTest {
 
         mockkStatic("androidx.lifecycle.FlowLiveDataConversions")
         mockkStatic("com.simprints.infra.config.store.models.ProjectConfigurationKt")
-        mockkStatic("com.simprints.core.tools.extentions.Flow_extKt")
+        mockkStatic("com.simprints.core.tools.extensions.Flow_extKt")
         setupDefaultMocks()
     }
 

--- a/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCaseTest.kt
+++ b/feature/dashboard/src/test/java/com/simprints/feature/dashboard/settings/syncinfo/usecase/ObserveSyncInfoUseCaseTest.kt
@@ -129,7 +129,7 @@ internal class ObserveSyncInfoUseCaseTest {
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
         mockkStatic("com.simprints.infra.config.store.models.ProjectConfigurationKt")
-        mockkStatic("com.simprints.core.tools.extentions.Flow_extKt")
+        mockkStatic("com.simprints.core.tools.extensions.Flow_extKt")
         setupDefaultMocks()
         createUseCase()
     }

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrFragment.kt
@@ -29,8 +29,8 @@ import androidx.navigation.fragment.navArgs
 import com.simprints.core.DispatcherBG
 import com.simprints.core.domain.permission.PermissionStatus
 import com.simprints.core.livedata.LiveDataEventWithContentObserver
-import com.simprints.core.tools.extentions.getCurrentPermissionStatus
-import com.simprints.core.tools.extentions.permissionFromResult
+import com.simprints.core.tools.extensions.getCurrentPermissionStatus
+import com.simprints.core.tools.extensions.permissionFromResult
 import com.simprints.feature.externalcredential.R
 import com.simprints.feature.externalcredential.databinding.FragmentExternalCredentialScanOcrBinding
 import com.simprints.feature.externalcredential.screens.controller.ExternalCredentialViewModel

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanqr/ExternalCredentialScanQrFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanqr/ExternalCredentialScanQrFragment.kt
@@ -23,9 +23,9 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.simprints.core.domain.tokenization.TokenizableString
-import com.simprints.core.tools.extentions.getCurrentPermissionStatus
-import com.simprints.core.tools.extentions.hasPermission
-import com.simprints.core.tools.extentions.permissionFromResult
+import com.simprints.core.tools.extensions.getCurrentPermissionStatus
+import com.simprints.core.tools.extensions.hasPermission
+import com.simprints.core.tools.extensions.permissionFromResult
 import com.simprints.feature.externalcredential.R
 import com.simprints.feature.externalcredential.databinding.FragmentExternalCredentialScanQrBinding
 import com.simprints.feature.externalcredential.screens.controller.ExternalCredentialViewModel

--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/search/ExternalCredentialSearchFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/search/ExternalCredentialSearchFragment.kt
@@ -21,7 +21,7 @@ import androidx.navigation.fragment.navArgs
 import com.simprints.core.domain.common.FlowType
 import com.simprints.core.domain.externalcredential.ExternalCredentialType
 import com.simprints.core.livedata.LiveDataEventWithContentObserver
-import com.simprints.core.tools.extentions.hideKeyboard
+import com.simprints.core.tools.extensions.hideKeyboard
 import com.simprints.feature.externalcredential.R
 import com.simprints.feature.externalcredential.databinding.FragmentExternalCredentialSearchBinding
 import com.simprints.feature.externalcredential.ext.getCredentialFieldTitle

--- a/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/ReportActionRequestEventsUseCase.kt
+++ b/feature/login-check/src/main/java/com/simprints/feature/logincheck/usecases/ReportActionRequestEventsUseCase.kt
@@ -1,7 +1,7 @@
 package com.simprints.feature.logincheck.usecases
 
 import com.simprints.core.SessionCoroutineScope
-import com.simprints.core.tools.extentions.toJsonElementMap
+import com.simprints.core.tools.extensions.toJsonElementMap
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.utils.SimNetworkUtils
 import com.simprints.infra.events.event.domain.models.BiometricDataSource

--- a/feature/login/src/main/java/com/simprints/feature/login/screens/qrscanner/QrScannerFragment.kt
+++ b/feature/login/src/main/java/com/simprints/feature/login/screens/qrscanner/QrScannerFragment.kt
@@ -10,7 +10,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
-import com.simprints.core.tools.extentions.hasPermission
+import com.simprints.core.tools.extensions.hasPermission
 import com.simprints.feature.login.R
 import com.simprints.feature.login.databinding.FragmentQrScannerBinding
 import com.simprints.infra.logging.LoggingConstants

--- a/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchFragment.kt
+++ b/feature/matcher/src/main/java/com/simprints/matcher/screen/MatchFragment.kt
@@ -12,9 +12,9 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.simprints.core.domain.permission.PermissionStatus
 import com.simprints.core.livedata.LiveDataEventWithContentObserver
-import com.simprints.core.tools.extentions.applicationSettingsIntent
-import com.simprints.core.tools.extentions.hasPermission
-import com.simprints.core.tools.extentions.permissionFromResult
+import com.simprints.core.tools.extensions.applicationSettingsIntent
+import com.simprints.core.tools.extensions.hasPermission
+import com.simprints.core.tools.extensions.permissionFromResult
 import com.simprints.feature.exitform.ExitFormContract
 import com.simprints.feature.exitform.ExitFormResult
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION

--- a/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
+++ b/fingerprint/capture/src/main/java/com/simprints/fingerprint/capture/screen/FingerprintCaptureViewModel.kt
@@ -13,7 +13,7 @@ import com.simprints.core.domain.common.TemplateIdentifier
 import com.simprints.core.livedata.LiveDataEvent
 import com.simprints.core.livedata.LiveDataEventWithContent
 import com.simprints.core.livedata.send
-import com.simprints.core.tools.extentions.updateOnIndex
+import com.simprints.core.tools.extensions.updateOnIndex
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.fingerprint.capture.extensions.isEager

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/controller/ConnectScannerControllerFragment.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/controller/ConnectScannerControllerFragment.kt
@@ -17,8 +17,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.simprints.core.domain.permission.PermissionStatus
 import com.simprints.core.domain.permission.worstPermissionStatus
 import com.simprints.core.livedata.LiveDataEventWithContentObserver
-import com.simprints.core.tools.extentions.hasPermissions
-import com.simprints.core.tools.extentions.permissionFromResult
+import com.simprints.core.tools.extensions.hasPermissions
+import com.simprints.core.tools.extensions.permissionFromResult
 import com.simprints.feature.alert.AlertContract
 import com.simprints.feature.alert.AlertResult
 import com.simprints.feature.alert.toArgs

--- a/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/serialentrypair/SerialEntryPairFragment.kt
+++ b/fingerprint/connect/src/main/java/com/simprints/fingerprint/connect/screens/issues/serialentrypair/SerialEntryPairFragment.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
 import com.simprints.core.livedata.LiveDataEventWithContentObserver
-import com.simprints.core.tools.extentions.hideKeyboard
+import com.simprints.core.tools.extensions.hideKeyboard
 import com.simprints.fingerprint.connect.R
 import com.simprints.fingerprint.connect.databinding.FragmentSerialEntryPairBinding
 import com.simprints.fingerprint.connect.screens.ConnectScannerViewModel

--- a/id/src/main/java/com/simprints/id/Application.kt
+++ b/id/src/main/java/com/simprints/id/Application.kt
@@ -6,7 +6,7 @@ import androidx.work.Configuration
 import com.simprints.core.AppScope
 import com.simprints.core.CoreApplication
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
-import com.simprints.core.tools.extentions.deviceHardwareId
+import com.simprints.core.tools.extensions.deviceHardwareId
 import com.simprints.core.tools.utils.LanguageHelper
 import com.simprints.infra.enrolment.records.repository.local.migration.RealmToRoomMigrationScheduler
 import com.simprints.infra.eventsync.BuildConfig.DB_ENCRYPTION

--- a/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
+++ b/infra/auth-store/src/main/java/com/simprints/infra/authstore/domain/LoginInfoStore.kt
@@ -5,7 +5,7 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.core.domain.tokenization.isTokenized
-import com.simprints.core.tools.extentions.onUpdate
+import com.simprints.core.tools.extensions.onUpdate
 import com.simprints.infra.security.SecurityManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject

--- a/infra/core/src/main/java/com/simprints/core/CoreModule.kt
+++ b/infra/core/src/main/java/com/simprints/core/CoreModule.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.work.WorkManager
 import com.lyft.kronos.AndroidClockFactory
 import com.simprints.core.tools.exceptions.AppCoroutineExceptionHandler
-import com.simprints.core.tools.extentions.deviceHardwareId
-import com.simprints.core.tools.extentions.packageVersionName
+import com.simprints.core.tools.extensions.deviceHardwareId
+import com.simprints.core.tools.extensions.packageVersionName
 import com.simprints.core.tools.time.KronosTimeHelperImpl
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.utils.EncodingUtils

--- a/infra/core/src/main/java/com/simprints/core/tools/extensions/Activity.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extensions/Activity.ext.kt
@@ -1,4 +1,4 @@
-package com.simprints.core.tools.extentions
+package com.simprints.core.tools.extensions
 
 import android.app.Activity
 import android.content.Context

--- a/infra/core/src/main/java/com/simprints/core/tools/extensions/Any.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extensions/Any.ext.kt
@@ -1,4 +1,4 @@
-package com.simprints.core.tools.extentions
+package com.simprints.core.tools.extensions
 
 // Sealed whens throw compiling issues only if the whens result is assigned to variables.
 // safeSealedWhens to force the Sealed whens to be exhaustive:

--- a/infra/core/src/main/java/com/simprints/core/tools/extensions/Context.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extensions/Context.ext.kt
@@ -1,4 +1,4 @@
-package com.simprints.core.tools.extentions
+package com.simprints.core.tools.extensions
 
 import android.annotation.SuppressLint
 import android.content.Context

--- a/infra/core/src/main/java/com/simprints/core/tools/extensions/Coroutines.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extensions/Coroutines.ext.kt
@@ -1,4 +1,4 @@
-package com.simprints.core.tools.extentions
+package com.simprints.core.tools.extensions
 
 import kotlinx.coroutines.CancellableContinuation
 import kotlin.coroutines.resume

--- a/infra/core/src/main/java/com/simprints/core/tools/extensions/Cursor.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extensions/Cursor.ext.kt
@@ -1,4 +1,4 @@
-package com.simprints.core.tools.extentions
+package com.simprints.core.tools.extensions
 
 import android.database.Cursor
 import androidx.core.database.getIntOrNull

--- a/infra/core/src/main/java/com/simprints/core/tools/extensions/Float.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extensions/Float.ext.kt
@@ -1,4 +1,4 @@
-package com.simprints.core.tools.extentions
+package com.simprints.core.tools.extensions
 
 import android.content.Context
 import android.util.TypedValue

--- a/infra/core/src/main/java/com/simprints/core/tools/extensions/Flow.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extensions/Flow.ext.kt
@@ -1,4 +1,4 @@
-package com.simprints.core.tools.extentions
+package com.simprints.core.tools.extensions
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.drop

--- a/infra/core/src/main/java/com/simprints/core/tools/extensions/List.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extensions/List.ext.kt
@@ -1,4 +1,4 @@
-package com.simprints.core.tools.extentions
+package com.simprints.core.tools.extensions
 
 fun <T> List<T>.updateOnIndex(
     index: Int,

--- a/infra/core/src/main/java/com/simprints/core/tools/extensions/Map.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extensions/Map.ext.kt
@@ -1,4 +1,4 @@
-package com.simprints.core.tools.extentions
+package com.simprints.core.tools.extensions
 
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive

--- a/infra/core/src/main/java/com/simprints/core/tools/extensions/RectF.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extensions/RectF.ext.kt
@@ -1,4 +1,4 @@
-package com.simprints.core.tools.extentions
+package com.simprints.core.tools.extensions
 
 import android.graphics.RectF
 import kotlin.math.abs

--- a/infra/core/src/main/java/com/simprints/core/tools/extensions/SharedPreferences.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extensions/SharedPreferences.ext.kt
@@ -1,4 +1,4 @@
-package com.simprints.core.tools.extentions
+package com.simprints.core.tools.extensions
 
 import android.content.SharedPreferences
 import kotlinx.coroutines.channels.awaitClose

--- a/infra/core/src/test/java/com/simprints/core/tools/extensions/ActivityExtTest.kt
+++ b/infra/core/src/test/java/com/simprints/core/tools/extensions/ActivityExtTest.kt
@@ -5,7 +5,7 @@ import androidx.core.app.ActivityCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
 import com.simprints.core.domain.permission.PermissionStatus
-import com.simprints.core.tools.extentions.permissionFromResult
+import com.simprints.core.tools.extensions.permissionFromResult
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic

--- a/infra/core/src/test/java/com/simprints/core/tools/extensions/FlowExtTest.kt
+++ b/infra/core/src/test/java/com/simprints/core/tools/extensions/FlowExtTest.kt
@@ -1,4 +1,4 @@
-package com.simprints.core.tools.extentions
+package com.simprints.core.tools.extensions
 
 import com.google.common.truth.Truth.*
 import kotlinx.coroutines.flow.flowOf

--- a/infra/core/src/test/java/com/simprints/core/tools/extensions/ListExtTest.kt
+++ b/infra/core/src/test/java/com/simprints/core/tools/extensions/ListExtTest.kt
@@ -1,4 +1,4 @@
-package com.simprints.core.tools.extentions
+package com.simprints.core.tools.extensions
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test

--- a/infra/core/src/test/java/com/simprints/core/tools/extensions/RectFExtTest.kt
+++ b/infra/core/src/test/java/com/simprints/core/tools/extensions/RectFExtTest.kt
@@ -3,7 +3,7 @@ package com.simprints.core.tools.extensions
 import android.graphics.RectF
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.*
-import com.simprints.core.tools.extentions.area
+import com.simprints.core.tools.extensions.area
 import org.junit.Test
 import org.junit.runner.RunWith
 

--- a/infra/core/src/test/java/com/simprints/core/tools/extensions/SharedPreferencesExtTest.kt
+++ b/infra/core/src/test/java/com/simprints/core/tools/extensions/SharedPreferencesExtTest.kt
@@ -5,7 +5,7 @@ import android.content.SharedPreferences
 import androidx.test.core.app.*
 import androidx.test.ext.junit.runners.*
 import com.google.common.truth.Truth.*
-import com.simprints.core.tools.extentions.onUpdate
+import com.simprints.core.tools.extensions.onUpdate
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle

--- a/infra/core/src/test/java/com/simprints/core/tools/utils/MapUtilKtTest.kt
+++ b/infra/core/src/test/java/com/simprints/core/tools/utils/MapUtilKtTest.kt
@@ -1,7 +1,7 @@
 package com.simprints.core.tools.utils
 
-import com.simprints.core.tools.extentions.toJsonElementMap
-import com.simprints.core.tools.extentions.toStringMap
+import com.simprints.core.tools.extensions.toJsonElementMap
+import com.simprints.core.tools.extensions.toStringMap
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiInvalidIntentPayload.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiInvalidIntentPayload.kt
@@ -1,7 +1,7 @@
 package com.simprints.infra.eventsync.event.remote.models
 
 import androidx.annotation.Keep
-import com.simprints.core.tools.extentions.toStringMap
+import com.simprints.core.tools.extensions.toStringMap
 import com.simprints.infra.config.store.models.TokenKeyType
 import com.simprints.infra.events.event.domain.models.InvalidIntentEvent.InvalidIntentPayload
 import kotlinx.serialization.Serializable

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiSuspiciousIntentPayload.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiSuspiciousIntentPayload.kt
@@ -1,7 +1,7 @@
 package com.simprints.infra.eventsync.event.remote.models
 
 import androidx.annotation.Keep
-import com.simprints.core.tools.extentions.toStringMap
+import com.simprints.core.tools.extensions.toStringMap
 import com.simprints.infra.config.store.models.TokenKeyType
 import com.simprints.infra.events.event.domain.models.SuspiciousIntentEvent.SuspiciousIntentPayload
 import kotlinx.serialization.Serializable

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventToApiUseCaseTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventToApiUseCaseTest.kt
@@ -5,7 +5,7 @@ import com.google.common.truth.Truth.*
 import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.core.domain.tokenization.asTokenizableEncrypted
 import com.simprints.core.domain.tokenization.asTokenizableRaw
-import com.simprints.core.tools.extentions.safeSealedWhens
+import com.simprints.core.tools.extensions.safeSealedWhens
 import com.simprints.core.tools.utils.StringTokenizer
 import com.simprints.infra.config.store.models.Project
 import com.simprints.infra.config.store.models.ProjectState

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration10to11.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration10to11.kt
@@ -7,7 +7,7 @@ import androidx.annotation.Keep
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.simprints.core.domain.common.Modality
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.events.event.domain.models.scope.DatabaseInfo
 import com.simprints.infra.events.event.domain.models.scope.Device
 import com.simprints.infra.events.event.domain.models.scope.EventScopeEndCause

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration12to13.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration12to13.kt
@@ -5,8 +5,8 @@ import android.database.sqlite.SQLiteDatabase
 import androidx.annotation.VisibleForTesting
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.simprints.core.tools.extentions.getLongWithColumnName
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getLongWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MIGRATION
 import com.simprints.infra.logging.Simber
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration14to15.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration14to15.kt
@@ -3,9 +3,9 @@ package com.simprints.infra.events.event.local.migrations
 import android.content.ContentValues
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.simprints.core.tools.extentions.getIntWithColumnName
-import com.simprints.core.tools.extentions.getLongWithColumnName
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getIntWithColumnName
+import com.simprints.core.tools.extensions.getLongWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MIGRATION
 import com.simprints.infra.logging.Simber
 import net.zetetic.database.sqlcipher.SQLiteDatabase

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration15to16.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration15to16.kt
@@ -2,7 +2,7 @@ package com.simprints.infra.events.event.local.migrations
 
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MIGRATION
 import com.simprints.infra.logging.Simber
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration16to17.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration16to17.kt
@@ -2,7 +2,7 @@ package com.simprints.infra.events.event.local.migrations
 
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MIGRATION
 import com.simprints.infra.logging.Simber
 import org.json.JSONArray

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration1to2.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration1to2.kt
@@ -3,7 +3,7 @@ package com.simprints.infra.events.event.local.migrations
 import android.database.Cursor
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MIGRATION
 import com.simprints.infra.logging.Simber
 import org.json.JSONObject

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration2to3.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration2to3.kt
@@ -2,7 +2,7 @@ package com.simprints.infra.events.event.local.migrations
 
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MIGRATION
 import com.simprints.infra.logging.Simber
 

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration3to4.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration3to4.kt
@@ -3,7 +3,7 @@ package com.simprints.infra.events.event.local.migrations
 import android.database.Cursor
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MIGRATION
 import com.simprints.infra.logging.Simber
 import org.json.JSONObject

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration5to6.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration5to6.kt
@@ -3,7 +3,7 @@ package com.simprints.infra.events.event.local.migrations
 import android.database.Cursor
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MIGRATION
 import com.simprints.infra.logging.Simber
 import org.json.JSONArray

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration6to7.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration6to7.kt
@@ -3,7 +3,7 @@ package com.simprints.infra.events.event.local.migrations
 import android.database.Cursor
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MIGRATION
 import com.simprints.infra.logging.Simber
 import org.json.JSONObject

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration7to8.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration7to8.kt
@@ -5,7 +5,7 @@ import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.core.tools.utils.randomUUID
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MIGRATION
 import com.simprints.infra.logging.Simber

--- a/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration9to10.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/local/migrations/EventMigration9to10.kt
@@ -5,7 +5,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.simprints.core.domain.tokenization.serialization.TokenizableStringSerializer.FIELD_CLASS_NAME
 import com.simprints.core.domain.tokenization.serialization.TokenizableStringSerializer.FIELD_VALUE
 import com.simprints.core.domain.tokenization.serialization.TokenizableStringSerializer.RAW
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.MIGRATION
 import com.simprints.infra.logging.Simber
 

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration10to11Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration10to11Test.kt
@@ -9,8 +9,8 @@ import androidx.test.ext.junit.runners.*
 import androidx.test.platform.app.*
 import com.google.common.truth.Truth.*
 import com.simprints.core.domain.common.Modality
-import com.simprints.core.tools.extentions.getLongWithColumnName
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getLongWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.core.tools.utils.randomUUID
 import com.simprints.infra.events.event.domain.models.EventType
 import com.simprints.infra.events.event.domain.models.scope.DatabaseInfo

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration11to12Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration11to12Test.kt
@@ -6,8 +6,8 @@ import androidx.room.testing.MigrationTestHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
-import com.simprints.core.tools.extentions.getIntWithColumnName
-import com.simprints.core.tools.extentions.getLongWithColumnName
+import com.simprints.core.tools.extensions.getIntWithColumnName
+import com.simprints.core.tools.extensions.getLongWithColumnName
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import org.junit.Rule
 import org.junit.Test

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration12to13Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration12to13Test.kt
@@ -6,9 +6,9 @@ import androidx.room.testing.MigrationTestHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
-import com.simprints.core.tools.extentions.getIntWithColumnName
-import com.simprints.core.tools.extentions.getLongWithColumnName
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getIntWithColumnName
+import com.simprints.core.tools.extensions.getLongWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import org.junit.Rule
 import org.junit.Test

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration13to14Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration13to14Test.kt
@@ -6,9 +6,9 @@ import androidx.room.testing.MigrationTestHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
-import com.simprints.core.tools.extentions.getIntWithColumnName
-import com.simprints.core.tools.extentions.getLongWithColumnName
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getIntWithColumnName
+import com.simprints.core.tools.extensions.getLongWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.events.event.domain.models.scope.EventScopeType
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import org.junit.Rule

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration14to15Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration14to15Test.kt
@@ -6,7 +6,7 @@ import androidx.room.testing.MigrationTestHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import org.junit.Rule
 import org.junit.Test

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration15to16Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration15to16Test.kt
@@ -6,7 +6,7 @@ import androidx.room.testing.MigrationTestHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import org.junit.Rule
 import org.junit.Test

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration16to17Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration16to17Test.kt
@@ -8,7 +8,7 @@ import androidx.sqlite.db.SupportSQLiteQuery
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.core.tools.utils.randomUUID
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import io.mockk.spyk

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration1to2Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration1to2Test.kt
@@ -7,7 +7,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.core.tools.utils.randomUUID
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import com.simprints.infra.events.event.local.migrations.MigrationTestingTools.retrieveCursorWithEventById

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration2to3Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration2to3Test.kt
@@ -7,7 +7,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth
-import com.simprints.core.tools.extentions.getIntWithColumnName
+import com.simprints.core.tools.extensions.getIntWithColumnName
 import com.simprints.core.tools.utils.randomUUID
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import com.simprints.infra.events.event.local.migrations.MigrationTestingTools.retrieveCursorWithEventById

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration3to4Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration3to4Test.kt
@@ -8,7 +8,7 @@ import androidx.sqlite.db.SupportSQLiteQuery
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.core.tools.utils.randomUUID
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import com.simprints.infra.events.event.local.migrations.MigrationTestingTools.retrieveCursorWithEventById

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration4to5Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration4to5Test.kt
@@ -6,8 +6,8 @@ import androidx.room.testing.MigrationTestHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
-import com.simprints.core.tools.extentions.getIntWithColumnName
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getIntWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import org.junit.Rule
 import org.junit.Test

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration5to6Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration5to6Test.kt
@@ -8,7 +8,7 @@ import androidx.sqlite.db.SupportSQLiteQuery
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.core.tools.utils.randomUUID
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import io.mockk.spyk

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration6to7Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration6to7Test.kt
@@ -8,7 +8,7 @@ import androidx.sqlite.db.SupportSQLiteQuery
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.*
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.core.tools.utils.randomUUID
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import io.mockk.spyk

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration7To8Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration7To8Test.kt
@@ -10,7 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import com.simprints.core.domain.common.TemplateIdentifier
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.core.tools.utils.randomUUID
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import com.simprints.testtools.common.syntax.assertThrows

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration9To10Test.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigration9To10Test.kt
@@ -6,7 +6,7 @@ import androidx.room.testing.MigrationTestHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.events.event.local.EventRoomDatabase
 import org.junit.Rule
 import org.junit.Test

--- a/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigrationTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/local/migrations/EventMigrationTest.kt
@@ -5,7 +5,7 @@ import android.database.sqlite.SQLiteDatabase.CONFLICT_NONE
 import androidx.room.testing.MigrationTestHelper
 import androidx.test.ext.junit.runners.*
 import androidx.test.platform.app.*
-import com.simprints.core.tools.extentions.getStringWithColumnName
+import com.simprints.core.tools.extensions.getStringWithColumnName
 import com.simprints.infra.events.event.domain.models.Event
 import com.simprints.infra.events.event.domain.models.EventType
 import com.simprints.infra.events.event.local.EventRoomDatabase

--- a/infra/ui-base/src/main/java/com/simprints/infra/uibase/camera/qrscan/QrCodeDetector.kt
+++ b/infra/ui-base/src/main/java/com/simprints/infra/uibase/camera/qrscan/QrCodeDetector.kt
@@ -6,8 +6,8 @@ import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.barcode.common.Barcode
 import com.google.mlkit.vision.common.InputImage
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
-import com.simprints.core.tools.extentions.resumeSafely
-import com.simprints.core.tools.extentions.resumeWithExceptionSafely
+import com.simprints.core.tools.extensions.resumeSafely
+import com.simprints.core.tools.extensions.resumeWithExceptionSafely
 import com.simprints.infra.logging.LoggingConstants
 import com.simprints.infra.logging.Simber
 import dagger.assisted.Assisted

--- a/infra/ui-base/src/main/java/com/simprints/infra/view/imagecapture/CaptureProgressView.kt
+++ b/infra/ui-base/src/main/java/com/simprints/infra/view/imagecapture/CaptureProgressView.kt
@@ -18,7 +18,7 @@ import android.view.View
 import android.view.animation.LinearInterpolator
 import androidx.annotation.ColorInt
 import androidx.core.os.BundleCompat
-import com.simprints.core.tools.extentions.dpToPx
+import com.simprints.core.tools.extensions.dpToPx
 import com.simprints.infra.uibase.R
 import com.simprints.infra.uibase.annotations.ExcludedFromGeneratedTestCoverageReports
 

--- a/infra/ui-base/src/main/java/com/simprints/infra/view/imagecapture/CaptureTargetView.kt
+++ b/infra/ui-base/src/main/java/com/simprints/infra/view/imagecapture/CaptureTargetView.kt
@@ -12,7 +12,7 @@ import android.util.AttributeSet
 import android.view.View
 import androidx.annotation.ColorInt
 import androidx.core.os.BundleCompat
-import com.simprints.core.tools.extentions.dpToPx
+import com.simprints.core.tools.extensions.dpToPx
 import com.simprints.infra.uibase.R
 import com.simprints.infra.uibase.annotations.ExcludedFromGeneratedTestCoverageReports
 


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2026.3.0**

### Notable changes

* A package was wrongly named 'extentions' instead of 'extensions'
* To make it worse in tests there were both 'extentions' and 'extensions' :)
* This PR renames the packages and all imports to the correct spelling so that my OCD can let me sleep tonight

### Testing guidance

* Everything should work as before (famous last words for the second time today - I'm really pushing it!)

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
