### PR TITLE
MS-1572 Remove unnecessary UI state resets in OCR fragment init

### DIFF
--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrFragment.kt
@@ -136,10 +136,8 @@ internal class ExternalCredentialScanOcrFragment : Fragment(R.layout.fragment_ex
         cameraInitLock.withLock {
             if (!cameraFrameProvider.isInitialised()) {
                 initCamera(ocrConfig)
-                renderInitialState()
             }
         }
-        renderInitialState()
     }
 
     private fun initObservers() {


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1572)
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.3.0**

* When rotating the device during the scan, the screen state was reset while the scan still continued.

### Notable changes

* Removed manual state initialisation. Listening to the state is sufficient.

### Testing guidance

* Do biometric flow up to OCR
* Start OCR capture
* Rotate the device

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
