### PR TITLE
[MS-1563] Coroutine cancellation exception no longer send the error upstream

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -246,6 +246,7 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
                         }
                     } catch (e: CancellationException) {
                         Simber.e("Image analysis cancelled", e, tag = FACE_CAPTURE)
+                        throw e
                     } catch (t: Throwable) {
                         Simber.e("Image analysis crashed", t, tag = FACE_CAPTURE)
                         // submitError updates LiveData, so ensure it happens on the main thread

--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -41,6 +41,7 @@ import com.simprints.infra.uibase.view.awaitLayout
 import com.simprints.infra.uibase.view.setCheckedWithLeftDrawable
 import com.simprints.infra.uibase.viewbinding.viewBinding
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -243,6 +244,8 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
                             val cropped = frameCropToTargetUseCase(frame)
                             vm.process(originalBitmap = frame.bitmap, croppedBitmap = cropped)
                         }
+                    } catch (e: CancellationException) {
+                        Simber.e("Image analysis cancelled", e, tag = FACE_CAPTURE)
                     } catch (t: Throwable) {
                         Simber.e("Image analysis crashed", t, tag = FACE_CAPTURE)
                         // submitError updates LiveData, so ensure it happens on the main thread


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1563)
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.3.0**

When `LiveFeedbackFragment` is displayed, the fragment cannot be restored after app goes into background. 
The cause was the `CancellationException` that was thrown when the processing coroutine has been cancelled when app goes to background. This exception was propagated upstream which lead to fragment being closed.

### Notable changes

`CancellationException` is no longer processed upstream.

### Testing guidance

* Navigate to `LiveFeedbackFragment`
* Send SID to background by pressing the 'home' button on the navigation bar
* Return back to SID

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Test cases in Testiny are up to date (or ticket created)

