### PR TITLE
Image injection bitmap recycling fix

### DIFF
--- a/infra/camera/src/main/java/com/simprints/infra/camera/CameraFrameProvider.kt
+++ b/infra/camera/src/main/java/com/simprints/infra/camera/CameraFrameProvider.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.simprints.core.DispatcherBG
 import com.simprints.core.DispatcherMain
 import com.simprints.core.ExcludedFromGeneratedTestCoverageReports
+import com.simprints.core.tools.extensions.clone
 import com.simprints.infra.camera.helpers.CameraFocusHelper
 import com.simprints.infra.camera.helpers.FrameEmissionHelper
 import com.simprints.infra.camera.usecase.FramePreProcessUseCase
@@ -221,7 +222,12 @@ class CameraFrameProvider @Inject internal constructor(
             targetRect = targetRect,
         )
         displayInjectedImage(frame)
-        frames.tryEmit(frame)
+        if (frame.isInjected) {
+            // Clone injected frames so callers can recycle the bitmap without affecting the preview overlay.
+            frames.tryEmit(frame.copy(bitmap = frame.bitmap.clone()))
+        } else {
+            frames.tryEmit(frame)
+        }
     }
 
     private fun displayInjectedImage(frame: Frame) {

--- a/infra/core/src/main/java/com/simprints/core/tools/extensions/Bitmap.ext.kt
+++ b/infra/core/src/main/java/com/simprints/core/tools/extensions/Bitmap.ext.kt
@@ -1,0 +1,5 @@
+package com.simprints.core.tools.extensions
+
+import android.graphics.Bitmap
+
+fun Bitmap.clone(): Bitmap = copy(config ?: Bitmap.Config.ARGB_8888, isMutable)


### PR DESCRIPTION
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.3.0**

* LiveFeedbackViewModel explicitly recycles bitmaps to avoid leaking them in certain scenarios.
* When same bitmap instance is set to image view (injection preview) and is later recycled, it crashes.

### Notable changes

* Clone emitted frame's bitmap to avoid recycling the exact bitmap that is used in image view

### Testing guidance

* Just run the capture automated test suite.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
