### PR TITLE
[MS-1592] Include verification match threshold when creating identifcation responses for external credentials

### DIFF
--- a/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/CreateIdentifyResponseUseCase.kt
+++ b/feature/orchestrator/src/main/java/com/simprints/feature/orchestrator/usecases/response/CreateIdentifyResponseUseCase.kt
@@ -99,10 +99,16 @@ internal class CreateIdentifyResponseUseCase @Inject constructor(
         .flatMap { credentialSearchResult ->
             credentialSearchResult.matchResults.mapNotNull { credentialMatchResult ->
                 val sdk = credentialMatchResult.bioSdk
-                val policy = projectConfiguration.getModalitySdkConfig(sdk)?.decisionPolicy ?: return@mapNotNull null
+                val sdkConfiguration = projectConfiguration.getModalitySdkConfig(sdk) ?: return@mapNotNull null
                 val matchResult = credentialMatchResult.comparisonResult
 
-                sdk to AppMatchResult(matchResult.subjectId, matchResult.comparisonScore, policy, true)
+                sdk to AppMatchResult(
+                    guid = matchResult.subjectId,
+                    confidenceScore = matchResult.comparisonScore,
+                    decisionPolicy = sdkConfiguration.decisionPolicy,
+                    isCredentialMatch = true,
+                    verificationMatchThreshold = sdkConfiguration.verificationMatchThreshold,
+                )
             }
         }.groupDescendingResultsBySdk()
 

--- a/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/response/CreateIdentifyResponseUseCaseTest.kt
+++ b/feature/orchestrator/src/test/java/com/simprints/feature/orchestrator/usecases/response/CreateIdentifyResponseUseCaseTest.kt
@@ -486,6 +486,138 @@ class CreateIdentifyResponseUseCaseTest {
     }
 
     @Test
+    fun `Marks credential match as linked and verified when confidence meets the SDK verification threshold`() = runTest {
+        val credentialGuid = "credentialGuid"
+        val credentialConfidence = 90f
+        val verificationMatchThreshold = 80f
+
+        val credentialFaceMatches = listOf<CredentialMatch>(
+            mockk {
+                every { comparisonResult } returns ComparisonResult(
+                    subjectId = credentialGuid,
+                    comparisonScore = credentialConfidence,
+                )
+                every { bioSdk } returns ModalitySdkType.RANK_ONE
+            },
+        )
+
+        val result = useCase(
+            mockk {
+                every { multifactorId?.allowedExternalCredentials } returns null
+                every { identification.maxNbOfReturnedCandidates } returns 5
+                every { face?.rankOne?.decisionPolicy } returns DecisionPolicy(20, 50, 100)
+                every { face?.rankOne?.verificationMatchThreshold } returns verificationMatchThreshold
+                every { fingerprint?.secugenSimMatcher?.decisionPolicy } returns null
+            },
+            results = listOf(
+                mockk<ExternalCredentialSearchResult.Complete>(relaxed = true) {
+                    every { matchResults } returns credentialFaceMatches
+                },
+            ),
+            project = project,
+        )
+
+        val identification = (result as AppIdentifyResponse).identifications.single()
+        assertThat(identification.guid).isEqualTo(credentialGuid)
+        assertThat(identification.isLinkedToScannedCredential).isTrue()
+        assertThat(identification.isCredentialVerified).isTrue()
+    }
+
+    @Test
+    fun `Marks credential match as linked but not verified when confidence is below the SDK verification threshold`() = runTest {
+        val credentialGuid = "credentialGuid"
+        val credentialConfidence = 70f
+        val verificationMatchThreshold = 80f
+
+        val credentialFaceMatches = listOf<CredentialMatch>(
+            mockk {
+                every { comparisonResult } returns ComparisonResult(
+                    subjectId = credentialGuid,
+                    comparisonScore = credentialConfidence,
+                )
+                every { bioSdk } returns ModalitySdkType.RANK_ONE
+            },
+        )
+
+        val result = useCase(
+            mockk {
+                every { multifactorId?.allowedExternalCredentials } returns null
+                every { identification.maxNbOfReturnedCandidates } returns 5
+                every { face?.rankOne?.decisionPolicy } returns DecisionPolicy(20, 50, 100)
+                every { face?.rankOne?.verificationMatchThreshold } returns verificationMatchThreshold
+                every { fingerprint?.secugenSimMatcher?.decisionPolicy } returns null
+            },
+            results = listOf(
+                mockk<ExternalCredentialSearchResult.Complete>(relaxed = true) {
+                    every { matchResults } returns credentialFaceMatches
+                },
+            ),
+            project = project,
+        )
+
+        val identification = (result as AppIdentifyResponse).identifications.single()
+        assertThat(identification.guid).isEqualTo(credentialGuid)
+        assertThat(identification.isLinkedToScannedCredential).isTrue()
+        assertThat(identification.isCredentialVerified).isFalse()
+    }
+
+    @Test
+    fun `Marks credential match as linked with null verification status when SDK has no verification threshold configured`() = runTest {
+        val credentialGuid = "credentialGuid"
+        val credentialConfidence = 90f
+
+        val credentialFaceMatches = listOf<CredentialMatch>(
+            mockk {
+                every { comparisonResult } returns ComparisonResult(
+                    subjectId = credentialGuid,
+                    comparisonScore = credentialConfidence,
+                )
+                every { bioSdk } returns ModalitySdkType.RANK_ONE
+            },
+        )
+
+        val result = useCase(
+            mockk {
+                every { multifactorId?.allowedExternalCredentials } returns null
+                every { identification.maxNbOfReturnedCandidates } returns 5
+                every { face?.rankOne?.decisionPolicy } returns DecisionPolicy(20, 50, 100)
+                every { face?.rankOne?.verificationMatchThreshold } returns null
+                every { fingerprint?.secugenSimMatcher?.decisionPolicy } returns null
+            },
+            results = listOf(
+                mockk<ExternalCredentialSearchResult.Complete>(relaxed = true) {
+                    every { matchResults } returns credentialFaceMatches
+                },
+            ),
+            project = project,
+        )
+
+        val identification = (result as AppIdentifyResponse).identifications.single()
+        assertThat(identification.guid).isEqualTo(credentialGuid)
+        assertThat(identification.isLinkedToScannedCredential).isTrue()
+        assertThat(identification.isCredentialVerified).isNull()
+    }
+
+    @Test
+    fun `Regular match results are not linked to a scanned credential and have no verification status`() = runTest {
+        val result = useCase(
+            mockk {
+                every { multifactorId?.allowedExternalCredentials } returns null
+                every { identification.maxNbOfReturnedCandidates } returns 2
+                every { face?.rankOne?.decisionPolicy } returns DecisionPolicy(20, 50, 100)
+                every { face?.rankOne?.verificationMatchThreshold } returns 80f
+                every { fingerprint?.secugenSimMatcher?.decisionPolicy } returns null
+            },
+            results = listOf(createFaceMatchResult(90f)),
+            project = project,
+        )
+
+        val identification = (result as AppIdentifyResponse).identifications.single()
+        assertThat(identification.isLinkedToScannedCredential).isFalse()
+        assertThat(identification.isCredentialVerified).isNull()
+    }
+
+    @Test
     fun `Returns scanned credential when credential search result is present`() = runTest {
         val id = "id"
         val type = ExternalCredentialType.NHISCard


### PR DESCRIPTION

[JIRA ticket](https://simprints.atlassian.net/browse/MS-1592)
Will be released in: **2026.3.0**

### Root cause analysis (for bugfixes only)

First known affected version: **2026.1.0**

*  Found by EST team that the isVerify flag is no more returned by SID 
### Notable changes

* Restored the verificationMatchThreshold  in the credential-match mapping.

### Testing guidance

* Execute an identification flow when MFID is enabled. For successful identification flows, SID should return `isCredentialVerified = true`.


### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
