### PR TITLE
MS-1588 Replace some API enums with strings

### DIFF
--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiFaceConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiFaceConfiguration.kt
@@ -9,13 +9,13 @@ import kotlinx.serialization.Serializable
 @Keep
 @Serializable
 internal data class ApiFaceConfiguration(
-    val allowedSDKs: List<BioSdk>,
+    val allowedSDKs: List<String>,
     val isAutoCapture: Boolean = false,
     val rankOne: ApiFaceSdkConfiguration? = null,
     val simFace: ApiFaceSdkConfiguration? = null,
 ) {
     fun toDomain(): FaceConfiguration = FaceConfiguration(
-        allowedSDKs = allowedSDKs.map { it.toDomain() },
+        allowedSDKs = allowedSDKs.mapNotNull { ApiBioSdk.fromString(it) },
         isAutoCapture = isAutoCapture,
         rankOne = rankOne?.toDomain(),
         simFace = simFace?.toDomain(),
@@ -44,14 +44,11 @@ internal data class ApiFaceConfiguration(
     }
 
     @Keep
-    enum class BioSdk {
-        RANK_ONE,
-        SIM_FACE,
-        ;
-
-        fun toDomain() = when (this) {
-            RANK_ONE -> ModalitySdkType.RANK_ONE
-            SIM_FACE -> ModalitySdkType.SIM_FACE
+    object ApiBioSdk {
+        fun fromString(value: String?): ModalitySdkType? = when (value?.uppercase()) {
+            "RANK_ONE" -> ModalitySdkType.RANK_ONE
+            "SIM_FACE" -> ModalitySdkType.SIM_FACE
+            else -> null
         }
     }
 

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiFingerprintConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiFingerprintConfiguration.kt
@@ -11,14 +11,14 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class ApiFingerprintConfiguration(
     val allowedScanners: List<VeroGeneration>,
-    val allowedSDKs: List<BioSdk>,
+    val allowedSDKs: List<String>,
     val displayHandIcons: Boolean,
     val secugenSimMatcher: ApiFingerprintSdkConfiguration? = null,
     val nec: ApiFingerprintSdkConfiguration? = null,
 ) {
     fun toDomain() = FingerprintConfiguration(
         allowedScanners.map { it.toDomain() },
-        allowedSDKs.map { it.toDomain() },
+        allowedSDKs.mapNotNull { ApiBioSdk.fromString(it) },
         displayHandIcons,
         secugenSimMatcher?.toDomain(),
         nec?.toDomain(),
@@ -89,14 +89,11 @@ internal data class ApiFingerprintConfiguration(
     }
 
     @Keep
-    enum class BioSdk {
-        SECUGEN_SIM_MATCHER,
-        NEC,
-        ;
-
-        fun toDomain() = when (this) {
-            SECUGEN_SIM_MATCHER -> ModalitySdkType.SECUGEN_SIM_MATCHER
-            NEC -> ModalitySdkType.NEC
+    object ApiBioSdk {
+        fun fromString(value: String?): ModalitySdkType? = when (value?.uppercase()) {
+            "SECUGEN_SIM_MATCHER" -> ModalitySdkType.SECUGEN_SIM_MATCHER
+            "NEC" -> ModalitySdkType.NEC
+            else -> null
         }
     }
 

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiGeneralConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiGeneralConfiguration.kt
@@ -9,8 +9,8 @@ import kotlinx.serialization.Serializable
 @Keep
 @Serializable
 internal data class ApiGeneralConfiguration(
-    val modalities: List<ApiModality>,
-    val matchingModalities: List<ApiModality>,
+    val modalities: List<String>,
+    val matchingModalities: List<String>,
     val languageOptions: List<String>,
     val defaultLanguage: String,
     val collectLocation: Boolean,
@@ -18,8 +18,8 @@ internal data class ApiGeneralConfiguration(
     val settingsPassword: String? = null,
 ) {
     fun toDomain(): GeneralConfiguration = GeneralConfiguration(
-        modalities.map { it.toDomain() },
-        matchingModalities.map { it.toDomain() },
+        modalities.mapNotNull { ApiModality.fromString(it) },
+        matchingModalities.mapNotNull { ApiModality.fromString(it) },
         languageOptions,
         defaultLanguage,
         collectLocation,
@@ -30,14 +30,11 @@ internal data class ApiGeneralConfiguration(
     )
 
     @Keep
-    enum class ApiModality {
-        FACE,
-        FINGERPRINT,
-        ;
-
-        fun toDomain(): Modality = when (this) {
-            FACE -> Modality.FACE
-            FINGERPRINT -> Modality.FINGERPRINT
+    object ApiModality {
+        fun fromString(value: String?): Modality? = when (value?.uppercase()) {
+            "FACE" -> Modality.FACE
+            "FINGERPRINT" -> Modality.FINGERPRINT
+            else -> null
         }
     }
 }

--- a/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiMultiFactorIdConfiguration.kt
+++ b/infra/config-store/src/main/java/com/simprints/infra/config/store/remote/models/ApiMultiFactorIdConfiguration.kt
@@ -7,23 +7,19 @@ import com.simprints.infra.config.store.models.GhanaIdCardConfig
 import com.simprints.infra.config.store.models.MultiFactorIdConfiguration
 import com.simprints.infra.config.store.models.NhisCardConfig
 import com.simprints.infra.config.store.models.QrCodeConfig
-import com.simprints.infra.config.store.remote.models.ApiExternalCredentialType.FAYDA_CARD
-import com.simprints.infra.config.store.remote.models.ApiExternalCredentialType.GHANA_CARD
-import com.simprints.infra.config.store.remote.models.ApiExternalCredentialType.NHIS_CARD
-import com.simprints.infra.config.store.remote.models.ApiExternalCredentialType.QR_CODE
 import kotlinx.serialization.Serializable
 
 @Keep
 @Serializable
 internal data class ApiMultiFactorIdConfiguration(
-    val allowedExternalCredentials: List<ApiExternalCredentialType>,
+    val allowedExternalCredentials: List<String>,
     val ghanaCard: ApiGhanaIdCardConfig? = null,
     val nhisCard: ApiNhisCardConfig? = null,
     val qrCode: ApiQrCodeConfig? = null,
     val faydaCard: ApiFaydaCardConfig? = null,
 ) {
     fun toDomain(): MultiFactorIdConfiguration = MultiFactorIdConfiguration(
-        allowedExternalCredentials = allowedExternalCredentials.map { it.toDomain() },
+        allowedExternalCredentials = allowedExternalCredentials.mapNotNull { ApiExternalCredentialType.fromString(it) },
         ghanaIdCardConfig = ghanaCard?.toDomain(),
         nhisCardConfig = nhisCard?.toDomain(),
         qrCodeConfig = qrCode?.toDomain(),
@@ -62,24 +58,12 @@ data class ApiFaydaCardConfig(
 }
 
 @Keep
-enum class ApiExternalCredentialType {
-    NHIS_CARD,
-    GHANA_CARD,
-    QR_CODE,
-    FAYDA_CARD,
-    ;
-
-    fun toDomain(): ExternalCredentialType = when (this) {
-        NHIS_CARD -> ExternalCredentialType.NHISCard
-        GHANA_CARD -> ExternalCredentialType.GhanaIdCard
-        QR_CODE -> ExternalCredentialType.QRCode
-        FAYDA_CARD -> ExternalCredentialType.FaydaCard
+object ApiExternalCredentialType {
+    fun fromString(value: String?): ExternalCredentialType? = when (value?.uppercase()) {
+        "NHIS_CARD" -> ExternalCredentialType.NHISCard
+        "GHANA_CARD" -> ExternalCredentialType.GhanaIdCard
+        "QR_CODE" -> ExternalCredentialType.QRCode
+        "FAYDA_CARD" -> ExternalCredentialType.FaydaCard
+        else -> null
     }
-}
-
-fun ExternalCredentialType.fromDomainToApi(): ApiExternalCredentialType = when (this) {
-    ExternalCredentialType.NHISCard -> NHIS_CARD
-    ExternalCredentialType.GhanaIdCard -> GHANA_CARD
-    ExternalCredentialType.QRCode -> QR_CODE
-    ExternalCredentialType.FaydaCard -> FAYDA_CARD
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiFaceConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiFaceConfigurationTest.kt
@@ -1,8 +1,9 @@
 package com.simprints.infra.config.store.remote.models
 
-import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.*
 import com.simprints.core.domain.common.AgeGroup
 import com.simprints.infra.config.store.models.FaceConfiguration
+import com.simprints.infra.config.store.models.ModalitySdkType
 import com.simprints.infra.config.store.testtools.apiFaceConfiguration
 import com.simprints.infra.config.store.testtools.faceConfiguration
 import org.junit.Test
@@ -32,6 +33,18 @@ class ApiFaceConfigurationTest {
             ),
         )
         assertThat(apiFaceConfigurationWithAgeRange.toDomain()).isEqualTo(faceConfigurationWithAgeRange)
+    }
+
+    @Test
+    fun `should map correctly the BioSdk face enums`() {
+        val mapping = mapOf(
+            "RANK_ONE" to ModalitySdkType.RANK_ONE,
+            "SIM_FACE" to ModalitySdkType.SIM_FACE,
+            "NEC" to null,
+            "UNKNOWN" to null,
+        )
+
+        mapping.forEach { assertThat(ApiFaceConfiguration.ApiBioSdk.fromString(it.key)).isEqualTo(it.value) }
     }
 
     @Test

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiFingerprintConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiFingerprintConfigurationTest.kt
@@ -39,7 +39,7 @@ class ApiFingerprintConfigurationTest {
     fun `should map correctly the model when the vero1 is missing`() {
         val apiFingerprintConfiguration = ApiFingerprintConfiguration(
             listOf(ApiFingerprintConfiguration.VeroGeneration.VERO_2),
-            listOf(ApiFingerprintConfiguration.BioSdk.SECUGEN_SIM_MATCHER),
+            listOf("SECUGEN_SIM_MATCHER"),
             true,
             ApiFingerprintConfiguration.ApiFingerprintSdkConfiguration(
                 fingersToCapture = listOf(ApiFingerprintConfiguration.ApiFinger.LEFT_3RD_FINGER),
@@ -76,7 +76,7 @@ class ApiFingerprintConfigurationTest {
     fun `should map correctly the model when the vero2 is missing`() {
         val apiFingerprintConfiguration = ApiFingerprintConfiguration(
             listOf(ApiFingerprintConfiguration.VeroGeneration.VERO_1),
-            listOf(ApiFingerprintConfiguration.BioSdk.NEC),
+            listOf("NEC"),
             true,
             null,
             ApiFingerprintConfiguration.ApiFingerprintSdkConfiguration(
@@ -107,6 +107,18 @@ class ApiFingerprintConfigurationTest {
         )
 
         assertThat(apiFingerprintConfiguration.toDomain()).isEqualTo(fingerprintConfiguration)
+    }
+
+    @Test
+    fun `should map correctly the BioSdk fingerprint enums`() {
+        val mapping = mapOf(
+            "SECUGEN_SIM_MATCHER" to ModalitySdkType.SECUGEN_SIM_MATCHER,
+            "NEC" to ModalitySdkType.NEC,
+            "RANK_ONE" to null,
+            "UNKNOWN" to null,
+        )
+
+        mapping.forEach { assertThat(ApiFingerprintConfiguration.ApiBioSdk.fromString(it.key)).isEqualTo(it.value) }
     }
 
     @Test

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiGeneralConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiGeneralConfigurationTest.kt
@@ -1,6 +1,6 @@
 package com.simprints.infra.config.store.remote.models
 
-import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.*
 import com.simprints.core.domain.common.Modality
 import com.simprints.infra.config.store.models.SettingsPasswordConfig
 import com.simprints.infra.config.store.testtools.apiGeneralConfiguration
@@ -16,25 +16,22 @@ class ApiGeneralConfigurationTest {
     @Test
     fun `should map correctly the Modality enums`() {
         val mapping = mapOf(
-            ApiGeneralConfiguration.ApiModality.FACE to Modality.FACE,
-            ApiGeneralConfiguration.ApiModality.FINGERPRINT to Modality.FINGERPRINT,
+            "FACE" to Modality.FACE,
+            "FINGERPRINT" to Modality.FINGERPRINT,
+            "UNKNOWN" to null,
         )
 
-        mapping.forEach {
-            assertThat(it.key.toDomain()).isEqualTo(it.value)
-        }
+        mapping.forEach { assertThat(ApiGeneralConfiguration.ApiModality.fromString(it.key)).isEqualTo(it.value) }
     }
 
     @Test
     fun `should map correctly the settings passwords`() {
-        assertThat(SettingsPasswordConfig.toDomain(null)).isEqualTo(
-            SettingsPasswordConfig.NotSet,
+        val mapping = mapOf(
+            null to SettingsPasswordConfig.NotSet,
+            "" to SettingsPasswordConfig.NotSet,
+            "123" to SettingsPasswordConfig.Locked("123"),
         )
-        assertThat(SettingsPasswordConfig.toDomain("")).isEqualTo(
-            SettingsPasswordConfig.NotSet,
-        )
-        assertThat(SettingsPasswordConfig.toDomain("123")).isEqualTo(
-            SettingsPasswordConfig.Locked("123"),
-        )
+
+        mapping.forEach { assertThat(SettingsPasswordConfig.toDomain(it.key)).isEqualTo(it.value) }
     }
 }

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiProjectConfigurationTest.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/remote/models/ApiProjectConfigurationTest.kt
@@ -1,11 +1,11 @@
 package com.simprints.infra.config.store.remote.models
 
-import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.*
+import com.simprints.core.domain.externalcredential.ExternalCredentialType
 import com.simprints.infra.config.store.models.ProjectConfiguration
 import com.simprints.infra.config.store.testtools.apiConsentConfiguration
 import com.simprints.infra.config.store.testtools.apiGeneralConfiguration
 import com.simprints.infra.config.store.testtools.apiIdentificationConfiguration
-import com.simprints.core.domain.externalcredential.ExternalCredentialType
 import com.simprints.infra.config.store.testtools.apiMultiFactorIdConfiguration
 import com.simprints.infra.config.store.testtools.apiProjectConfiguration
 import com.simprints.infra.config.store.testtools.apiSynchronizationConfiguration
@@ -27,12 +27,25 @@ class ApiProjectConfigurationTest {
     @Test
     fun `should correctly map fayda card configuration`() {
         val apiConfig = ApiMultiFactorIdConfiguration(
-            allowedExternalCredentials = listOf(ApiExternalCredentialType.FAYDA_CARD),
+            allowedExternalCredentials = listOf("FAYDA_CARD"),
             faydaCard = ApiFaydaCardConfig(isCapturingAllFields = true),
         )
         val domain = apiConfig.toDomain()
         assertThat(domain.allowedExternalCredentials).containsExactly(ExternalCredentialType.FaydaCard)
         assertThat(domain.faydaCardConfig?.isCapturingAllFields).isTrue()
+    }
+
+    @Test
+    fun `should map ExternalCredentialType strings to domain types`() {
+        val cases = mapOf(
+            "NHIS_CARD" to ExternalCredentialType.NHISCard,
+            "GHANA_CARD" to ExternalCredentialType.GhanaIdCard,
+            "QR_CODE" to ExternalCredentialType.QRCode,
+            "FAYDA_CARD" to ExternalCredentialType.FaydaCard,
+            "UNKNOWN" to null,
+        )
+
+        cases.forEach { (value, expectedType) -> assertThat(ApiExternalCredentialType.fromString(value)).isEqualTo(expectedType) }
     }
 
     @Test

--- a/infra/config-store/src/test/java/com/simprints/infra/config/store/testtools/Models.kt
+++ b/infra/config-store/src/test/java/com/simprints/infra/config/store/testtools/Models.kt
@@ -55,7 +55,6 @@ import com.simprints.infra.config.store.remote.models.ApiAllowedAgeRange
 import com.simprints.infra.config.store.remote.models.ApiConsentConfiguration
 import com.simprints.infra.config.store.remote.models.ApiDecisionPolicy
 import com.simprints.infra.config.store.remote.models.ApiDeviceState
-import com.simprints.infra.config.store.remote.models.ApiExternalCredentialType
 import com.simprints.infra.config.store.remote.models.ApiFaceConfiguration
 import com.simprints.infra.config.store.remote.models.ApiFaceConfiguration.ApiFaceSdkConfiguration
 import com.simprints.infra.config.store.remote.models.ApiFingerprintConfiguration
@@ -171,7 +170,7 @@ internal val faceSdkConfiguration = FaceSdkConfiguration(
 )
 
 internal val apiFaceConfiguration = ApiFaceConfiguration(
-    allowedSDKs = listOf(ApiFaceConfiguration.BioSdk.RANK_ONE),
+    allowedSDKs = listOf("RANK_ONE"),
     isAutoCapture = true,
     rankOne = ApiFaceSdkConfiguration(
         nbOfImagesToCapture = 2,
@@ -259,7 +258,7 @@ internal val protoVero2Configuration = ProtoVero2Configuration
 
 internal val apiFingerprintConfiguration = ApiFingerprintConfiguration(
     allowedScanners = listOf(ApiFingerprintConfiguration.VeroGeneration.VERO_2),
-    allowedSDKs = listOf(ApiFingerprintConfiguration.BioSdk.SECUGEN_SIM_MATCHER),
+    allowedSDKs = listOf("SECUGEN_SIM_MATCHER"),
     displayHandIcons = true,
     secugenSimMatcher = ApiFingerprintConfiguration.ApiFingerprintSdkConfiguration(
         fingersToCapture = listOf(ApiFingerprintConfiguration.ApiFinger.LEFT_3RD_FINGER),
@@ -313,8 +312,8 @@ internal val protoFingerprintConfiguration = ProtoFingerprintConfiguration
     ).build()
 
 internal val apiGeneralConfiguration = ApiGeneralConfiguration(
-    listOf(ApiGeneralConfiguration.ApiModality.FACE),
-    listOf(ApiGeneralConfiguration.ApiModality.FACE),
+    listOf("FACE"),
+    listOf("FACE"),
     listOf("en"),
     "en",
     collectLocation = true,
@@ -485,7 +484,8 @@ internal val protoSynchronizationConfiguration = ProtoSynchronizationConfigurati
             .build(),
     ).build()
 
-internal val apiAllowedExternalCredential = ApiExternalCredentialType.NHIS_CARD
+@Suppress("ktlint:standard:property-naming")
+internal const val apiAllowedExternalCredential = "NHIS_CARD"
 
 internal val apiMultiFactorIdConfiguration = ApiMultiFactorIdConfiguration(
     allowedExternalCredentials = listOf(apiAllowedExternalCredential),

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/ApiExternalCredential.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/ApiExternalCredential.kt
@@ -3,8 +3,6 @@ package com.simprints.infra.eventsync.event.remote
 import androidx.annotation.Keep
 import com.simprints.core.domain.externalcredential.ExternalCredential
 import com.simprints.core.domain.tokenization.asTokenizableEncrypted
-import com.simprints.infra.config.store.remote.models.ApiExternalCredentialType
-import com.simprints.infra.config.store.remote.models.fromDomainToApi
 import kotlinx.serialization.Serializable
 
 @Keep

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/ApiExternalCredentialType.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/ApiExternalCredentialType.kt
@@ -1,0 +1,29 @@
+package com.simprints.infra.eventsync.event.remote
+
+import androidx.annotation.Keep
+import com.simprints.core.domain.externalcredential.ExternalCredentialType
+import kotlinx.serialization.Serializable
+
+@Keep
+@Serializable
+enum class ApiExternalCredentialType {
+    NHIS_CARD,
+    GHANA_CARD,
+    QR_CODE,
+    FAYDA_CARD,
+    ;
+
+    fun toDomain(): ExternalCredentialType = when (this) {
+        NHIS_CARD -> ExternalCredentialType.NHISCard
+        GHANA_CARD -> ExternalCredentialType.GhanaIdCard
+        QR_CODE -> ExternalCredentialType.QRCode
+        FAYDA_CARD -> ExternalCredentialType.FaydaCard
+    }
+}
+
+fun ExternalCredentialType.fromDomainToApi(): ApiExternalCredentialType = when (this) {
+    ExternalCredentialType.NHISCard -> ApiExternalCredentialType.NHIS_CARD
+    ExternalCredentialType.GhanaIdCard -> ApiExternalCredentialType.GHANA_CARD
+    ExternalCredentialType.QRCode -> ApiExternalCredentialType.QR_CODE
+    ExternalCredentialType.FaydaCard -> ApiExternalCredentialType.FAYDA_CARD
+}

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiExternalCredentialSelectionPayload.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/remote/models/ApiExternalCredentialSelectionPayload.kt
@@ -2,10 +2,10 @@ package com.simprints.infra.eventsync.event.remote.models
 
 import androidx.annotation.Keep
 import com.simprints.infra.config.store.models.TokenKeyType
-import com.simprints.infra.config.store.remote.models.ApiExternalCredentialType
-import com.simprints.infra.config.store.remote.models.fromDomainToApi
 import com.simprints.infra.events.event.domain.models.ExternalCredentialSelectionEvent
 import com.simprints.infra.events.event.domain.models.ExternalCredentialSelectionEvent.SkipReason
+import com.simprints.infra.eventsync.event.remote.ApiExternalCredentialType
+import com.simprints.infra.eventsync.event.remote.fromDomainToApi
 import com.simprints.infra.eventsync.event.remote.models.ApiExternalCredentialSelectionPayload.ApiExternalCredentialSkipReason
 import kotlinx.serialization.Serializable
 

--- a/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventScopeToApiUseCase.kt
+++ b/infra/event-sync/src/main/java/com/simprints/infra/eventsync/event/usecases/MapDomainEventScopeToApiUseCase.kt
@@ -11,7 +11,6 @@ import javax.inject.Inject
 internal class MapDomainEventScopeToApiUseCase @Inject constructor(
     private val mapDomainEventToApiUseCase: MapDomainEventToApiUseCase,
 ) {
-
     operator fun invoke(
         scope: EventScope,
         events: List<Event>,

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/ApiExternalCredentialTypeTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/ApiExternalCredentialTypeTest.kt
@@ -1,0 +1,35 @@
+package com.simprints.infra.eventsync.event.remote
+
+import com.google.common.truth.Truth.assertThat
+import com.simprints.core.domain.externalcredential.ExternalCredentialType
+import org.junit.Test
+
+class ApiExternalCredentialTypeTest {
+    @Test
+    fun `api type to domain mapping matches all supported credentials`() {
+        val cases = mapOf(
+            ApiExternalCredentialType.NHIS_CARD to ExternalCredentialType.NHISCard,
+            ApiExternalCredentialType.GHANA_CARD to ExternalCredentialType.GhanaIdCard,
+            ApiExternalCredentialType.QR_CODE to ExternalCredentialType.QRCode,
+            ApiExternalCredentialType.FAYDA_CARD to ExternalCredentialType.FaydaCard,
+        )
+
+        cases.forEach { (apiType, expectedDomainType) ->
+            assertThat(apiType.toDomain()).isEqualTo(expectedDomainType)
+        }
+    }
+
+    @Test
+    fun `domain type to api mapping matches all supported credentials`() {
+        val cases = mapOf(
+            ExternalCredentialType.NHISCard to ApiExternalCredentialType.NHIS_CARD,
+            ExternalCredentialType.GhanaIdCard to ApiExternalCredentialType.GHANA_CARD,
+            ExternalCredentialType.QRCode to ApiExternalCredentialType.QR_CODE,
+            ExternalCredentialType.FaydaCard to ApiExternalCredentialType.FAYDA_CARD,
+        )
+
+        cases.forEach { (domainType, expectedApiType) ->
+            assertThat(domainType.fromDomainToApi()).isEqualTo(expectedApiType)
+        }
+    }
+}

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/subject/ApiEnrolmentRecordCreationEventTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/subject/ApiEnrolmentRecordCreationEventTest.kt
@@ -5,11 +5,11 @@ import com.simprints.core.domain.common.TemplateIdentifier
 import com.simprints.core.domain.externalcredential.ExternalCredential
 import com.simprints.core.domain.externalcredential.ExternalCredentialType
 import com.simprints.core.domain.tokenization.asTokenizableEncrypted
-import com.simprints.infra.config.store.remote.models.ApiExternalCredentialType
 import com.simprints.infra.events.event.domain.models.EnrolmentRecordCreationEvent
 import com.simprints.infra.events.event.domain.models.FingerprintReference
 import com.simprints.infra.events.event.domain.models.FingerprintTemplate
 import com.simprints.infra.eventsync.event.remote.ApiExternalCredential
+import com.simprints.infra.eventsync.event.remote.ApiExternalCredentialType
 import com.simprints.infra.eventsync.event.remote.ApiFingerprintTemplate
 import com.simprints.infra.eventsync.event.remote.models.ApiEnrolmentRecordCreationPayload
 import com.simprints.infra.eventsync.event.remote.models.ApiFingerprintReference

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/subject/ApiEnrolmentRecordMoveEventTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/subject/ApiEnrolmentRecordMoveEventTest.kt
@@ -5,11 +5,11 @@ import com.simprints.core.domain.common.TemplateIdentifier
 import com.simprints.core.domain.externalcredential.ExternalCredential
 import com.simprints.core.domain.externalcredential.ExternalCredentialType
 import com.simprints.core.domain.tokenization.asTokenizableEncrypted
-import com.simprints.infra.config.store.remote.models.ApiExternalCredentialType
 import com.simprints.infra.events.event.domain.models.EnrolmentRecordMoveEvent
 import com.simprints.infra.events.event.domain.models.FingerprintReference
 import com.simprints.infra.events.event.domain.models.FingerprintTemplate
 import com.simprints.infra.eventsync.event.remote.ApiExternalCredential
+import com.simprints.infra.eventsync.event.remote.ApiExternalCredentialType
 import com.simprints.infra.eventsync.event.remote.ApiFingerprintTemplate
 import com.simprints.infra.eventsync.event.remote.models.ApiEnrolmentRecordMovePayload
 import com.simprints.infra.eventsync.event.remote.models.ApiFingerprintReference

--- a/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/subject/ApiEnrolmentRecordUpdateEventTest.kt
+++ b/infra/event-sync/src/test/java/com/simprints/infra/eventsync/event/remote/models/subject/ApiEnrolmentRecordUpdateEventTest.kt
@@ -5,13 +5,13 @@ import com.simprints.core.domain.common.TemplateIdentifier
 import com.simprints.core.domain.externalcredential.ExternalCredential
 import com.simprints.core.domain.externalcredential.ExternalCredentialType
 import com.simprints.core.domain.tokenization.asTokenizableEncrypted
-import com.simprints.infra.config.store.remote.models.ApiExternalCredentialType
 import com.simprints.infra.events.event.domain.models.EnrolmentRecordUpdateEvent
 import com.simprints.infra.events.event.domain.models.FaceReference
 import com.simprints.infra.events.event.domain.models.FaceTemplate
 import com.simprints.infra.events.event.domain.models.FingerprintReference
 import com.simprints.infra.events.event.domain.models.FingerprintTemplate
 import com.simprints.infra.eventsync.event.remote.ApiExternalCredential
+import com.simprints.infra.eventsync.event.remote.ApiExternalCredentialType
 import com.simprints.infra.eventsync.event.remote.ApiFingerprintTemplate
 import com.simprints.infra.eventsync.event.remote.models.ApiEnrolmentRecordUpdatePayload
 import com.simprints.infra.eventsync.event.remote.models.ApiFaceReference


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1588)
Will be released in: **2027.1.0**

### Notable changes

* Separate the external credential enum in events and config APIs to decouple those modules and allow only changing the config module.
* Replace specific enum types in the config API with strings based on how likely we are to add new values to those fields in the future. 

### Testing guidance

* Down-syncing all kinds of project configuration options - everything should work as before:
  * Each SDK type
  * Each modality type
  * Each external config

### Additional work checklist

* [x] Effect on other features and security has been considered
* [x] Design document marked as "In development" (if applicable)
* [x] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [x] Test cases in Testiny are up to date (or ticket created)
* [x] Other teams notified about the changes (if applicable)
