### PR TITLE
MS-1584 Explicitly reset OCR capture progress view state

### DIFF
--- a/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrFragment.kt
+++ b/feature/external-credential/src/main/java/com/simprints/feature/externalcredential/screens/scanocr/ExternalCredentialScanOcrFragment.kt
@@ -159,9 +159,7 @@ internal class ExternalCredentialScanOcrFragment : Fragment(R.layout.fragment_ex
                         binding.captureProgress.setProgressAnimated(
                             100,
                             durationMs = PROGRESS_FINISH_REMAINING_MS,
-                            onComplete = {
-                                viewModel.processOcrResultsAndFinish()
-                            },
+                            onComplete = { viewModel.processOcrResultsAndFinish() },
                             interpolator = AccelerateInterpolator(),
                         )
                     }
@@ -224,6 +222,8 @@ internal class ExternalCredentialScanOcrFragment : Fragment(R.layout.fragment_ex
 
     private fun renderInitialState() = with(binding) {
         val documentTypeText = viewModel.getDocumentTypeRes().run(::getString)
+        captureProgress.resetAnimation()
+        captureProgress.isVisible = false
         permissionRequestView.isVisible = false
         instructionsText.isVisible = true
         instructionsText.text = getString(IDR.string.mfid_scan_instructions, documentTypeText)
@@ -232,6 +232,7 @@ internal class ExternalCredentialScanOcrFragment : Fragment(R.layout.fragment_ex
         progressContainer.isInvisible = true
         buttonScan.isVisible = true
         buttonScan.setOnClickListener {
+            captureProgress.resetAnimation()
             viewModel.startScanning()
         }
         viewfinderMask.maskColor = ContextCompat.getColor(requireContext(), IDR.color.simprints_black)

--- a/infra/camera/src/main/java/com/simprints/infra/camera/view/CaptureProgressView.kt
+++ b/infra/camera/src/main/java/com/simprints/infra/camera/view/CaptureProgressView.kt
@@ -179,8 +179,7 @@ class CaptureProgressView @JvmOverloads constructor(
     override fun onDetachedFromWindow() {
         bindTarget(null)
         super.onDetachedFromWindow()
-        progressAnimator?.cancel()
-        progressAnimator = null
+        cancelAnimator()
     }
 
     fun setProgressAnimated(
@@ -189,7 +188,7 @@ class CaptureProgressView @JvmOverloads constructor(
         interpolator: TimeInterpolator = LinearInterpolator(),
         onComplete: (() -> Unit)? = null,
     ) {
-        progressAnimator?.cancel()
+        cancelAnimator()
         progressAnimator = ValueAnimator.ofInt(progress, value).apply {
             duration = durationMs
             this.interpolator = interpolator
@@ -201,6 +200,18 @@ class CaptureProgressView @JvmOverloads constructor(
             })
             start()
         }
+    }
+
+    private fun cancelAnimator() {
+        // Removing listeners prevents unintended onComplete triggering on cancellation
+        progressAnimator?.removeAllListeners()
+        progressAnimator?.cancel()
+        progressAnimator = null
+    }
+
+    fun resetAnimation() {
+        cancelAnimator()
+        progress = 0
     }
 
     /**


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1584)
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.3.0**

* When OCR screen is minimised with "don't keep activities" the state of the screen is reset as expected
* Progress view preserves the internal state within "onInstanceStateSave()" and not reset, so once the capture restarts the animation continues from last saved state.

### Notable changes

* Explicitly reset the progress bar every time the capture is started in order to override the restored internal state.
* The internal state saving is preserved as-is to avoid breaking the config change handling

### Testing guidance

* Describe how the reviewers can verify that issue is fixed

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
