### PR TITLE
[MS-1593] Include CI build number in the  release APK filename

### DIFF
--- a/.github/workflows/pipeline-deploy-to-internal.yml
+++ b/.github/workflows/pipeline-deploy-to-internal.yml
@@ -25,6 +25,7 @@ jobs:
             upload-artifact: ${{ needs.build-internal-aab.outputs.build-artifact }}
             version-name: ${{ needs.get-version.outputs.version-name }}
             version-code: ${{ needs.build-internal-aab.outputs.version-code }}
+            build-number: ${{ github.run_number }}
             mapping-file: ${{ needs.build-internal-aab.outputs.optional-mapping-file }}
         needs:
             - get-version

--- a/.github/workflows/reusable-upload-to-internal-and-release.yml
+++ b/.github/workflows/reusable-upload-to-internal-and-release.yml
@@ -15,6 +15,10 @@ on:
                 description: "Android version code for the build (used to download the universal APK from Play)"
                 type: string
                 required: true
+            build-number:
+                description: "CI build number to append to the released APK filename (e.g. 173)"
+                type: string
+                required: true
             mapping-file:
                 description: "Optional artifact name of the ProGuard mapping file"
                 type: string
@@ -62,9 +66,10 @@ jobs:
                     GOOGLE_API_KEY_JSON: ${{ secrets.GOOGLE_API_KEY_JSON }}
                     VERSION_CODE: ${{ inputs.version-code }}
                     VERSION_NAME: ${{ inputs.version-name }}
+                    BUILD_NUMBER: ${{ inputs.build-number }}
                     PACKAGE_NAME: com.simprints.id
                 run: |
-                    APK_NAME="simprints-id-${VERSION_NAME}-universal.apk"
+                    APK_NAME="simprints-id-${VERSION_NAME}+${BUILD_NUMBER}-universal.apk"
                     OUTPUT_APK="$APK_NAME" python3 .github/scripts/download-universal-apk.py
                     echo "apk-name=$APK_NAME" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
[JIRA ticket](https://simprints.atlassian.net/browse/MS-1593)
Will be released in: **2027.1.0**

### Notable changes

* Update the Android release workflow to append the build number to the generated APK filename. This will make it easier to differentiate APK URLs between different builds of the same release.

### Testing guidance

* when running the workflow the apk name should include the github run number 

### Additional work checklist

* [ ] Effect on other features and security has been considered
* [ ] Design document marked as "In development" (if applicable)
* [ ] External (Gitbook) and internal (Confluence) Documentation is up to date (or ticket created)
* [ ] Test cases in Testiny are up to date (or ticket created)
* [ ] Other teams notified about the changes (if applicable)
