### PR TITLE
restore version-code output in reusable-build-apk workflow

### DIFF
--- a/.github/workflows/reusable-build-apk.yml
+++ b/.github/workflows/reusable-build-apk.yml
@@ -17,6 +17,9 @@ on:
             optional-mapping-file:
                 description: "The mapping file for the built APK"
                 value: ${{ jobs.build-apk.outputs.mapping-text }}
+            version-code:
+                description: "The computed Android version code for the build"
+                value: ${{ jobs.build-apk.outputs.version-code }}
 
 jobs:
     build-apk:
@@ -24,6 +27,7 @@ jobs:
         outputs:
             build-artifact: ${{ steps.set-build-artifact.outputs.artifact }}
             mapping-text: ${{ steps.build-internal-apk.outputs.mapping }}
+            version-code: ${{ steps.set-build-artifact.outputs.version-code }}
 
         runs-on: ubuntu-latest
 
@@ -119,4 +123,6 @@ jobs:
 
             -   name: Set build-artifact output
                 id: set-build-artifact
-                run: echo "artifact=${{ env.FILE_NAME }}" >> $GITHUB_OUTPUT
+                run: |
+                    echo "artifact=${{ env.FILE_NAME }}" >> $GITHUB_OUTPUT
+                    echo "version-code=$VERSION_CODE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This was a merge issue I intrduced when I merged 2026.2.1 into main 