### PR TITLE
Ensure that DISABLED spoof check state is parsed correctly

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModel.kt
@@ -17,8 +17,8 @@ import com.simprints.face.infra.basebiosdk.detection.FaceDetector
 import com.simprints.face.infra.biosdkresolver.ResolveFaceBioSdkUseCase
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.ExperimentalProjectConfiguration.Companion.FACE_AUTO_CAPTURE_IMAGING_DURATION_MILLIS_DEFAULT
-import com.simprints.infra.config.store.models.FaceConfiguration
 import com.simprints.infra.config.store.models.FaceConfiguration.SpoofCheckConfiguration
+import com.simprints.infra.config.store.models.FaceConfiguration.SpoofCheckMode
 import com.simprints.infra.config.store.models.ModalitySdkType
 import com.simprints.infra.config.store.models.experimental
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.FACE_CAPTURE
@@ -273,12 +273,12 @@ internal class LiveFeedbackViewModel @Inject constructor(
     private fun finishCapture(attemptNumber: Int) {
         Simber.i("Finish capture", tag = FACE_CAPTURE)
         viewModelScope.launch {
-            if (spoofCheckConfig == SpoofCheckConfiguration.DISABLED) {
+            if (spoofCheckConfig.mode == SpoofCheckMode.DISABLED) {
                 sendEventsAndFinish(attemptNumber)
             } else {
                 runSpoofChecksOnCaptures()
 
-                if (spoofCheckConfig.mode == FaceConfiguration.SpoofCheckMode.RECORDED) {
+                if (spoofCheckConfig.mode == SpoofCheckMode.RECORDED) {
                     sendEventsAndFinish(attemptNumber)
                 } else {
                     val spoofCheckPassed = userCaptures.map { it.spoofCheckResult }.all {

--- a/face/capture/src/main/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCase.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCase.kt
@@ -25,14 +25,18 @@ class GetSpoofCheckConfigurationUseCase @Inject constructor(
 
         // TODO use the Face SDK configuration instead
         return projectConfiguration.experimental().let {
-            FaceConfiguration.SpoofCheckConfiguration(
-                mode = it.spoofCheckMode,
-                threshold = it.spoofCheckThreshold,
-                maxAttempts = it.spoofMaxAttempts,
-                maxBitmapSize = it.spoofMaxBitmapSize,
-                validationUiDurationMs = it.spoofMinValidationUiDurationMs,
-                validationErrorUiDurationMs = it.spoofMinValidationErrorUiDurationMs,
-            )
+            if (it.spoofCheckMode == FaceConfiguration.SpoofCheckMode.DISABLED) {
+                FaceConfiguration.SpoofCheckConfiguration.DISABLED
+            } else {
+                FaceConfiguration.SpoofCheckConfiguration(
+                    mode = it.spoofCheckMode,
+                    threshold = it.spoofCheckThreshold,
+                    maxAttempts = it.spoofMaxAttempts,
+                    maxBitmapSize = it.spoofMaxBitmapSize,
+                    validationUiDurationMs = it.spoofMinValidationUiDurationMs,
+                    validationErrorUiDurationMs = it.spoofMinValidationErrorUiDurationMs,
+                )
+            }
         }
     }
 }

--- a/face/capture/src/test/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCaseTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/usecases/GetSpoofCheckConfigurationUseCaseTest.kt
@@ -81,4 +81,33 @@ class GetSpoofCheckConfigurationUseCaseTest {
         assertThat(result.maxAttempts).isEqualTo(3)
         assertThat(result.maxBitmapSize).isEqualTo(1000)
     }
+
+    @Test
+    fun `Returns config when ROC V3 is used with spoof check is disabled`() {
+        every { projectConfiguration.face } returns faceConfiguration
+        every { faceConfiguration.getSdkConfiguration(any()) } returns faceSdkConfiguration
+        every { faceSdkConfiguration.version } returns "3.1"
+        every { projectConfiguration.custom } returns mapOf(
+            "spoofCheckMode" to JsonPrimitive("DISABLED"),
+            "spoofCheckThreshold" to JsonPrimitive(0.75f),
+            "spoofMaxAttempts" to JsonPrimitive(3),
+            "spoofMaxBitmapSize" to JsonPrimitive(1000),
+        )
+
+        val result = useCase(projectConfiguration, ModalitySdkType.RANK_ONE)
+
+        assertThat(result).isEqualTo(SpoofCheckConfiguration.DISABLED)
+    }
+
+    @Test
+    fun `Returns config when ROC V3 is used without spoof check configuration`() {
+        every { projectConfiguration.face } returns faceConfiguration
+        every { faceConfiguration.getSdkConfiguration(any()) } returns faceSdkConfiguration
+        every { faceSdkConfiguration.version } returns "3.1"
+        every { projectConfiguration.custom } returns mapOf()
+
+        val result = useCase(projectConfiguration, ModalitySdkType.RANK_ONE)
+
+        assertThat(result).isEqualTo(SpoofCheckConfiguration.DISABLED)
+    }
 }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/FaceConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/FaceConfiguration.kt
@@ -48,8 +48,8 @@ data class FaceConfiguration(
                 threshold = 0f,
                 maxAttempts = 0,
                 maxBitmapSize = 0,
-                validationUiDurationMs = 0,
-                validationErrorUiDurationMs = 0,
+                validationUiDurationMs = 1, // To avoid division by 0
+                validationErrorUiDurationMs = 1, // To avoid division by 0
             )
         }
     }


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.3.0**

* When the spoof check for ROCv3 is disabled, a new object is still created from the custom configuration fields instead of using the correct instance. This erroneously enables the check even when it should be disabled.

### Notable changes

* Tightened the custom configuration parsing to avoid creating new instances for the "disabled" state.
* Tightened the checks in VM to rely on the explicit mode value instead of comparing to "DISABLED" instance.

### Testing guidance

* Run workflows with ROCv3 and disabled/missing spoof configuration. Checks should not be running.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
