### PR TITLE
[MS-1571] Perform age and gender enrichment in the capturing phase

### DIFF
--- a/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModel.kt
+++ b/face/capture/src/main/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModel.kt
@@ -188,12 +188,33 @@ internal class LiveFeedbackViewModel @Inject constructor(
     }
 
     /**
+     * Evaluates existing state to determine if the capture session is logically finished
+     */
+    private fun isCaptureComplete(): Boolean {
+        if (phase != LiveFeedbackState.Phase.CAPTURING) return false
+
+        return if (isAutoCapture) {
+            // Auto mode finishes when the imaging duration expires
+            (timeHelper.now().ms - captureImagingStartTime) >= autoCaptureImagingDurationMillis
+        } else {
+            // Manual mode finishes when the requested sample count is met
+            userCaptures.size >= samplesToCapture
+        }
+    }
+
+    /**
      * Processes the image. Called on the CameraX analyzer executor (off the main thread).
      */
     fun process(
         originalBitmap: Bitmap,
         croppedBitmap: Bitmap,
     ) {
+        // Drop frames if capture is complete to avoid race conditions.
+        if (isCaptureComplete()) {
+            originalBitmap.recycle()
+            croppedBitmap.recycle()
+            return
+        }
         // Skip processing and only update progress bar while spoof check is running
         if (phase == LiveFeedbackState.Phase.VALIDATING) {
             emit(phase = LiveFeedbackState.Phase.VALIDATING)
@@ -317,6 +338,7 @@ internal class LiveFeedbackViewModel @Inject constructor(
     private fun finishCapture(attemptNumber: Int) {
         Simber.i("Finish capture", tag = FACE_CAPTURE)
         viewModelScope.launch {
+            enrichCapturesWithAgeAndGender()
             if (spoofCheckConfig.mode == SpoofCheckMode.DISABLED) {
                 sendEventsAndFinish(attemptNumber)
             } else {
@@ -343,14 +365,6 @@ internal class LiveFeedbackViewModel @Inject constructor(
     }
 
     private suspend fun sendEventsAndFinish(attemptNumber: Int) {
-        // Freeze frame processing so `process()` can't concurrently mutate `userCaptures`/
-        // `fallbackCapture` while we enrich captures and write events below.
-        emit(phase = LiveFeedbackState.Phase.VALIDATING)
-
-        // Age/gender estimation is extra native processing, so it's only run here on the final,
-        // accepted set of captures.
-        enrichCapturesWithAgeAndGender()
-
         sortedQualifyingCaptures = userCaptures
             .filter { isAutoCapture || it.hasValidStatus() } // Auto-capture images are pre-qualified
             .sortedByDescending { it.face?.quality }

--- a/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModelTest.kt
+++ b/face/capture/src/test/java/com/simprints/face/capture/screens/livefeedback/LiveFeedbackViewModelTest.kt
@@ -35,6 +35,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.random.Random
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Behaviour-pinning tests for the refactored [LiveFeedbackViewModel], written from
@@ -287,6 +288,26 @@ internal class LiveFeedbackViewModelTest {
     }
 
     @Test
+    fun `manual - frames arriving while finishing is still in progress are dropped, not appended`() = runTest {
+        val validFace = getFace()
+        every { faceDetector.analyze(frame) } returns validFace
+        // Simulate the camera delivering another frame while finishCapture()
+        every { faceDetector.analyze(frame, estimateAgeAndGender = true) } answers {
+            assertThat(viewModel.state.value.phase).isEqualTo(LiveFeedbackState.Phase.CAPTURING)
+            viewModel.process(frame, frame)
+            validFace
+        }
+
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
+        viewModel.startCapture()
+        viewModel.process(frame, frame) // reaches the requested sample count and triggers finishCapture()
+
+        assertThat(viewModel.userCaptures).hasSize(1)
+        verify(exactly = 1) { faceDetector.analyze(frame) }
+    }
+
+    @Test
     fun `auto - does not start until start capture is pressed`() = runTest {
         every { isUsingAutoCapture.invoke(any()) } returns true
         every { faceDetector.analyze(frame) } returns getFace()
@@ -335,6 +356,35 @@ internal class LiveFeedbackViewModelTest {
                 LiveFeedbackState.Phase.FINISHED,
             ).inOrder()
         coVerify { eventReporter.addCaptureEvents(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `auto - frames arriving while finishing is still in progress are dropped, not appended`() = runTest {
+        every { isUsingAutoCapture.invoke(any()) } returns true
+        val validFace = getFace()
+        every { faceDetector.analyze(frame) } returns validFace
+
+        var elapsedMs = 0L
+        every { timeHelper.now() } answers { Timestamp(elapsedMs) }
+
+        // Simulate a frame arriving while finishCapture() is still running
+        every { faceDetector.analyze(frame, estimateAgeAndGender = true) } answers {
+            assertThat(viewModel.state.value.phase).isEqualTo(LiveFeedbackState.Phase.CAPTURING)
+            viewModel.process(frame, frame)
+            validFace
+        }
+
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
+        viewModel.startCapture()
+        viewModel.process(frame, frame) // begins CAPTURING at t=0
+
+        elapsedMs = AUTO_CAPTURE_IMAGING_DURATION_MS + 1
+        advanceTimeBy((AUTO_CAPTURE_IMAGING_DURATION_MS + 1).milliseconds) // fires the timeout job -> finishCapture()
+
+        // Only the original sample was ever captured - the frame injected mid-finish was dropped.
+        assertThat(viewModel.userCaptures).hasSize(1)
+        verify(exactly = 1) { faceDetector.analyze(frame) }
     }
 
     @Test
@@ -602,7 +652,7 @@ internal class LiveFeedbackViewModelTest {
     }
 
     @Test
-    fun `event saving - age and gender estimation is not repeated on every failed spoof-check retry`() = runTest {
+    fun `event saving - age and gender estimation runs during CAPTURING for every spoof-check retry`() = runTest {
         every { getSpoofCheckConfiguration.invoke(any(), any()) } returns spoofConfig(FaceConfiguration.SpoofCheckMode.ENFORCED)
         every { faceDetector.analyze(frame) } returns getFace()
         every { faceDetector.analyze(any(), estimateAgeAndGender = true) } returns getFace()
@@ -611,13 +661,14 @@ internal class LiveFeedbackViewModelTest {
         viewModel.initAutoCapture()
         viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
 
-        // Attempt 1 fails and gets discarded.
+        // Attempt 1 fails and gets discarded, but enrichment already ran while still CAPTURING,
         viewModel.process(frame, frame)
         viewModel.startCapture()
         viewModel.process(frame, frame)
         advanceUntilIdle()
         assertThat(viewModel.state.value.phase).isEqualTo(LiveFeedbackState.Phase.NOT_STARTED)
-        verify(exactly = 0) { faceDetector.analyze(any(), estimateAgeAndGender = true) }
+        // Once for the captured sample and once for the fallback capture.
+        verify(exactly = 2) { faceDetector.analyze(any(), estimateAgeAndGender = true) }
 
         // Attempt 2 reaches maxAttempts and finishes despite still failing spoof check.
         viewModel.process(frame, frame)
@@ -626,9 +677,30 @@ internal class LiveFeedbackViewModelTest {
         advanceUntilIdle()
         assertThat(viewModel.state.value.phase).isEqualTo(LiveFeedbackState.Phase.FINISHED)
 
-        // Enrichment only runs once, for the final (accepted) attempt's captures + fallback -
-        // never for the discarded first attempt.
-        verify(exactly = 2) { faceDetector.analyze(any(), estimateAgeAndGender = true) }
+        // Enrichment runs again for the second attempt's captures + fallback.
+        verify(exactly = 4) { faceDetector.analyze(any(), estimateAgeAndGender = true) }
+    }
+
+    @Test
+    fun `event saving - disabled spoof check never shows VALIDATING phase or the orange validation tint`() = runTest {
+        // Default configuration from setUp() is SpoofCheckConfiguration.DISABLED.
+        val validFace = getFace()
+        every { faceDetector.analyze(frame) } returns validFace
+        every { faceDetector.analyze(any(), estimateAgeAndGender = true) } returns validFace
+        val states = collectStates()
+
+        viewModel.initAutoCapture()
+        viewModel.initCapture(ModalitySdkType.SIM_FACE, 1)
+        viewModel.process(frame, frame) // fallback frame before start
+        viewModel.startCapture()
+        viewModel.process(frame, frame) // captured sample -> finishes
+        advanceUntilIdle()
+
+        assertThat(states.map { it.phase }).contains(LiveFeedbackState.Phase.FINISHED)
+        // Age/gender enrichment must never trigger
+        assertThat(states.map { it.phase }).doesNotContain(LiveFeedbackState.Phase.VALIDATING)
+        assertThat(states.map { it.progress.tint }).doesNotContain(Progress.Tint.VALIDATION)
+        coVerify(exactly = 0) { faceDetector.spoofCheck(any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1571)
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.3.0**

* The Orange progress bar (the capture validation step ) appears after capture when spoof detection is disabled. It should only be displayed when spoof detection is enabled.

### Notable changes

* Move the age/gender estimation to the capturing phase.

### Testing guidance

* Do any face capture flow and check that the capture validation progress bar doesn't appear when spoof detection is disabled.


### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
