### PR TITLE
Bugfix/camera memeory leaks

### DIFF
--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/TroubleshootingFragment.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/TroubleshootingFragment.kt
@@ -40,7 +40,7 @@ internal class TroubleshootingFragment : Fragment(R.layout.fragment_troubleshoot
             },
         )
 
-        val adapter = TroubleshootingPagerAdapter(requireActivity())
+        val adapter = TroubleshootingPagerAdapter(childFragmentManager, viewLifecycleOwner.lifecycle)
         binding.troubleshootingPager.adapter = adapter
 
         TabLayoutMediator(binding.troubleshootingTabs, binding.troubleshootingPager) { tab, position ->

--- a/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/TroubleshootingPagerAdapter.kt
+++ b/feature/troubleshooting/src/main/java/com/simprints/feature/troubleshooting/TroubleshootingPagerAdapter.kt
@@ -1,7 +1,8 @@
 package com.simprints.feature.troubleshooting
 
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.simprints.feature.troubleshooting.intents.IntentLogFragment
 import com.simprints.feature.troubleshooting.networking.NetworkingLogFragment
@@ -12,8 +13,9 @@ import com.simprints.infra.uibase.annotations.ExcludedFromGeneratedTestCoverageR
 
 @ExcludedFromGeneratedTestCoverageReports("UI code")
 internal class TroubleshootingPagerAdapter(
-    fragmentActivity: FragmentActivity,
-) : FragmentStateAdapter(fragmentActivity) {
+    fragmentManager: FragmentManager,
+    lifecycle: Lifecycle,
+) : FragmentStateAdapter(fragmentManager, lifecycle) {
     override fun getItemCount(): Int = Tabs.entries.size
 
     override fun createFragment(position: Int): Fragment = Tabs.entries[position].factory()

--- a/infra/camera/src/main/java/com/simprints/infra/camera/CameraFrameProvider.kt
+++ b/infra/camera/src/main/java/com/simprints/infra/camera/CameraFrameProvider.kt
@@ -171,6 +171,8 @@ class CameraFrameProvider @Inject internal constructor(
                         }
                     }
             } catch (e: Exception) {
+                preview?.surfaceProvider = null
+                preview = null
                 Simber.e("Camera binding failed", e, tag = CrashReportTag.CAMERA)
                 onError(e)
             }
@@ -199,12 +201,15 @@ class CameraFrameProvider @Inject internal constructor(
         imageAnalysis?.clearAnalyzer()
         imageAnalysis = null
 
-        cameraProvider?.unbindAll()
-        cameraProvider = null
-
-        // Explicitly detach the surface provider
-        preview?.surfaceProvider = null
-        preview = null
+        try {
+            cameraProvider?.unbindAll()
+        } finally {
+            // Always detach the surface provider, even if unbindAll() throws,
+            // so the Preview never keeps retaining the PreviewView.
+            cameraProvider = null
+            preview?.surfaceProvider = null
+            preview = null
+        }
 
         previewSurface = null
         injectionOverlay = null

--- a/infra/camera/src/main/java/com/simprints/infra/camera/CameraFrameProvider.kt
+++ b/infra/camera/src/main/java/com/simprints/infra/camera/CameraFrameProvider.kt
@@ -59,6 +59,7 @@ class CameraFrameProvider @Inject internal constructor(
     private var cameraProvider: ProcessCameraProvider? = null
     private var imageCapture: ImageCapture? = null
     private var imageAnalysis: ImageAnalysis? = null
+    private var preview: Preview? = null
     private var camera: Camera? = null
 
     private lateinit var previewRect: Rect
@@ -139,11 +140,16 @@ class CameraFrameProvider @Inject internal constructor(
         imageCapture = capture
 
         withContext(mainDispatcher) {
-            val preview = Preview
+            // Clear any previously bound preview's surface provider to avoid CameraX's internal
+            // cache retaining a reference to the old PreviewView after unbinding.
+            preview?.surfaceProvider = null
+
+            val newPreview = Preview
                 .Builder()
                 .setResolutionSelector(resolutionSelector)
                 .build()
                 .also { it.surfaceProvider = previewView.surfaceProvider }
+            preview = newPreview
 
             val provider = ProcessCameraProvider.awaitInstance(context).also {
                 cameraProvider = it
@@ -157,7 +163,7 @@ class CameraFrameProvider @Inject internal constructor(
                         cameraSelector,
                         imageAnalysis,
                         capture,
-                        preview,
+                        newPreview,
                     ).also { boundCamera ->
                         with(cameraFocusManagerFactory.create(CrashReportTag.CAMERA)) {
                             setUpFocusOnTap(previewView, boundCamera)
@@ -195,6 +201,10 @@ class CameraFrameProvider @Inject internal constructor(
 
         cameraProvider?.unbindAll()
         cameraProvider = null
+
+        // Explicitly detach the surface provider
+        preview?.surfaceProvider = null
+        preview = null
 
         previewSurface = null
         injectionOverlay = null


### PR DESCRIPTION
JIRA ticket [MS-1575](https://simprints.atlassian.net/browse/MS-1575) And [MS-1576](https://simprints.atlassian.net/browse/MS-1576)
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.3.0**

* I found them using leek canary 

### Notable changes


[MS-1575] Explicitly detach surface provider when unbinding CameraX Preview

• Tracks the bound  Preview  instance in  CameraFrameProvider 
• Nulls out  surfaceProvider  before rebinding and on unbind, to prevent CameraX from retaining a stale reference to the old  PreviewView  

[MS-1576] Use childFragmentManager and lifecycle in TroubleshootingPagerAdapter

•  TroubleshootingPagerAdapter  now takes  FragmentManager  +  Lifecycle  instead of  FragmentActivity 
•  TroubleshootingFragment  passes  childFragmentManager  and  viewLifecycleOwner.lifecycle  for correct fragment scoping/lifecycle handling

### Testing guidance

* Testing face capture flows.
* Testing the troubleshooting screen.

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)


[MS-1575]: https://simprints.atlassian.net/browse/MS-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MS-1576]: https://simprints.atlassian.net/browse/MS-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MS-1575]: https://simprints.atlassian.net/browse/MS-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MS-1576]: https://simprints.atlassian.net/browse/MS-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ