### PR TITLE
[MS-1541] Stop event sync retries on network connection failure

### DIFF
--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTask.kt
@@ -42,6 +42,7 @@ import com.simprints.infra.network.exceptions.BackendMaintenanceException
 import com.simprints.infra.network.exceptions.NetworkConnectionException
 import com.simprints.infra.network.exceptions.SyncCloudIntegrationException
 import com.simprints.infra.serialization.SimJson
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
@@ -226,6 +227,7 @@ internal class EventUpSyncTask @Inject constructor(
                 .let(eventFilter)
                 .map { (scope, events) -> mapDomainEventScopeToApiUseCase(scope, events.orEmpty(), project) }
             val uploadedScopes = mutableListOf<String>()
+            var isNetworkUnavailable = false
 
             scopesToUpload.takeIf { it.isNotEmpty() }?.apply {
                 val requestId = UUID.randomUUID().toString()
@@ -245,13 +247,23 @@ internal class EventUpSyncTask @Inject constructor(
                         content = createUpSyncContent(this.size),
                     )
                     uploadedScopes.addAll(this.map { it.id })
+                } catch (ex: CancellationException) {
+                    throw ex
                 } catch (ex: Exception) {
+                    isNetworkUnavailable = ex is NetworkConnectionException
                     handleFailedRequest(requestId, ex, eventScope, requestStartTime)
                 }
             }
 
-            Simber.d("Deleting ${uploadedScopes.size} session scopes", tag = SYNC)
+            Simber.d("Deleting ${uploadedScopes.size} $eventScopeTypeToUpload scopes", tag = SYNC)
             eventRepository.deleteEventScopes(uploadedScopes)
+
+            // Without connectivity the upload will keep failing immediately on every iteration,
+            // spinning the loop indefinitely and logging a new failure event each time. Stop
+            // retrying this scope type until the next scheduled sync attempt instead.
+            if (isNetworkUnavailable) {
+                break
+            }
         }
     }
 

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTaskTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/sync/up/tasks/EventUpSyncTaskTest.kt
@@ -45,6 +45,7 @@ import com.simprints.infra.network.exceptions.NetworkConnectionException
 import com.simprints.infra.network.exceptions.SyncCloudIntegrationException
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.SerializationException
@@ -435,6 +436,83 @@ internal class EventUpSyncTaskTest {
         eventUpSyncTask.upSync(operation, eventScope).toList()
 
         coVerify(exactly = 0) { eventRepo.deleteEventScope(any()) }
+    }
+
+    @Test
+    fun `when upload fails due to network issue should stop retrying instead of looping indefinitely`() = runTest {
+        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.ALL)
+
+        // Scopes remain closed forever since the failed upload is never deleted,
+        // simulating a device that stays offline.
+        coEvery { eventRepo.getClosedEventScopesCount(EventScopeType.SESSION) } returns 1
+        coEvery { eventRepo.getClosedEventScopes(any(), any()) } returns emptyList()
+        coEvery { eventRepo.getClosedEventScopes(EventScopeType.SESSION, any()) } returns listOf(
+            createSessionScope(GUID1),
+        )
+        coEvery {
+            eventRepo.getEventsFromScope(GUID1)
+        } returns listOf(createEventWithSessionId(GUID1, GUID1))
+
+        coEvery {
+            eventRemoteDataSource.post(any(), any(), any())
+        } throws NetworkConnectionException(
+            cause = Exception(),
+        )
+
+        eventUpSyncTask.upSync(operation, eventScope).toList()
+
+        // Only a single attempt (and a single failure event) should be recorded per sync run,
+        // instead of spinning in a tight loop and logging duplicate events while offline.
+        coVerify(exactly = 1) { eventRemoteDataSource.post(any(), any(), any()) }
+        coVerify(exactly = 1) { eventRepo.addOrUpdateEvent(eventScope, any<EventUpSyncRequestEvent>()) }
+    }
+
+    @Test
+    fun `when upload is cancelled it should rethrow instead of treating it as a failed request`() = runTest {
+        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.ALL)
+
+        coEvery { eventRepo.getClosedEventScopesCount(EventScopeType.SESSION) } returns 1
+        coEvery { eventRepo.getClosedEventScopes(any(), any()) } returns emptyList()
+        coEvery { eventRepo.getClosedEventScopes(EventScopeType.SESSION, any()) } returns listOf(
+            createSessionScope(GUID1),
+        )
+        coEvery {
+            eventRepo.getEventsFromScope(GUID1)
+        } returns listOf(createEventWithSessionId(GUID1, GUID1))
+
+        coEvery {
+            eventRemoteDataSource.post(any(), any(), any())
+        } throws CancellationException("Upload was cancelled")
+
+        eventUpSyncTask.upSync(operation, eventScope).toList()
+
+        // The exception should propagate straight out of the request try/catch
+        coVerify(exactly = 0) { eventRepo.deleteEventScopes(any()) }
+        coVerify(exactly = 0) { eventRepo.addOrUpdateEvent(eventScope, any<EventUpSyncRequestEvent>()) }
+    }
+
+    @Test
+    fun `when upload is cancelled it should stop uploading remaining scope types`() = runTest {
+        setUpSyncKind(UpSynchronizationConfiguration.UpSynchronizationKind.ALL)
+
+        coEvery { eventRepo.getClosedEventScopesCount(EventScopeType.SESSION) } returns 1
+        coEvery { eventRepo.getClosedEventScopesCount(EventScopeType.UP_SYNC) } returns 1
+        coEvery { eventRepo.getClosedEventScopesCount(EventScopeType.DOWN_SYNC) } returns 1
+        coEvery { eventRepo.getClosedEventScopesCount(EventScopeType.SAMPLE_UP_SYNC) } returns 1
+        coEvery { eventRepo.getClosedEventScopes(any(), any()) } returns listOf(createSessionScope(GUID1))
+        coEvery {
+            eventRepo.getEventsFromScope(GUID1)
+        } returns listOf(createEventWithSessionId(GUID1, GUID1))
+
+        coEvery {
+            eventRemoteDataSource.post(any(), any(), any())
+        } throws CancellationException("Upload was cancelled")
+
+        eventUpSyncTask.upSync(operation, eventScope).toList()
+
+        // Cancellation aborts the whole upSync flow immediately, so only the first
+        // scope type attempted its (single) request before the rest were abandoned.
+        coVerify(exactly = 1) { eventRemoteDataSource.post(any(), any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
[MS-1541](https://simprints.atlassian.net/browse/MS-1541)
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.3.0**

* When the device is offline, `EventUpSyncTask.uploadEventScopeType` retries uploading closed event scopes in a `while` loop with no delay/backoff.
* Each failed upload attempt calls `authStore.getFirebaseToken()` under the hood, which throws `NetworkConnectionException` when `FirebaseAuthManager` can't reach the network. This is caught and unconditionally logs a new `EventUpSyncRequestEvent`, unlike the success path which only logs when there's useful content.
* Because the failed scope is never deleted, the loop's exit condition (`getClosedEventScopesCount(...) > 0`) stays true, so it retries immediately with no backoff — spinning indefinitely while offline and creating a new event on every iteration, which shows up as accumulating extra events on the dashboard sync screen.

### Changes

* `EventUpSyncTask.uploadEventScopeType`: when the upload fails with a `NetworkConnectionException`, break out of the retry loop for that scope type instead of retrying immediately, deferring the retry to the next scheduled sync attempt. This limits the failure to a single logged event per sync run while offline instead of an unbounded tight loop.

### Testing guidance

* To verify manually: put the device in airplane mode with pending events to sync, trigger a sync, and confirm the sync screen event count stops growing after a single failed attempt instead of climbing continuously.

### Additional work checklist

- [ ] Effect on other features and security has been considered
- [ ] Design document marked as "In development" (if applicable)
- [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
- [ ] Test cases in Testiny are up to date (or ticket created)
- [ ] Other teams notified about the changes (if applicable)


[MS-1541]: https://simprints.atlassian.net/browse/MS-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ