### PR TITLE
[MS-1520] Don't send empty moduleIds in DeviceConfigurationUpdatedEvent

### DIFF
--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCase.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCase.kt
@@ -19,15 +19,20 @@ internal class TokenizeEventPayloadFieldsUseCase @Inject constructor(
                 project = project,
             )
         }
-        val tokenizedListFields = event.getTokenizableListFields().mapValues { (tokenKeyType, listFieldValue) ->
-            listFieldValue.map { fieldValue ->
-                tokenizationProcessor.tokenizeIfNecessary(
-                    tokenizableString = fieldValue,
-                    tokenKeyType = tokenKeyType,
-                    project = project,
-                )
+        val tokenizedListFields = event
+            .getTokenizableListFields()
+            // Empty lists have nothing to tokenize, and propagating them would replace an absent
+            // field with an empty one that the backend then rejects as untokenized.
+            .filterValues { it.isNotEmpty() }
+            .mapValues { (tokenKeyType, listFieldValue) ->
+                listFieldValue.map { fieldValue ->
+                    tokenizationProcessor.tokenizeIfNecessary(
+                        tokenizableString = fieldValue,
+                        tokenKeyType = tokenKeyType,
+                        project = project,
+                    )
+                }
             }
-        }
         return event.setTokenizedFields(tokenizedFields).setTokenizedListFields(tokenizedListFields)
     }
 }

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventToApiUseCaseTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventToApiUseCaseTest.kt
@@ -640,6 +640,18 @@ internal class MapDomainEventToApiUseCaseTest {
     }
 
     @Test
+    fun `when no modules are selected, then downSyncModules should be omitted from the ApiEvent`() {
+        val event = createDeviceConfigurationUpdatedEvent().let {
+            it.copy(payload = it.payload.copy(configuration = it.payload.configuration.copy(downSyncModules = null)))
+        }
+        val apiEvent = useCase(event, project)
+        val json = JSONObject(SimJson.encodeToString(apiEvent))
+
+        assertThat(json.getJSONObject("payload").getJSONObject("configuration").has("downSyncModules")).isFalse()
+        assertThat(json.getJSONArray("tokenizedFields").length()).isEqualTo(0)
+    }
+
+    @Test
     fun `when event contains tokenized attendant id, then ApiEvent should contain tokenizedField`() {
         validateUserIdTokenization(attendantId = "attendantId".asTokenizableEncrypted())
     }

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCaseTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/usecases/TokenizeEventPayloadFieldsUseCaseTest.kt
@@ -62,6 +62,17 @@ internal class TokenizeEventPayloadFieldsUseCaseTest {
     }
 
     @Test
+    fun `should not invoke tokenizeIfNecessary for empty list of TokenizableString`() {
+        every { event.getTokenizableFields() } returns emptyMap()
+        every { event.getTokenizableListFields() } returns mapOf(tokenKeyTypeList to emptyList())
+
+        useCase(event = event, project = project)
+
+        verify(exactly = 0) { tokenizationProcessor.tokenizeIfNecessary(any(), any(), any()) }
+        verify { event.setTokenizedListFields(emptyMap()) }
+    }
+
+    @Test
     fun `should handle both field and list of TokenizableString in same event`() {
         every { event.getTokenizableFields() } returns mapOf(tokenKeyType to rawString)
         every { event.getTokenizableListFields() } returns mapOf(tokenKeyTypeList to listOf(rawString, rawString))

--- a/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/DeviceConfigurationUpdatedEventTest.kt
+++ b/infra/events/src/test/java/com/simprints/infra/events/event/domain/models/DeviceConfigurationUpdatedEventTest.kt
@@ -1,6 +1,7 @@
 package com.simprints.infra.events.event.domain.models
 
 import com.google.common.truth.Truth.*
+import com.simprints.core.domain.tokenization.TokenizableString
 import com.simprints.core.domain.tokenization.asTokenizableEncrypted
 import com.simprints.core.domain.tokenization.asTokenizableRaw
 import com.simprints.infra.config.store.models.TokenKeyType
@@ -56,13 +57,36 @@ class DeviceConfigurationUpdatedEventTest {
         )
     }
 
-    private fun createDefaultEvent(): DeviceConfigurationUpdatedEvent = DeviceConfigurationUpdatedEvent(
-        createdAt = CREATED_AT,
-        language = "en",
-        downSyncModules = listOf(
+    @Test
+    fun setTokenizableFields_keepsExistingModuleIdsWhenMapHasNoModuleIds() {
+        val event = createDefaultEvent()
+
+        val updatedEvent = event.setTokenizedListFields(emptyMap()) as DeviceConfigurationUpdatedEvent
+
+        assertThat(updatedEvent.payload.configuration.downSyncModules).containsExactly(
+            "module1".asTokenizableRaw(),
+            "module2".asTokenizableEncrypted(),
+        )
+    }
+
+    @Test
+    fun setTokenizableFields_keepsModuleIdsNullWhenMapHasNoModuleIds() {
+        val event = createDefaultEvent(downSyncModules = null)
+
+        val updatedEvent = event.setTokenizedListFields(emptyMap()) as DeviceConfigurationUpdatedEvent
+
+        assertThat(updatedEvent.payload.configuration.downSyncModules).isNull()
+    }
+
+    private fun createDefaultEvent(
+        downSyncModules: List<TokenizableString>? = listOf(
             "module1".asTokenizableRaw(),
             "module2".asTokenizableEncrypted(),
         ),
+    ): DeviceConfigurationUpdatedEvent = DeviceConfigurationUpdatedEvent(
+        createdAt = CREATED_AT,
+        language = "en",
+        downSyncModules = downSyncModules,
         sourceUpdate = DeviceConfigurationUpdatedEvent.DeviceConfigurationUpdateSource.REMOTE,
     )
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1520)
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.2.0**

* If selected moduleIds on the device are empty, it generates an event with an empty array (instead of null) for moduleIds but doesn't list them in tokenized fields (as there's nothing tokenized in there). However, the backend validation trips as it sees a path that should be tokenized but is not listed as such.

### Notable changes

* When moduleIds are empty - set the value to null instead of empty array so that JSON conversion omits it

### Testing guidance

* Login with a project configured with module partitioning but don't select modules
* Go to settings and change language
* Sync
* Backend should not complain

### Additional work checklist

* [x] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
