### PR TITLE
Restore face quality check

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/models/FaceDetection.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/models/FaceDetection.kt
@@ -22,6 +22,7 @@ internal data class FaceDetection(
     enum class Status {
         VALID,
         VALID_CAPTURING,
+        BAD_QUALITY,
         NOFACE,
         OFFYAW,
         OFFROLL,

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -343,6 +343,9 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
             LiveFeedbackState.Feedback.TOO_FAR ->
                 renderInvalidFace(IDR.string.face_capture_title_too_far, IDR.string.face_capture_error_too_far)
 
+            LiveFeedbackState.Feedback.BAD_QUALITY ->
+                renderInvalidFace(IDR.string.face_capture_title_bad_quality, IDR.string.face_capture_error_bad_quality)
+
             LiveFeedbackState.Feedback.VALID -> {
                 if (state.isAutoCapture) {
                     captureFeedbackBtn.setText(IDR.string.face_capture_prep_begin_button_capturing)

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackState.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackState.kt
@@ -21,7 +21,7 @@ internal data class LiveFeedbackState(
      * UI-facing guidance derived from the latest [FaceDetection].
      * Decoupled from the biometric [FaceDetection.Status] so the fragment maps it to text/visuals via a simple lookup.
      */
-    enum class Feedback { NONE, NO_FACE, LOOK_STRAIGHT, TOO_CLOSE, TOO_FAR, VALID, VALID_CAPTURING }
+    enum class Feedback { NONE, NO_FACE, LOOK_STRAIGHT, TOO_CLOSE, TOO_FAR, BAD_QUALITY, VALID, VALID_CAPTURING }
 
     companion object {
         fun initial(isAutoCapture: Boolean = false) = LiveFeedbackState(
@@ -54,4 +54,5 @@ internal fun FaceDetection.Status.toFeedback(): LiveFeedbackState.Feedback = whe
     FaceDetection.Status.OFFROLL -> LiveFeedbackState.Feedback.LOOK_STRAIGHT
     FaceDetection.Status.TOOCLOSE -> LiveFeedbackState.Feedback.TOO_CLOSE
     FaceDetection.Status.TOOFAR -> LiveFeedbackState.Feedback.TOO_FAR
+    FaceDetection.Status.BAD_QUALITY -> LiveFeedbackState.Feedback.BAD_QUALITY
 }

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModel.kt
@@ -228,7 +228,14 @@ internal class LiveFeedbackViewModel @Inject constructor(
                 }
             }
         } else {
-            feedback = faceDetection.status.toFeedback()
+            feedback = if (fallbackCapture != null && faceDetection.status == FaceDetection.Status.BAD_QUALITY) {
+                // In some environment it might be difficult to maintain the image quality for long enough to press capture button,
+                // therefore once we have at least one good quality fallback capture, the user can ignore the "bad_quality" state
+                // and proceed with capture as long as the face is in the correct position.
+                LiveFeedbackState.Feedback.VALID
+            } else {
+                faceDetection.status.toFeedback()
+            }
         }
 
         when (newPhase) {
@@ -419,6 +426,7 @@ internal class LiveFeedbackViewModel @Inject constructor(
             areaOccupied > faceTarget.areaRange.endInclusive -> FaceDetection.Status.TOOCLOSE
             potentialFace.yaw !in faceTarget.yawTarget -> FaceDetection.Status.OFFYAW
             potentialFace.roll !in faceTarget.rollTarget -> FaceDetection.Status.OFFROLL
+            potentialFace.quality < qualityThreshold -> FaceDetection.Status.BAD_QUALITY
             phase == LiveFeedbackState.Phase.CAPTURING -> FaceDetection.Status.VALID_CAPTURING
             else -> FaceDetection.Status.VALID
         }

--- a/face/capture/src/main/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporter.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporter.kt
@@ -95,6 +95,7 @@ internal class SimpleCaptureEventReporter @Inject constructor(
             FaceDetection.Status.OFFROLL -> FaceCapturePayload.Result.OFF_ROLL
             FaceDetection.Status.TOOCLOSE -> FaceCapturePayload.Result.TOO_CLOSE
             FaceDetection.Status.TOOFAR -> FaceCapturePayload.Result.TOO_FAR
+            FaceDetection.Status.BAD_QUALITY -> FaceCapturePayload.Result.BAD_QUALITY
         }
     }
 

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModelTest.kt
@@ -334,6 +334,65 @@ internal class LiveFeedbackViewModelTest {
     }
 
     @Test
+    fun `auto - invalid faces map to the correct feedback`() = runTest {
+        every { isUsingAutoCapture.invoke(any()) } returns true
+        every { faceDetector.analyze(frame) } returnsMany listOf(
+            getFace(Rect(0, 0, 30, 30)), // too far
+            getFace(Rect(0, 0, 80, 80)), // too close
+            getFace(yaw = 45f), // off yaw
+            getFace(roll = 45f), // off roll
+            getFace(quality = 0f), // bad quality
+            null, // no face
+        )
+        val states = collectStates()
+
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.startCapture()
+        repeat(6) {
+            viewModel.process(frame, frame)
+        }
+        advanceUntilIdle()
+
+        val feedbacks = states.map { it.feedback }
+        assertThat(feedbacks).containsAtLeast(
+            LiveFeedbackState.Feedback.NONE, // This may repeat multiple time so cannot do exact comparison
+            LiveFeedbackState.Feedback.TOO_FAR,
+            LiveFeedbackState.Feedback.TOO_CLOSE,
+            LiveFeedbackState.Feedback.LOOK_STRAIGHT,
+            LiveFeedbackState.Feedback.BAD_QUALITY,
+            LiveFeedbackState.Feedback.NO_FACE,
+        )
+        coVerify(exactly = 0) { eventReporter.addCaptureEvents(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `auto - returns correct amount of valid faces after finishing`() = runTest {
+        every { isUsingAutoCapture.invoke(any()) } returns true
+        every { faceDetector.analyze(frame) } returnsMany listOf(
+            getFace(Rect(0, 0, 30, 30)), // too far
+            getFace(quality = 0.95f), // good
+            getFace(quality = 0f), // bad quality
+            getFace(quality = 0.9f), // good, but will be replaced
+            getFace(quality = 0.97f), // good
+            null, // no face
+        )
+        val states = collectStates()
+
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2, 0)
+        viewModel.startCapture()
+        repeat(7) {
+            viewModel.process(frame, frame)
+        }
+        advanceUntilIdle()
+
+        assertThat(viewModel.sortedQualifyingCaptures).hasSize(2)
+        assertThat(viewModel.sortedQualifyingCaptures.map { it.face?.quality }).containsExactly(0.97f, 0.95f)
+        coVerify(exactly = 2) { eventReporter.addCaptureEvents(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `spoof RECORDED finishes regardless of score`() = runTest {
         every { getSpoofCheckConfiguration.invoke(any(), any()) } returns spoofConfig()
         every { faceDetector.analyze(frame) } returns getFace()

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModelTest.kt
@@ -198,7 +198,34 @@ internal class LiveFeedbackViewModelTest {
             getFace(Rect(0, 0, 80, 80)), // too close
             getFace(yaw = 45f), // off yaw
             getFace(roll = 45f), // off roll
+            getFace(quality = 0f),
             null, // no face
+        )
+        val states = collectStates()
+
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2, 0)
+        repeat(6) { viewModel.process(frame, frame) }
+
+        val feedbacks = states.map { it.feedback }
+        assertThat(feedbacks).containsExactly(
+            LiveFeedbackState.Feedback.NONE,
+            LiveFeedbackState.Feedback.TOO_FAR,
+            LiveFeedbackState.Feedback.TOO_CLOSE,
+            LiveFeedbackState.Feedback.LOOK_STRAIGHT,
+            LiveFeedbackState.Feedback.BAD_QUALITY,
+            LiveFeedbackState.Feedback.NO_FACE,
+        )
+        coVerify(exactly = 0) { eventReporter.addCaptureEvents(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `manual - bad quality faces considered valid after a valid fallback capture`() = runTest {
+        every { faceDetector.analyze(frame) } returnsMany listOf(
+            getFace(quality = 0f),
+            getFace(),
+            getFace(yaw = 45f), // to switch out the result
+            getFace(quality = 0f),
         )
         val states = collectStates()
 
@@ -207,13 +234,13 @@ internal class LiveFeedbackViewModelTest {
         repeat(5) { viewModel.process(frame, frame) }
 
         val feedbacks = states.map { it.feedback }
-        assertThat(feedbacks).containsAtLeast(
-            LiveFeedbackState.Feedback.TOO_FAR,
-            LiveFeedbackState.Feedback.TOO_CLOSE,
+        assertThat(feedbacks).containsExactly(
+            LiveFeedbackState.Feedback.NONE,
+            LiveFeedbackState.Feedback.BAD_QUALITY,
+            LiveFeedbackState.Feedback.VALID,
             LiveFeedbackState.Feedback.LOOK_STRAIGHT,
-            LiveFeedbackState.Feedback.NO_FACE,
+            LiveFeedbackState.Feedback.VALID,
         )
-        coVerify(exactly = 0) { eventReporter.addCaptureEvents(any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -525,7 +552,7 @@ internal class LiveFeedbackViewModelTest {
         )
 
     companion object {
-        private const val QUALITY_THRESHOLD = -1f
+        private const val QUALITY_THRESHOLD = 0.5f
         private const val AUTO_CAPTURE_IMAGING_DURATION_MS = 3000L
     }
 }

--- a/face/capture/src/test/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporterTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/usecases/SimpleCaptureEventReporterTest.kt
@@ -154,8 +154,9 @@ class SimpleCaptureEventReporterTest {
         reporter.addCaptureEvents(getDetection(FaceDetection.Status.OFFROLL), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
         reporter.addCaptureEvents(getDetection(FaceDetection.Status.TOOCLOSE), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
         reporter.addCaptureEvents(getDetection(FaceDetection.Status.TOOFAR), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
+        reporter.addCaptureEvents(getDetection(FaceDetection.Status.BAD_QUALITY), 1, 0.5f, SpoofCheckConfiguration.DISABLED)
 
-        coVerify(exactly = 5) {
+        coVerify(exactly = 6) {
             eventRepository.addOrUpdateEvent(withArg { assertThat(it).isInstanceOf(FaceCaptureEvent::class.java) })
         }
         coVerify(exactly = 0) {

--- a/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/FaceCaptureEvent.kt
+++ b/infra/events/src/main/java/com/simprints/infra/events/event/domain/models/FaceCaptureEvent.kt
@@ -82,8 +82,6 @@ data class FaceCaptureEvent(
         enum class Result {
             VALID,
             INVALID,
-
-            @Deprecated("Not used since 2026.3.0")
             BAD_QUALITY,
             OFF_YAW,
             OFF_ROLL,

--- a/infra/resources/src/main/res/values-am-rET/strings.xml
+++ b/infra/resources/src/main/res/values-am-rET/strings.xml
@@ -185,6 +185,8 @@
     <string name="face_capture_title_previewing">ለማንሳት እየተዘጋጀ</string>
     <string name="face_capture_title_no_face">ምንም ፊት ማግኘት አልቻለም</string>
     <string name="face_capture_error_no_face">ፊቱ ክቡን መሙላቱን ያረጋግጡ</string>
+    <string name="face_capture_title_bad_quality">ግልጽ ያልሆነ ምስል</string>
+    <string name="face_capture_error_bad_quality">ይበልጥ ግልጽ የሆነ ፎቶ ለማግኘት መብራቱን ለማስተካከል ወይም ፊቱን ለማስተካከል ይሞክሩ</string>
     <string name="face_capture_title_too_far">ፊቱ በጣም ርቋል</string>
     <string name="face_capture_error_too_far">ቀረብ አድርግ(ፊት ርቋል)</string>
     <string name="face_capture_title_too_close">ፊቱ በጣም ቀርቧል</string>

--- a/infra/resources/src/main/res/values-am/strings.xml
+++ b/infra/resources/src/main/res/values-am/strings.xml
@@ -185,6 +185,8 @@
     <string name="face_capture_title_previewing">ለማንሳት እየተዘጋጀ</string>
     <string name="face_capture_title_no_face">ምንም ፊት ማግኘት አልቻለም</string>
     <string name="face_capture_error_no_face">ፊቱ ክቡን መሙላቱን ያረጋግጡ</string>
+    <string name="face_capture_title_bad_quality">ግልጽ ያልሆነ ምስል</string>
+    <string name="face_capture_error_bad_quality">ይበልጥ ግልጽ የሆነ ፎቶ ለማግኘት መብራቱን ለማስተካከል ወይም ፊቱን ለማስተካከል ይሞክሩ</string>
     <string name="face_capture_title_too_far">ፊቱ በጣም ርቋል</string>
     <string name="face_capture_error_too_far">ቀረብ አድርግ(ፊት ርቋል)</string>
     <string name="face_capture_title_too_close">ፊቱ በጣም ቀርቧል</string>

--- a/infra/resources/src/main/res/values-fr/strings.xml
+++ b/infra/resources/src/main/res/values-fr/strings.xml
@@ -187,6 +187,8 @@
     <string name="face_capture_title_previewing">Préparation du scan</string>
     <string name="face_capture_title_no_face">Aucun visage détecté</string>
     <string name="face_capture_error_no_face">Assurez-vous que le visage soit dans le cercle</string>
+    <string name="face_capture_title_bad_quality">Image floue</string>
+    <string name="face_capture_error_bad_quality">Essayez d\'ajuster l\'éclairage ou de repositionner le visage pour obtenir une meilleure photo.</string>
     <string name="face_capture_title_too_far">Trop loin</string>
     <string name="face_capture_error_too_far">Rapprochez-vous</string>
     <string name="face_capture_title_too_close">Trop près</string>

--- a/infra/resources/src/main/res/values/strings.xml
+++ b/infra/resources/src/main/res/values/strings.xml
@@ -182,6 +182,8 @@
     <string name="face_capture_title_previewing">Preparing to scan</string>
     <string name="face_capture_title_no_face">No face detected</string>
     <string name="face_capture_error_no_face">Make sure the face fills the circle</string>
+    <string name="face_capture_title_bad_quality">Unclear Image</string>
+    <string name="face_capture_error_bad_quality">Try adjusting the lighting or repositioning the face for a clearer photo</string>
     <string name="face_capture_title_too_far">Too far</string>
     <string name="face_capture_error_too_far">Move closer</string>
     <string name="face_capture_title_too_close">Too close</string>


### PR DESCRIPTION
[JIRA ticket]()
Will be released in: **2026.3.0**

### Notable changes

* Restored the "bad quality" case UI and enums
* Restore the quality check to get at least one good quality image. In manual capture skipping the quality checks if good fallback is available to prevent unnecessary difficulties during capture (https://simprints.atlassian.net/browse/MS-746). In auto-capture checking quality of all images.

### Testing guidance

* Set very high quality threshold and point to a bad quality image of a face. 

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
