### PR TITLE
Reset auto-capture on LiveFeedbackFragment pause

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackFragment.kt
@@ -176,6 +176,11 @@ internal class LiveFeedbackFragment : Fragment(R.layout.fragment_live_feedback) 
         Simber.i("Camera setup finished", tag = FACE_CAPTURE)
     }
 
+    override fun onPause() {
+        vm.holdOffAutoCapture()
+        super.onPause()
+    }
+
     override fun onResume() {
         super.onResume()
         vm.onScreenResumed(requireActivity().getCurrentPermissionStatus(Manifest.permission.CAMERA))


### PR DESCRIPTION
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.3.0**

* Auto-capture was successfully continued after application restart, which is a new and unexpected (even if it seems good) behaviour. 

### Notable changes

* Resetting auto-capture on screen pause so that it is restarted explicitly after restart.

### Testing guidance

* Auto-capture autotests

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
