### PR TITLE
Change the sync button rendering order so that "TRY AGAIN" does not override "SYNCING"

### DIFF
--- a/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
+++ b/feature/dashboard/src/main/java/com/simprints/feature/dashboard/settings/syncinfo/SyncInfoFragment.kt
@@ -226,8 +226,8 @@ internal class SyncInfoFragment : Fragment(R.layout.fragment_sync_info) {
         binding.buttonSyncRecordsNow.isEnabled = records.isSyncButtonEnabled
         binding.buttonSyncRecordsNow.text = getString(
             when {
-                records.isSyncButtonForRetry -> IDR.string.sync_info_button_try_again
                 records.isProgressVisible -> IDR.string.sync_info_button_records_syncing
+                records.isSyncButtonForRetry -> IDR.string.sync_info_button_try_again
                 else -> IDR.string.sync_info_button_sync_records
             },
         )


### PR DESCRIPTION
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.3.0**

Marked by one of the Automated tests

* During sync the button changes from "SYNCING" to "TRY AGAIN".

### Notable changes

* Changed the order in which sync button labels are resolved to avoid overriding the "SYNCING" state while sync is active.

### Testing guidance

* Run "TCF-51" cases either manually or in automation.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
