### PR TITLE
[MS-1545] Increment attempt number on face recapture

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/CaptureAttemptTracker.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/CaptureAttemptTracker.kt
@@ -1,0 +1,23 @@
+package com.simprints.face.capture.screens
+
+import dagger.hilt.android.scopes.ActivityRetainedScoped
+import javax.inject.Inject
+
+@ActivityRetainedScoped
+internal class CaptureAttemptTracker @Inject constructor() {
+    // The attempt number to hand out to the next capture attempt that starts
+    private var nextAttemptNumber: Int = 0
+
+    var attemptNumber: Int = 0
+        private set
+
+    fun onNewCaptureAttemptStarted() {
+        attemptNumber = nextAttemptNumber
+        nextAttemptNumber++
+    }
+
+    fun reset() {
+        attemptNumber = 0
+        nextAttemptNumber = 0
+    }
+}

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/FaceCaptureViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/FaceCaptureViewModel.kt
@@ -55,9 +55,10 @@ internal class FaceCaptureViewModel @Inject constructor(
     private val saveLicenseCheckEvent: SaveLicenseCheckEventUseCase,
     private val shouldShowInstructions: ShouldShowInstructionsScreenUseCase,
     @param:DeviceID private val deviceID: String,
+    private val captureAttemptTracker: CaptureAttemptTracker,
 ) : ViewModel() {
-    // Updated in live feedback screen
-    var attemptNumber: Int = 0
+    val attemptNumber: Int
+        get() = captureAttemptTracker.attemptNumber
     var samplesToCapture = 1
     var initialised = false
     lateinit var bioSDK: ModalitySdkType
@@ -92,6 +93,10 @@ internal class FaceCaptureViewModel @Inject constructor(
         activity: Activity,
         sdk: ModalitySdkType,
     ) = viewModelScope.launch {
+        if (::bioSDK.isInitialized && bioSDK != sdk) {
+            resetForNewCaptureStep()
+        }
+
         if (initialised) {
             Simber.i("Face bio SDK already initialised", tag = FACE_CAPTURE)
             return@launch
@@ -209,6 +214,16 @@ internal class FaceCaptureViewModel @Inject constructor(
         Simber.i("Starting face recapture flow", tag = FACE_CAPTURE)
         faceDetections = listOf()
         _recaptureEvent.send()
+    }
+
+    /**
+     * Resets the state that is scoped to a single capture step
+     **/
+    private fun resetForNewCaptureStep() {
+        Simber.i("Resetting face capture state for a new capture step", tag = FACE_CAPTURE)
+        captureAttemptTracker.reset()
+        initialised = false
+        faceDetections = emptyList()
     }
 
     private fun saveFaceDetections() {

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -118,7 +118,10 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
         // Wait till the views gets its final size then init frame processor and setup the camera
         binding.faceCaptureCamera.post {
             if (view != null) {
-                vm.initCapture(mainVm.bioSDK, mainVm.samplesToCapture, mainVm.attemptNumber)
+                vm.initCapture(
+                    bioSdk = mainVm.bioSDK,
+                    samplesToCapture = mainVm.samplesToCapture,
+                )
             }
         }
 

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModel.kt
@@ -10,6 +10,7 @@ import com.simprints.core.tools.time.TimeHelper
 import com.simprints.face.capture.models.FaceDetection
 import com.simprints.face.capture.models.FaceTarget
 import com.simprints.face.capture.models.SymmetricTarget
+import com.simprints.face.capture.screens.CaptureAttemptTracker
 import com.simprints.face.capture.usecases.GetSpoofCheckConfigurationUseCase
 import com.simprints.face.capture.usecases.IsUsingAutoCaptureUseCase
 import com.simprints.face.capture.usecases.SimpleCaptureEventReporter
@@ -50,9 +51,9 @@ internal class LiveFeedbackViewModel @Inject constructor(
     private val timeHelper: TimeHelper,
     private val isUsingAutoCaptureUseCase: IsUsingAutoCaptureUseCase,
     private val getSpoofCheckConfiguration: GetSpoofCheckConfigurationUseCase,
+    private val captureAttemptTracker: CaptureAttemptTracker,
     @param:DispatcherBG private val bgDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
-    private var attemptNumber: Int = 1
     private var samplesToCapture: Int = 1
     private var qualityThreshold: Float = 0f
 
@@ -153,11 +154,9 @@ internal class LiveFeedbackViewModel @Inject constructor(
     fun initCapture(
         bioSdk: ModalitySdkType,
         samplesToCapture: Int,
-        attemptNumber: Int,
     ) {
         Simber.i("Initialise face detection", tag = FACE_CAPTURE)
         this.samplesToCapture = samplesToCapture
-        this.attemptNumber = attemptNumber
         viewModelScope.launch {
             faceDetector = resolveFaceBioSdk(bioSdk).detector
 
@@ -179,6 +178,8 @@ internal class LiveFeedbackViewModel @Inject constructor(
     }
 
     fun startCapture() {
+        // Single path for every new capture attempt
+        captureAttemptTracker.onNewCaptureAttemptStarted()
         if (isAutoCapture) {
             isAutoCaptureHeldOff = false
         } else {
@@ -223,7 +224,7 @@ internal class LiveFeedbackViewModel @Inject constructor(
                     captureImagingStartTime = captureStartTime.ms
                     autoCaptureImagingTimeoutJob = viewModelScope.launch {
                         delay(autoCaptureImagingDurationMillis)
-                        finishCapture(attemptNumber)
+                        finishCapture(captureAttemptTracker.attemptNumber)
                     }
                 }
             }
@@ -248,7 +249,7 @@ internal class LiveFeedbackViewModel @Inject constructor(
                 } else {
                     userCaptures.add(faceDetection)
                     if (userCaptures.size == samplesToCapture) {
-                        finishCapture(attemptNumber)
+                        finishCapture(captureAttemptTracker.attemptNumber)
                     }
                 }
             }
@@ -382,7 +383,7 @@ internal class LiveFeedbackViewModel @Inject constructor(
         emit(phase = LiveFeedbackState.Phase.VALIDATION_FAILED)
         val duration = measureTimedValue {
             // Still track the capture attempt events for analytics and troubleshooting
-            sendCaptureEvents(attemptNumber)
+            sendCaptureEvents(captureAttemptTracker.attemptNumber)
 
             userCaptures.forEach {
                 it.original.recycle()

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/FaceCaptureViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/FaceCaptureViewModelTest.kt
@@ -67,6 +67,7 @@ class FaceCaptureViewModelTest {
     private lateinit var shouldShowInstructionsScreen: ShouldShowInstructionsScreenUseCase
 
     private lateinit var viewModel: FaceCaptureViewModel
+    private lateinit var captureAttemptTracker: CaptureAttemptTracker
 
     private val faceDetections = listOf<FaceDetection>(
         mockk(relaxed = true) {
@@ -81,6 +82,7 @@ class FaceCaptureViewModelTest {
         coEvery { faceImageUseCase.invoke(any(), any()) } returns null
         every { bitmapToByteArrayUseCase.invoke(any()) } returns byteArrayOf()
         every { authStore.signedInProjectId } returns "projectId"
+        captureAttemptTracker = CaptureAttemptTracker()
 
         viewModel = FaceCaptureViewModel(
             authStore,
@@ -95,6 +97,7 @@ class FaceCaptureViewModelTest {
             saveLicenseCheckEvent,
             shouldShowInstructionsScreen,
             "deviceId",
+            captureAttemptTracker,
         )
     }
 
@@ -155,6 +158,76 @@ class FaceCaptureViewModelTest {
 
         assertThat(viewModel.recaptureEvent.getOrAwaitValue()).isNotNull()
         assertThat(viewModel.getSampleDetection()).isNull()
+    }
+
+    @Test
+    fun `Recapture does not increment attempt number, since it is incremented when the next capture starts`() {
+        assertThat(viewModel.attemptNumber).isEqualTo(0)
+
+        viewModel.recapture()
+        assertThat(viewModel.attemptNumber).isEqualTo(0)
+
+        viewModel.recapture()
+        assertThat(viewModel.attemptNumber).isEqualTo(0)
+    }
+
+    @Test
+    fun `onNewCaptureAttemptStarted increments the attempt counter from the second call onwards`() {
+        assertThat(viewModel.attemptNumber).isEqualTo(0)
+
+        captureAttemptTracker.onNewCaptureAttemptStarted()
+        assertThat(viewModel.attemptNumber).isEqualTo(0)
+
+        captureAttemptTracker.onNewCaptureAttemptStarted()
+        assertThat(viewModel.attemptNumber).isEqualTo(1)
+    }
+
+    @Test
+    fun `Attempt number survives ViewModel recreation when the same CaptureAttemptTracker is retained`() {
+        captureAttemptTracker.onNewCaptureAttemptStarted()
+        captureAttemptTracker.onNewCaptureAttemptStarted()
+        captureAttemptTracker.onNewCaptureAttemptStarted()
+        assertThat(viewModel.attemptNumber).isEqualTo(2)
+
+        val restoredViewModel = FaceCaptureViewModel(
+            authStore,
+            configRepository,
+            faceImageUseCase,
+            eventReporter,
+            bitmapToByteArrayUseCase,
+            licenseRepository,
+            mockk {
+                coEvery { this@mockk(any()).initializer } returns faceBioSdkInitializer
+            },
+            saveLicenseCheckEvent,
+            shouldShowInstructionsScreen,
+            "deviceId",
+            captureAttemptTracker,
+        )
+
+        assertThat(restoredViewModel.attemptNumber).isEqualTo(2)
+    }
+
+    @Test
+    fun `Attempt number and init flag reset when a capture step starts for a different SDK`() {
+        val license = "license"
+        coEvery {
+            licenseRepository.getCachedLicense(Vendor.RankOne)
+        } returns License("2133-12-30T17:32:28Z", license, LicenseVersion("1.0"))
+        every { faceBioSdkInitializer.tryInitWithLicense(any(), license) } returns true
+        coJustRun { saveLicenseCheckEvent(any(), any()) }
+
+        viewModel.initFaceBioSdk(mockk(), ModalitySdkType.RANK_ONE)
+        captureAttemptTracker.onNewCaptureAttemptStarted()
+        captureAttemptTracker.onNewCaptureAttemptStarted()
+        captureAttemptTracker.onNewCaptureAttemptStarted()
+        assertThat(viewModel.attemptNumber).isEqualTo(2)
+        assertThat(viewModel.initialised).isTrue()
+
+        // A new capture step is started for a different SDK within the same (Activity-scoped) ViewModel
+        viewModel.initFaceBioSdk(mockk(), ModalitySdkType.SIM_FACE)
+
+        assertThat(viewModel.attemptNumber).isEqualTo(0)
     }
 
     @Test

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModelTest.kt
@@ -8,6 +8,7 @@ import com.google.common.truth.Truth.*
 import com.simprints.core.domain.permission.PermissionStatus
 import com.simprints.core.tools.time.TimeHelper
 import com.simprints.core.tools.time.Timestamp
+import com.simprints.face.capture.screens.CaptureAttemptTracker
 import com.simprints.face.capture.usecases.GetSpoofCheckConfigurationUseCase
 import com.simprints.face.capture.usecases.IsUsingAutoCaptureUseCase
 import com.simprints.face.capture.usecases.SimpleCaptureEventReporter
@@ -77,6 +78,8 @@ internal class LiveFeedbackViewModelTest {
 
     private lateinit var viewModel: LiveFeedbackViewModel
 
+    private val testCaptureAttemptTracker = CaptureAttemptTracker()
+
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
@@ -103,6 +106,7 @@ internal class LiveFeedbackViewModelTest {
             timeHelper,
             isUsingAutoCapture,
             getSpoofCheckConfiguration,
+            testCaptureAttemptTracker,
             testCoroutineRule.testCoroutineDispatcher,
         )
     }
@@ -162,7 +166,7 @@ internal class LiveFeedbackViewModelTest {
         every { faceDetector.analyze(frame) } returns getFace()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
         viewModel.process(frame, frame)
 
         with(viewModel.state.value) {
@@ -178,7 +182,7 @@ internal class LiveFeedbackViewModelTest {
         every { faceDetector.analyze(frame) } returns getFace()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2)
         viewModel.process(frame, frame)
         viewModel.startCapture()
         viewModel.process(frame, frame)
@@ -204,7 +208,7 @@ internal class LiveFeedbackViewModelTest {
         val states = collectStates()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2)
         repeat(6) { viewModel.process(frame, frame) }
 
         val feedbacks = states.map { it.feedback }
@@ -230,7 +234,7 @@ internal class LiveFeedbackViewModelTest {
         val states = collectStates()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2)
         repeat(5) { viewModel.process(frame, frame) }
 
         val feedbacks = states.map { it.feedback }
@@ -248,7 +252,7 @@ internal class LiveFeedbackViewModelTest {
         every { faceDetector.analyze(frame) } returns getFace()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2)
         viewModel.startCapture()
         viewModel.process(frame, frame)
 
@@ -262,7 +266,7 @@ internal class LiveFeedbackViewModelTest {
         val states = collectStates()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2)
         viewModel.process(frame, frame)
         viewModel.startCapture()
         viewModel.process(frame, frame)
@@ -288,7 +292,7 @@ internal class LiveFeedbackViewModelTest {
         every { faceDetector.analyze(frame) } returns getFace()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
         viewModel.process(frame, frame)
 
         assertThat(viewModel.state.value.phase).isEqualTo(LiveFeedbackState.Phase.NOT_STARTED)
@@ -302,7 +306,7 @@ internal class LiveFeedbackViewModelTest {
         every { faceDetector.analyze(frame) } returns getFace()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
         viewModel.startCapture()
         viewModel.holdOffAutoCapture()
         viewModel.process(frame, frame)
@@ -317,7 +321,7 @@ internal class LiveFeedbackViewModelTest {
         val states = collectStates()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
         viewModel.startCapture()
         viewModel.process(frame, frame)
 
@@ -347,7 +351,7 @@ internal class LiveFeedbackViewModelTest {
         val states = collectStates()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
         viewModel.startCapture()
         repeat(6) {
             viewModel.process(frame, frame)
@@ -380,7 +384,7 @@ internal class LiveFeedbackViewModelTest {
         val states = collectStates()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2)
         viewModel.startCapture()
         repeat(7) {
             viewModel.process(frame, frame)
@@ -400,7 +404,7 @@ internal class LiveFeedbackViewModelTest {
         val states = collectStates()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
         viewModel.process(frame, frame)
         viewModel.startCapture()
         viewModel.process(frame, frame)
@@ -418,7 +422,7 @@ internal class LiveFeedbackViewModelTest {
         coEvery { faceDetector.spoofCheck(any(), any()) } returns SpoofCheckResult(score = 0.1f)
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
         viewModel.process(frame, frame)
         viewModel.startCapture()
         viewModel.process(frame, frame)
@@ -435,7 +439,7 @@ internal class LiveFeedbackViewModelTest {
         val states = collectStates()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
         viewModel.process(frame, frame)
         viewModel.startCapture()
         viewModel.process(frame, frame)
@@ -454,7 +458,7 @@ internal class LiveFeedbackViewModelTest {
         coEvery { faceDetector.spoofCheck(any(), any()) } returns SpoofCheckResult(score = 0.9f)
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
 
         // Attempt 1
         viewModel.process(frame, frame)
@@ -472,6 +476,34 @@ internal class LiveFeedbackViewModelTest {
     }
 
     @Test
+    fun `spoof ENFORCED failing retry reports an incrementing attempt number`() = runTest {
+        every { getSpoofCheckConfiguration.invoke(any(), any()) } returns spoofConfig(FaceConfiguration.SpoofCheckMode.ENFORCED)
+        every { faceDetector.analyze(frame) } returns getFace()
+        coEvery { faceDetector.spoofCheck(any(), any()) } returns SpoofCheckResult(score = 0.9f)
+        val attemptNumbers = mutableListOf<Int>()
+        coEvery {
+            eventReporter.addCaptureEvents(any(), capture(attemptNumbers), any(), any(), any())
+        } just runs
+
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
+
+        // Attempt 0 fails spoof check
+        viewModel.process(frame, frame)
+        viewModel.startCapture()
+        viewModel.process(frame, frame)
+        advanceUntilIdle()
+
+        // Attempt 1 (retry) reaches maxAttempts and finishes
+        viewModel.process(frame, frame)
+        viewModel.startCapture()
+        viewModel.process(frame, frame)
+        advanceUntilIdle()
+
+        assertThat(attemptNumbers).containsAtLeast(0, 1)
+    }
+
+    @Test
     fun `frames are skipped while validating and progress uses the validation tint`() = runTest {
         every { getSpoofCheckConfiguration.invoke(any(), any()) } returns spoofConfig()
         every { faceDetector.analyze(frame) } returns getFace()
@@ -484,7 +516,7 @@ internal class LiveFeedbackViewModelTest {
         }
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
         viewModel.startCapture()
         viewModel.process(frame, frame)
         advanceUntilIdle()
@@ -497,7 +529,7 @@ internal class LiveFeedbackViewModelTest {
         every { faceDetector.analyze(frame) } returns getFace()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
         viewModel.process(frame, frame)
         viewModel.process(frame, frame)
         viewModel.process(frame, frame)
@@ -512,7 +544,7 @@ internal class LiveFeedbackViewModelTest {
         every { faceDetector.analyze(frame) } returns getFace()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
         viewModel.process(frame, frame) // fallback frame before start
         viewModel.startCapture()
         viewModel.process(frame, frame) // captured sample
@@ -529,7 +561,7 @@ internal class LiveFeedbackViewModelTest {
         every { faceDetector.analyze(any(), estimateAgeAndGender = true) } returns null
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 2)
         viewModel.process(frame, frame) // fallback frame before start
         viewModel.startCapture()
         viewModel.process(frame, frame)
@@ -555,7 +587,7 @@ internal class LiveFeedbackViewModelTest {
         every { faceDetector.analyze(any(), estimateAgeAndGender = true) } returns enrichedFace
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.RANK_ONE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.RANK_ONE, 1)
         viewModel.process(frame, frame) // fallback frame before start
         viewModel.startCapture()
         viewModel.process(frame, frame) // captured sample -> finishes
@@ -577,7 +609,7 @@ internal class LiveFeedbackViewModelTest {
         coEvery { faceDetector.spoofCheck(any(), any()) } returns SpoofCheckResult(score = 0.9f) // always fails
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
 
         // Attempt 1 fails and gets discarded.
         viewModel.process(frame, frame)
@@ -607,7 +639,7 @@ internal class LiveFeedbackViewModelTest {
         )
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
         viewModel.process(frame, frame) // fallback frame
         viewModel.startCapture()
         viewModel.process(frame, frame) // invalid capture -> finishes
@@ -627,7 +659,7 @@ internal class LiveFeedbackViewModelTest {
         every { faceDetector.analyze(frame) } returns getFace()
 
         viewModel.initAutoCapture()
-        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1, 0)
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
         viewModel.process(frame, frame) // pre-start fallback frame (held off)
         viewModel.startCapture()
         viewModel.process(frame, frame) // begins imaging


### PR DESCRIPTION
[MS-1545](https://simprints.atlassian.net/browse/MS-1545)
Will be released in: **2025.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **v2021.3.0**

* Found while investigating why `FaceCaptureEvent.attemptNb` was always `0` in analytics, regardless of how many times a user retook their face capture.

### Notable changes

* `FaceCaptureViewModel.recapture()` now increments `attemptNumber` on every recapture (covers the confirmation screen's decline/back-press/retake actions and the "no face detected" auto-retry).
* `LiveFeedbackViewModel.showValidationErrorAndReset()` now also increments the attempt count on a failed spoof-check retry, so each retry gets a distinct `attemptNb` instead of collapsing into one.
* `attemptNumber` is now backed by `SavedStateHandle` so it survives process death, and encapsulated with a private setter (only mutable via `recapture()`/internal reset) instead of a public mutable field.
* `initFaceBioSdk` resets the per-step state (`attemptNumber`, `initialised`) when a new capture step starts for a different face SDK, since `FaceCaptureViewModel` is Activity-scoped and can be reused across multiple face-capture steps (e.g. a project configured with more than one face SDK).
* Removed a stale/misleading default (`LiveFeedbackViewModel.attemptNumber = 1`) that was always overwritten before use.

### Testing guidance

* Manually: run a face capture flow, decline/retake at the confirmation screen a few times, and confirm the synced `FaceCaptureEvent.attemptNb` increments per retry instead of staying at `0`.

<img width="416" height="203" alt="image" src="https://github.com/user-attachments/assets/1f0cd9fc-4b10-4cda-a122-011ce5e1b8c4" />
<img width="533" height="205" alt="image" src="https://github.com/user-attachments/assets/aa848aef-d4fa-478a-a3f8-f111476a33d0" />

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)


[MS-1545]: https://simprints.atlassian.net/browse/MS-1545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ