### PR TITLE
MS-1587 Raise min and targer sdk

### DIFF
--- a/build-logic/convention/src/main/kotlin/common/SdkVersions.kt
+++ b/build-logic/convention/src/main/kotlin/common/SdkVersions.kt
@@ -5,7 +5,7 @@ import org.gradle.api.JavaVersion
 object SdkVersions {
     const val MIN = 24
     const val COMPILE = 37
-    const val TARGET = 36
+    const val TARGET = 37
 
     val JAVA_TARGET = JavaVersion.VERSION_21
 }

--- a/build-logic/convention/src/main/kotlin/common/SdkVersions.kt
+++ b/build-logic/convention/src/main/kotlin/common/SdkVersions.kt
@@ -3,7 +3,7 @@ package common
 import org.gradle.api.JavaVersion
 
 object SdkVersions {
-    const val MIN = 23
+    const val MIN = 24
     const val COMPILE = 37
     const val TARGET = 36
 


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1587)

### Notable changes

* Navigation library requires API 24 as min, other AndroidX libraries likely to do the same soon.
* There are single digit devices on API 23 in active projects and those devices are unlikely to update to the latest SID version.

### Testing guidance

* If it compiles, all is good.

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
