### PR TITLE
MS-1492 Add a configuration to show parental consent by default

### DIFF
--- a/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/ConsentFragment.kt
+++ b/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/ConsentFragment.kt
@@ -14,6 +14,8 @@ import com.simprints.core.livedata.LiveDataEventObserver
 import com.simprints.feature.consent.ConsentParams
 import com.simprints.feature.consent.R
 import com.simprints.feature.consent.databinding.FragmentConsentBinding
+import com.simprints.feature.consent.screens.consent.ConsentViewModel.Companion.GENERAL_CONSENT_TAB
+import com.simprints.feature.consent.screens.consent.ConsentViewModel.Companion.PARENTAL_CONSENT_TAB
 import com.simprints.feature.exitform.ExitFormContract
 import com.simprints.feature.exitform.ExitFormResult
 import com.simprints.infra.logging.LoggingConstants.CrashReportTag.ORCHESTRATION
@@ -141,10 +143,5 @@ internal class ConsentFragment : Fragment(R.layout.fragment_consent) {
         GENERAL_CONSENT_TAB -> ConsentTab.INDIVIDUAL
         PARENTAL_CONSENT_TAB -> ConsentTab.PARENTAL
         else -> throw IllegalStateException("Invalid consent tab selected")
-    }
-
-    companion object {
-        private const val GENERAL_CONSENT_TAB = 0
-        private const val PARENTAL_CONSENT_TAB = 1
     }
 }

--- a/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/ConsentViewModel.kt
+++ b/feature/consent/src/main/java/com/simprints/feature/consent/screens/consent/ConsentViewModel.kt
@@ -16,6 +16,7 @@ import com.simprints.feature.consent.screens.consent.helpers.ParentalConsentText
 import com.simprints.feature.exitform.ExitFormResult
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.ProjectConfiguration
+import com.simprints.infra.config.store.models.experimental
 import com.simprints.infra.events.event.domain.models.ConsentEvent
 import com.simprints.infra.events.session.SessionEventRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -32,24 +33,20 @@ internal class ConsentViewModel @Inject constructor(
     @param:SessionCoroutineScope private val sessionCoroutineScope: CoroutineScope,
 ) : ViewModel() {
     private val startConsentEventTime = timeHelper.now()
+    private var selectedTab: Int = TAB_NOT_SELECTED
 
     val viewState: LiveData<ConsentViewState>
-        get() = _viewState
-    private val _viewState = MutableLiveData(ConsentViewState())
-    private var selectedTab: Int = 0
+        field = MutableLiveData(ConsentViewState())
 
     val showExitForm: LiveData<LiveDataEvent>
-        get() = _showExitForm
-    private val _showExitForm = MutableLiveData<LiveDataEvent>()
-
+        field = MutableLiveData<LiveDataEvent>()
     val returnConsentResult: LiveData<LiveDataEventWithContent<Serializable>>
-        get() = _returnConsentResult
-    private val _returnConsentResult = MutableLiveData<LiveDataEventWithContent<Serializable>>()
+        field = MutableLiveData<LiveDataEventWithContent<Serializable>>()
 
     fun loadConfiguration(consentType: ConsentType) {
         viewModelScope.launch {
             val projectConfig = configRepository.getProjectConfiguration()
-            _viewState.postValue(
+            viewState.postValue(
                 mapConfigToViewState(
                     projectConfig = projectConfig,
                     consentType = consentType,
@@ -61,18 +58,18 @@ internal class ConsentViewModel @Inject constructor(
 
     fun acceptClicked(currentConsentTab: ConsentTab) {
         saveConsentEvent(currentConsentTab, ConsentEvent.ConsentPayload.Result.ACCEPTED)
-        _returnConsentResult.send(ConsentResult(true))
+        returnConsentResult.send(ConsentResult(true))
     }
 
     fun declineClicked(currentConsentTab: ConsentTab) {
         saveConsentEvent(currentConsentTab, ConsentEvent.ConsentPayload.Result.DECLINED)
-        _showExitForm.send()
+        showExitForm.send()
     }
 
     fun handleExitFormResponse(exitResult: ExitFormResult) {
         if (exitResult.wasSubmitted) {
             deleteLocationInfoFromSession()
-            _returnConsentResult.send(exitResult)
+            returnConsentResult.send(exitResult)
         }
     }
 
@@ -103,7 +100,15 @@ internal class ConsentViewModel @Inject constructor(
             } else {
                 null
             },
-            selectedTab = selectedTabIndex,
+            selectedTab = if (selectedTabIndex == TAB_NOT_SELECTED) {
+                if (allowParentalConsent && projectConfig.experimental().useParentalConsentAsDefault) {
+                    PARENTAL_CONSENT_TAB
+                } else {
+                    GENERAL_CONSENT_TAB
+                }
+            } else {
+                selectedTabIndex
+            },
         )
     }
 
@@ -127,5 +132,11 @@ internal class ConsentViewModel @Inject constructor(
 
     fun setSelectedTab(index: Int) {
         selectedTab = index
+    }
+
+    companion object {
+        const val TAB_NOT_SELECTED = -1
+        const val GENERAL_CONSENT_TAB = 0
+        const val PARENTAL_CONSENT_TAB = 1
     }
 }

--- a/feature/consent/src/test/java/com/simprints/feature/consent/screens/consent/ConsentViewModelTest.kt
+++ b/feature/consent/src/test/java/com/simprints/feature/consent/screens/consent/ConsentViewModelTest.kt
@@ -7,6 +7,8 @@ import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
 import com.simprints.feature.consent.ConsentResult
 import com.simprints.feature.consent.ConsentType
+import com.simprints.feature.consent.screens.consent.ConsentViewModel.Companion.GENERAL_CONSENT_TAB
+import com.simprints.feature.consent.screens.consent.ConsentViewModel.Companion.PARENTAL_CONSENT_TAB
 import com.simprints.feature.exitform.ExitFormResult
 import com.simprints.infra.config.store.ConfigRepository
 import com.simprints.infra.config.store.models.ProjectConfiguration
@@ -18,6 +20,7 @@ import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -75,18 +78,34 @@ class ConsentViewModelTest {
         assertThat(state.consentTextBuilder).isNotNull()
         assertThat(state.showParentalConsent).isTrue()
         assertThat(state.parentalTextBuilder).isNotNull()
+        assertThat(state.selectedTab).isEqualTo(GENERAL_CONSENT_TAB)
     }
 
     @Test
     fun `loadConfiguration passes correct values from config without parental consent to state`() = runTest {
         every { projectConfig.consent.allowParentalConsent } returns false
         every { projectConfig.general.modalities } returns defaultModalityList
+        every { projectConfig.custom } returns mapOf("useParentalConsentAsDefault" to JsonPrimitive(true))
 
         vm.loadConfiguration(ConsentType.ENROL)
         val state = vm.viewState.getOrAwaitValue()
 
         assertThat(state.showParentalConsent).isFalse()
         assertThat(state.parentalTextBuilder).isNull()
+        assertThat(state.selectedTab).isEqualTo(GENERAL_CONSENT_TAB)
+    }
+
+    @Test
+    fun `loadConfiguration passes correct values from config with parental consent as default to state`() = runTest {
+        every { projectConfig.consent.allowParentalConsent } returns true
+        every { projectConfig.custom } returns mapOf("useParentalConsentAsDefault" to JsonPrimitive(true))
+        every { projectConfig.general.modalities } returns defaultModalityList
+
+        vm.loadConfiguration(ConsentType.ENROL)
+        val state = vm.viewState.getOrAwaitValue()
+
+        assertThat(state.showParentalConsent).isTrue()
+        assertThat(state.selectedTab).isEqualTo(PARENTAL_CONSENT_TAB)
     }
 
     @Test

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/models/ExperimentalProjectConfiguration.kt
@@ -5,7 +5,6 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.floatOrNull
-import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
@@ -230,6 +229,13 @@ data class ExperimentalProjectConfiguration(
             ?.coerceAtLeast(0)
             ?: SPOOF_CHECK_MIN_VALIDATION_ERROR_UI_DURATION_MS_DEFAULT
 
+    val useParentalConsentAsDefault: Boolean
+        get() = customConfig
+            ?.get(USE_PARENTAL_CONSENT_AS_DEFAULT)
+            ?.jsonPrimitive
+            ?.booleanOrNull
+            .let { it == true }
+
     companion object {
         internal const val DISABLE_SUBJECT_POOL_VALIDATION = "disableSubjectPoolValidation"
         internal const val FACE_AUTO_CAPTURE_IMAGING_DURATION_MILLIS = "faceAutoCaptureImagingDurationMillis"
@@ -307,5 +313,7 @@ data class ExperimentalProjectConfiguration(
         const val SPOOF_CHECK_MIN_VALIDATION_UI_DURATION_MS_DEFAULT = 2000
         const val SPOOF_CHECK_MIN_VALIDATION_ERROR_UI_DURATION_MS = "spoofMinValidationErrorUiDurationMs"
         const val SPOOF_CHECK_MIN_VALIDATION_ERROR_UI_DURATION_MS_DEFAULT = 2000
+
+        const val USE_PARENTAL_CONSENT_AS_DEFAULT = "useParentalConsentAsDefault"
     }
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/models/ExperimentalProjectConfigurationTest.kt
@@ -437,4 +437,17 @@ internal class ExperimentalProjectConfigurationTest {
             assertThat(ExperimentalProjectConfiguration(config).spoofMinValidationErrorUiDurationMs).isEqualTo(result)
         }
     }
+
+    @Test
+    fun `use parent consent as default parsed correctly`() {
+        mapOf(
+            emptyMap<String, JsonElement>() to false,
+            mapOf(ExperimentalProjectConfiguration.USE_PARENTAL_CONSENT_AS_DEFAULT to JsonPrimitive(null)) to false,
+            mapOf(ExperimentalProjectConfiguration.USE_PARENTAL_CONSENT_AS_DEFAULT to JsonPrimitive("string")) to false,
+            mapOf(ExperimentalProjectConfiguration.USE_PARENTAL_CONSENT_AS_DEFAULT to JsonPrimitive(true)) to true,
+            mapOf(ExperimentalProjectConfiguration.USE_PARENTAL_CONSENT_AS_DEFAULT to JsonPrimitive(false)) to false,
+        ).forEach { (config, result) ->
+            assertThat(ExperimentalProjectConfiguration(config).useParentalConsentAsDefault).isEqualTo(result)
+        }
+    }
 }


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1492)
Will be released in: **2026.3.0**

### Notable changes

* Added a custom configuration flag to select parental consent as the default.
* Checking the custom config when building the initial consent page state.

### Testing guidance

* Set flag to "true", run some requests with consent enabled.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
